### PR TITLE
fix: disable console.log in xsConsoleLog (trace data goes to window._…)

### DIFF
--- a/xmlui/src/components-core/inspector/inspectorUtils.ts
+++ b/xmlui/src/components-core/inspector/inspectorUtils.ts
@@ -243,7 +243,7 @@ export function createLogEntry(
 export function xsConsoleLog(...args: any[]): void {
   const payload = ["[xs]", ...args];
   loggerService.log(payload);
-  console.log(...payload);
+  // console.log(...payload);
 }
 
 // =============================================================================


### PR DESCRIPTION
4 of 5 trace-related console.log calls were already commented out in the containers refactor (cc969a37). This finishes the job by disabling the last one in xsConsoleLog(), which is the central function called by Container, AppContent, StateContainer, and DataLoader. Trace data continues to flow to window._xsLogs and loggerService for tooling.