### PR TITLE
chore: add Claude Code local config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ coverage
 xmlui-optimized-output
 xmlui-temp-build
 
+# Claude Code local config
+.claude/
+.mcp.json
+
 docs/scripts/component-metadata.json


### PR DESCRIPTION
Prevent .claude/ and .mcp.json from being accidentally committed to the public repository. These contain machine-specific paths and local settings.