### PR TITLE
add mcp-paths.json

### DIFF
--- a/mcp-paths.json
+++ b/mcp-paths.json
@@ -1,0 +1,9 @@
+{
+  "componentDocs": "website/content/docs/reference/components",
+  "componentSource": "xmlui/src/components",
+  "extensionDocs": "website/content/docs/reference/extensions",
+  "extensionSource": "packages",
+  "pages": "website/content/docs/pages",
+  "howto": "website/content/docs/pages/howto",
+  "blog": "website/content/blog"
+}


### PR DESCRIPTION
0.12.7 broke the mcp server because paths moved. this manifest enables the mcp server to adjust to structural changes in the monorepo