### PR TITLE
fix async eval of template literals

### DIFF
--- a/xmlui/src/components-core/script-runner/eval-tree-async.ts
+++ b/xmlui/src/components-core/script-runner/eval-tree-async.ts
@@ -960,11 +960,11 @@ async function evalTemplateLiteralAsync(
   thread: LogicalThread,
   onStatementCompleted: OnStatementCompletedCallback,
 ): Promise<any> {
-  const segmentValuePromises = expr.segments.map(async (s) => {
-    const evaledValue = await evaluator(thisStack, s, evalContext, thread, onStatementCompleted);
+  const segmentValues = new Array(expr.segments.length);
+  for (let i = 0; i <  expr.segments.length; ++i){
+    const evaledValue = await evaluator(thisStack, expr.segments[i], evalContext, thread, onStatementCompleted);
     thisStack.pop();
-    return evaledValue;
-  });
-  const segmentValues = await Promise.all(segmentValuePromises);
+    segmentValues[i] = (evaledValue);
+  }
   return evalTemplateLiteralCore(segmentValues);
 }

--- a/xmlui/tests/components-core/scripts-runner/process-statement.test.ts
+++ b/xmlui/tests/components-core/scripts-runner/process-statement.test.ts
@@ -2000,6 +2000,27 @@ describe("Process statements", () => {
     }
     assert.fail("Exception expected");
   });
+
+  it("template literal regression", async () => {
+    // --- Arrange
+
+    const source = `
+    return \`f\${ obj.map(item => item) }\`;
+    `;
+    
+    const evalContext = createEvalContext({
+      localContext: {
+        obj: [1, 2, 3]
+      }
+    });
+    const statements = parseStatements(source);
+
+    // --- Act/Assert
+    await processStatementQueueAsync(statements, evalContext);
+    const thread = evalContext.mainThread!;
+    //expect(thread.blocks!.length).equal(1);
+    expect(thread.returnValue).equal("f1,2,3");
+  });
 });
 
 function getComponentStateClone(orig: any): any {


### PR DESCRIPTION
Some promises weren't awaited, so the displayed string was from converting a promise object to string.