### PR TITLE
feat: add app:trace instrumentation to Search component

### DIFF
--- a/packages/xmlui-search/src/Search.tsx
+++ b/packages/xmlui-search/src/Search.tsx
@@ -593,7 +593,22 @@ function useSearch(data: SearchItemData[], limit: number, query: string): Search
       : fuseRef.current.search(query, { limit: limit ?? defaultProps.limit });
 
     const mapped = postProcessSearch(limited, query);
-    return groupAndSortByCategory(mapped);
+    const sorted = groupAndSortByCategory(mapped);
+
+    // Emit app:trace when xsVerbose tracing is active
+    if ((window as any)._xsLogs) {
+      const xsTraceEvent = (window as any).xsTraceEvent;
+      if (typeof xsTraceEvent === "function") {
+        xsTraceEvent("search", {
+          term: query,
+          fuseHits: limited.length,
+          resultCount: sorted.length,
+          topResults: sorted.slice(0, 3).map((r) => r.item.title),
+        });
+      }
+    }
+
+    return sorted;
   }, [query, limit]);
 
   return results;


### PR DESCRIPTION
## Summary
- When `xsVerbose` tracing is active, the Search component now emits `app:trace` events on each Fuse.js search
- Each trace includes term, raw Fuse.js hit count, final result count, and top 3 result titles
- Gated on `window._xsLogs` existence so it is a no-op when tracing is off

## Context
The Search component runs entirely client-side (Fuse.js in React), which made its behavior invisible to the XMLUI inspector. With this change, each keystroke search appears in the inspector timeline alongside engine-generated events.

