### PR TITLE
fix: enable mock API in SSG client bundle to fix broken playgrounds

### DIFF
--- a/xmlui/bin/ssg.ts
+++ b/xmlui/bin/ssg.ts
@@ -413,7 +413,7 @@ export const ssg = async ({
   log("building project assets");
   await build({
     buildMode: "INLINE_ALL",
-    withMock: false,
+    withMock: true,
     withHostingMetaFiles: false,
     withRelativeRoot: false,
     flatDist: false,


### PR DESCRIPTION
The SSG build was creating the client-side JS bundle with withMock: false (introduced in 88ce91b0), which meant VITE_MOCK_ENABLED was falsy in the production bundle. Playgrounds use in-memory mock APIs via ApiInterceptorProvider with waitForApiInterceptor=true. The interceptor initialization follows a worker-based code path that checks VITE_MOCK_ENABLED — since it was false, the worker was never created, the child interceptor never initialized, and the playground content was never rendered.

The regular build (npm run build) uses --withMock, which is why playgrounds worked locally but not on the SSG-deployed site.