### PR TITLE
docs: remove /universal-properties redirect

### DIFF
--- a/docs/src/Main.xmlui
+++ b/docs/src/Main.xmlui
@@ -608,9 +608,6 @@
                 content="{appGlobals.content['pages/core-properties.md']}"
             />
         </Page>
-        <Page url="/universal-properties">
-            <Redirect to="/core-properties" />
-        </Page>
         <Page url="/template-properties">
             <DocumentPage
                 content="{appGlobals.content['pages/template-properties.md']}"


### PR DESCRIPTION
## Summary
- Remove the `/universal-properties` redirect to `/core-properties` from Main.xmlui, as the rename is complete

