### PR TITLE
docs: add link to global variables in AppState deprecation notice

### DIFF
--- a/xmlui/src/components/AppState/AppState.tsx
+++ b/xmlui/src/components/AppState/AppState.tsx
@@ -11,7 +11,7 @@ export const AppStateMd = createMetadata({
     "across your entire application. Unlike component variables that are scoped " +
     "locally, AppState allows any component to access and update shared state " +
     "without prop drilling.",
-  deprecationMessage: "The AppState component is deprecated. We will remove it in a future release. Please use global variables instead.",
+  deprecationMessage: "The AppState component is deprecated. We will remove it in a future release. Please use [global variables](/guides/markup#global-variables) instead.",
   events: {
     didUpdate: {
       description:


### PR DESCRIPTION
The deprecation message now points to /guides/markup#global-variables so both human readers and LLM tooling can find the replacement docs.