### PR TITLE
fix: error reporting bug while linting

### DIFF
--- a/xmlui/src/components-core/xmlui-parser.ts
+++ b/xmlui/src/components-core/xmlui-parser.ts
@@ -177,7 +177,6 @@ function createErrorReportComponent(
               },
             ],
           },
-          ,
         ];
 
         if (errorStartInContext >= lineStart && errorStartInContext < lineEnd) {


### PR DESCRIPTION
Only when lints were turned on, we've got this type error of 'cannot read prop of undefined, reading "type".'

See the diff. The extra comma in the array literal inserted an undefined object into the ComponentDef array, which expects objects of a certain shape. This array is part of the hand-constructed error report component. We do not touch this component tree for further analysis, since it's at the end of the pipeline. Except for the linter that tells us which components have unrecognised props on them. The linter has tried to access the "type" field of the object that has caused the error. We did not notice this, because the linter is a bit out of date and is usually turned off in our projects (a clear indication that we should update it).