### PR TITLE
Add type attribute to clickable header button

### DIFF
--- a/xmlui/src/components/Table/TableNative.tsx
+++ b/xmlui/src/components/Table/TableNative.tsx
@@ -858,7 +858,7 @@ type ClickableHeaderProps = {
 
 function ClickableHeader({ hasSorting, updateSorting, children }: ClickableHeaderProps) {
   return hasSorting ? (
-    <button className={styles.clickableHeader} onClick={updateSorting}>
+    <button type="button" className={styles.clickableHeader} onClick={updateSorting}>
       {children}
     </button>
   ) : (


### PR DESCRIPTION
This was breaking one of our forms that had a table inside it. 