### PR TITLE
img flexShrink: 1

### DIFF
--- a/xmlui/src/components/Image/ImageNative.tsx
+++ b/xmlui/src/components/Image/ImageNative.tsx
@@ -29,7 +29,7 @@ export const Image = forwardRef(function Img(
       className={classnames(styles.img, {
         [styles.clickable]: !!onClick,
       })}
-      style={{ objectFit: fit, boxShadow: "none", ...style, aspectRatio: aspectRatio }}
+      style={{ objectFit: fit, boxShadow: "none", ...style, flexShrink: 1, aspectRatio: aspectRatio }}
       onClick={onClick}
     />
   );


### PR DESCRIPTION
@Dotneteer the motivation was that the images displayed in the Mastodon client would sometimes overlap the icons below them. This solves the layout problem but led to other questions.

I wanted to see how to do this without changing the engine. When I asked yesterday about Markdown theme variables for images I forgot that I was using Markdown for post content, but Image for images, that's why I didn't see any theme vars on images.

I thought of this:

```
  <Markdown>
    <![CDATA[
      <img src="${item.reblog_preview_url}" width="${toolsState.value.zoom}%" />
    ]]>
  </Markdown>
```

Getting that to render was a journey. First I found that binding expressions in markdown didn't seem to work inside attributes. The code below makes that happen but I'm not sure we should use it,  I don't understand the context well enough.

Once I could render values into those expressions I found that the markdown above yields `src="undefined"`, but this yields the URL.

```
<variable name="imgUrl" value="{$item.reblog_preview_url}" />
<Markdown>
  <![CDATA[
    <img src="${imgUrl}" width="${toolsState.value.zoom}%" />
  ]]>
</Markdown>
```

Strange, but ok, now I have a Markdown-rendered image that themevars can influence.

```
<img class="_htmlImage_11909_350" src="https://social-coop-media.ams3.cdn.digitaloceanspaces.com/cache/media_attachments/files/114/433/589/367/285/555/small/0fb6c697d7bd8390.jpg" width="20%">
````

But now, although I can still set the width % dynamically:

<img width="893" alt="image" src="https://github.com/user-attachments/assets/5abfd41c-c121-48ce-b38d-84c938d257e8" />

The setting is no longer effective because the theme var overrides.

<img width="576" alt="image" src="https://github.com/user-attachments/assets/c3f9d7c9-b6cd-446d-9d1d-06044b07d879" />

What a tangled web we weave!

My tentative conclusions:

1. My original approach, `<Image src="{$item.reblog_preview_url}" width="{toolsState.value.zoom}%" />`, is XMLUI-idiomatic, it's what we would expect people to do

2. The change proposed here, `flexShrink: 1`, is a reasonable default

3. Having dynamic themed styles in XMLUI-rendered markdown (or anywhere, I guess) is out of scope, maybe interesting but very low priority if so

4. Binding expressions in our markdown should, however, probably work.

Oof. Crazy amount of commentary for a 1-line commit! But I think the commit is the right answer for the kind of thing I am doing here.

Finally: HtmlTags.module.scss exports everything else in that file except `themeVarsImage`, what is the purpose of those exports, where are the other ones used, and why isn't this one exported?


<hr/>

## appendix: binding expressions in atttributes

```
function bindingExpression({ extractValue }: { extractValue: ValueExtractor }) {
  return (tree: any) => {
    // Process text nodes
    visit(tree, "text", (node) => {
      return processTextNode(node);
    });

    // Also process HTML nodes
    visit(tree, "html", (node) => {
      return processHtmlNode(node);
    });
  };

  function processTextNode(node: any) {
    // Remove empty ${} expressions first
    node.value = node.value.replace(/\$\{\s*\}/g, "");

    const regex = /\$\{((?:[^{}]|\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})*)\}/g;
    const parts: string[] = node.value.split(regex);
    if (parts.length > 1) {
      node.type = "html";
      node.value = parts
        .map((part, index) => {
          const extracted = index % 2 === 0 ? part : extractValue(`{${part}}`);
          const resultExpr = mapByType(extracted);
          // The result expression might be an object, in that case we stringify it here,
          // at the last step, so that there are no unnecessary apostrophes
          return typeof resultExpr === "object" && resultExpr !== null
            ? JSON.stringify(resultExpr)
            : resultExpr;
        })
        .join("");
    }
  }

  function processHtmlNode(node: any) {
    if (!node.value) return;

    // Define a regex to match HTML tags with attributes
    const tagRegex = /<([a-zA-Z][a-zA-Z0-9]*)([^>]*?)>/g;

    // Process all HTML tags in the node
    node.value = node.value.replace(tagRegex, (match: string, tagName: string, attributes: string) => {
      // We'll manually parse attributes to handle complex cases
      let processedAttributes = attributes;

      // Find all attribute patterns
      const attrPattern = /\s([a-zA-Z][a-zA-Z0-9\-_]*)=["']([^"']*)["']/g;
      let attrMatch;

      // Create a copy of the attributes string that we can modify
      let offset = 0;

      // Process each attribute
      while ((attrMatch = attrPattern.exec(attributes)) !== null) {
        const fullMatch = attrMatch[0];
        const attrName = attrMatch[1];
        const attrValue = attrMatch[2];

        // Check if the attribute value contains a binding expression
        if (attrValue.includes('${')) {
          // Find all binding expressions in this attribute value
          const regex = /\$\{([^}]*)\}/g;
          let bindingMatch;
          let newAttrValue = attrValue;
          let valueOffset = 0;

          while ((bindingMatch = regex.exec(attrValue)) !== null) {
            const fullBindingMatch = bindingMatch[0];
            const expr = bindingMatch[1];

            // Evaluate the expression
            const evaluated = extractValue(`{${expr}}`);
            const result = mapByType(evaluated);

            // Replace the binding expression with its evaluated result
            const startPos = bindingMatch.index + valueOffset;
            const endPos = startPos + fullBindingMatch.length;

            newAttrValue =
              newAttrValue.substring(0, startPos) +
              result +
              newAttrValue.substring(endPos);

            // Adjust offset for future replacements
            valueOffset += (String(result).length - fullBindingMatch.length);
          }

          // Replace the attribute in the processed attributes
          const newAttr = ` ${attrName}="${newAttrValue}"`;
          const startIndex = attrMatch.index + offset;
          const endIndex = startIndex + fullMatch.length;

          processedAttributes =
            processedAttributes.substring(0, startIndex) +
            newAttr +
            processedAttributes.substring(endIndex);

          // Adjust offset for future replacements
          offset += (newAttr.length - fullMatch.length);
        }
      }

      // Return the tag with processed attributes
      return `<${tagName}${processedAttributes}>`;
    });
  }

  function mapByType(extracted: any) {
    if (extracted === null) {
      return null;
    } else if (extracted === undefined || typeof extracted === "undefined") {
      return undefined;
    } else if (typeof extracted === "object") {
      const arrowFuncResult = parseArrowFunc(extracted);
      if (arrowFuncResult) {
        return arrowFuncResult;
      }
      if (Array.isArray(extracted)) {
        return extracted;
      }
      return Object.fromEntries(
        Object.entries(extracted).map(([key, value]) => {
          return [key, mapByType(value)];
        }),
      );
    } else {
      return extracted;
    }
  }

  function parseArrowFunc(extracted: Record<string, any>): string {
    if (
      extracted.hasOwnProperty("type") &&
      extracted.type === T_ARROW_EXPRESSION &&
      extracted?._ARROW_EXPR_
    ) {
      return "[xmlui function]";
    }
    return "";
  }
}
```