### PR TITLE
perf: use ref pattern for AppState to prevent cascade re-renders

### DIFF
--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -388,7 +388,10 @@ export function AppContent({
   }, [appState, update]);
 
   // --- Create AppState object with global state management functions
-  const AppState = useMemo(() => createAppState(appStateContextValue), [appStateContextValue]);
+  // Use ref pattern to prevent AppState recreation when context changes
+  const appStateContextRef = useRef<IAppStateContext>(appStateContextValue);
+  appStateContextRef.current = appStateContextValue;
+  const AppState = useMemo(() => createAppState(appStateContextRef), []);
 
   // --- We assemble the app context object form the collected information
   const appContextValue = useMemo(() => {


### PR DESCRIPTION
## Summary

- Change `createAppState` to accept a ref instead of direct context value
- `AppState` object is now created once and always accesses latest context via `ref.current`
- Prevents `AppState` recreation when `appStateContextValue` changes, avoiding cascade re-renders

## Problem

In the xmlui-mastodon app (1362 following, large dataset with multiple AppState buckets), any AppState change triggered a cascade:

1. `appStateContextValue` changes when any bucket updates
2. `AppState = useMemo(() => createAppState(appStateContextValue), [appStateContextValue])` recreates AppState
3. `appContextValue` depends on `AppState`, so it also recreates
4. All components consuming AppContext re-render

Simple operations like opening Settings or toggling Grayscale took 3-4 seconds.

## Solution

Use a ref pattern so `createAppState` always accesses the latest context without being recreated:

```typescript
const appStateContextRef = useRef<IAppStateContext>(appStateContextValue);
appStateContextRef.current = appStateContextValue;
const AppState = useMemo(() => createAppState(appStateContextRef), []);
```

## Performance Impact

Tested with xmlui-mastodon (1362 following):

| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| Settings dialog close | 4612ms | 1985ms | **2.3x faster** |
| Grayscale toggle | 3613ms | 1766ms | **2x faster** |
| Settings dialog open | 3976ms | 2168ms | **1.8x faster** |
| Startup | 9314ms | 5896ms | **1.6x faster** |

## Sanity Check

- [x] Build passes (`npm run build:xmlui`)
- [x] Unit tests pass (7927 passed, 2 failed are pre-existing on main)
- [x] Manual testing in xmlui-mastodon shows ~2x improvement
- [x] No breaking changes - existing apps continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)