### PR TITLE
fix: double extraction of props, escape \{ -s in props

### DIFF
--- a/.changeset/easy-swans-roll.md
+++ b/.changeset/easy-swans-roll.md
@@ -1,0 +1,6 @@
+---
+"xmlui-vscode": patch
+"xmlui": patch
+---
+
+fix: add escaped \{ to textmate syntax, eliminate double extraction of props in FormItem causing bugs with escaped open curly brace being parsed as start of binding expression.

--- a/docs/src/syntax/grammar.tmLanguage.json
+++ b/docs/src/syntax/grammar.tmLanguage.json
@@ -223,7 +223,7 @@
       "patterns": [{ "include": "source.js" }]
     },
     "textWithBindingExpr": {
-      "patterns": [{ "include": "#entity" }, { "include": "#bindingExpr" }]
+      "patterns": [{ "include": "#entity" }, { "match": "\\\\{" }, { "include": "#bindingExpr" }]
     },
     "propOrVarTag": {
       "begin": "(</?)([a-zA-Z_][\\w\\.\\-]*?:)?((?:variable)|(?:property)|(?:prop))",

--- a/packages/xmlui-devtools/src/syntax/grammar.tmLanguage.json
+++ b/packages/xmlui-devtools/src/syntax/grammar.tmLanguage.json
@@ -223,7 +223,7 @@
       "patterns": [{ "include": "source.js" }]
     },
     "textWithBindingExpr": {
-      "patterns": [{ "include": "#entity" }, { "include": "#bindingExpr" }]
+      "patterns": [{ "include": "#entity" }, { "match": "\\\\{" }, { "include": "#bindingExpr" }]
     },
     "propOrVarTag": {
       "begin": "(</?)([a-zA-Z_][\\w\\.\\-]*?:)?((?:variable)|(?:property)|(?:prop))",

--- a/tools/vscode/syntaxes/xmlui.tmLanguage.json
+++ b/tools/vscode/syntaxes/xmlui.tmLanguage.json
@@ -223,7 +223,7 @@
       "patterns": [{ "include": "source.js" }]
     },
     "textWithBindingExpr": {
-      "patterns": [{ "include": "#entity" }, { "include": "#bindingExpr" }]
+      "patterns": [{ "include": "#entity" }, { "match": "\\\\{" }, { "include": "#bindingExpr" }]
     },
     "propOrVarTag": {
       "begin": "(</?)([a-zA-Z_][\\w\\.\\-]*?:)?((?:variable)|(?:property)|(?:prop))",

--- a/xmlui/src/components/FormItem/FormItem.tsx
+++ b/xmlui/src/components/FormItem/FormItem.tsx
@@ -179,9 +179,7 @@ export const FormItemMd = createMetadata({
       availableValues: filteredValidationSeverityValues,
       defaultValue: "error",
     },
-    inputTemplate: dComponent(
-      "This property is used to define a custom input template."
-    ),
+    inputTemplate: dComponent("This property is used to define a custom input template."),
     gap: {
       description: "This property defines the gap between the adornments and the input area.",
       valueType: "string",
@@ -264,7 +262,7 @@ export const formItemComponentRenderer = createComponentRenderer(
     } = node.props;
 
     //extractValue works as a memoization mechanism too (if there's nothing to resolve, it won't produce a new object every time)
-    const resolvedValidationPropsAndEvents: FormItemValidations = extractValue({
+    const resolvedValidationPropsAndEvents: FormItemValidations = {
       required: extractValue.asOptionalBoolean(required),
       requiredInvalidMessage: extractValue.asOptionalString(requiredInvalidMessage),
       minLength: extractValue.asOptionalNumber(minLength),
@@ -281,7 +279,7 @@ export const formItemComponentRenderer = createComponentRenderer(
       regex: extractValue.asOptionalString(regex),
       regexInvalidMessage: extractValue.asOptionalString(regexInvalidMessage),
       regexInvalidSeverity: parseSeverity(extractValue.asOptionalString(regexInvalidSeverity)),
-    });
+    };
 
     const nonLayoutCssProps = !layoutCss
       ? rest

--- a/xmlui/src/syntax/grammar.tmLanguage.json
+++ b/xmlui/src/syntax/grammar.tmLanguage.json
@@ -223,7 +223,7 @@
       "patterns": [{ "include": "source.js" }]
     },
     "textWithBindingExpr": {
-      "patterns": [{ "include": "#entity" }, { "include": "#bindingExpr" }]
+      "patterns": [{ "include": "#entity" }, { "match": "\\\\{" }, { "include": "#bindingExpr" }]
     },
     "propOrVarTag": {
       "begin": "(</?)([a-zA-Z_][\\w\\.\\-]*?:)?((?:variable)|(?:property)|(?:prop))",


### PR DESCRIPTION
This caused errors when double-parsing expressions like "\{{3}" becoming
"{3" then that becoming an "unclosed {" error because it tried to treat
it as a binding expression.