### PR TITLE
Fix duplicate SVG fetches for custom resource icons

### DIFF
--- a/xmlui/src/components/IconProvider.tsx
+++ b/xmlui/src/components/IconProvider.tsx
@@ -468,6 +468,7 @@ export function IconProvider({ children, icons }: { children: ReactNode, icons: 
     if (attachedResources.current[resourceUrl]) {
       return;
     }
+    attachedResources.current[resourceUrl] = true;
     const icon = await (await fetch(resourceUrl)).text();
 
     const div = document.createElement("div");
@@ -491,10 +492,7 @@ export function IconProvider({ children, icons }: { children: ReactNode, icons: 
     d.id = resourceUrl;
     d.setAttributeNS(null, "viewBox", attrs["viewBox"]);
 
-    if (!attachedResources.current[resourceUrl]) {
-      spriteRootRef.current!.appendChild(d);
-      attachedResources.current[resourceUrl] = true;
-    }
+    spriteRootRef.current!.appendChild(d);
     const customIcon = {
       name: resourceUrl,
       attributes: attrs,


### PR DESCRIPTION
## Summary
- When multiple components reference the same custom SVG icon (registered via `config.json` resources), every instance fires a separate `fetch()` for the same SVG file
- Root cause: `attachedResources.current[resourceUrl]` was set **after** the async fetch completed, so concurrent callers all passed the guard check
- Fix: set the guard **before** the fetch so the first caller claims the URL immediately

## Test plan
- Register a custom SVG icon in `config.json` resources (e.g. `"icon.bookmark": "icons/bookmark.svg"`)
- Use `<Icon name="bookmark">` in a list that renders many items
- Open browser Network tab, filter for the SVG filename
- Before fix: one fetch per component instance
- After fix: single fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)