### PR TITLE
fix(TileGrid): selection UX, render-loop, flash, and hideSelectionChe…

### DIFF
--- a/xmlui/src/components/Table/useRowSelection.tsx
+++ b/xmlui/src/components/Table/useRowSelection.tsx
@@ -535,9 +535,13 @@ export default function useRowSelection({
     }
   });
 
+  // Keep a ref to the callback so the effect below only fires when selectedItems
+  // changes — not when the parent re-renders and passes a new function reference.
+  const onSelectionDidChangeRef = useRef(onSelectionDidChange);
+  onSelectionDidChangeRef.current = onSelectionDidChange;
+
   useEffect(() => {
-    // console.log("selection DID CHANGE?");
-    void onSelectionDidChange?.(selectedItems);
+    void onSelectionDidChangeRef.current?.(selectedItems);
     if (selectedItems.length > 0 && typeof window !== "undefined") {
       const w = window as any;
       if (Array.isArray(w._xsLogs)) {
@@ -553,7 +557,7 @@ export default function useRowSelection({
         });
       }
     }
-  }, [selectedItems, onSelectionDidChange]);
+  }, [selectedItems]);
 
   /**
    * This operation checks or clears all rows

--- a/xmlui/src/components/TileGrid/TileGrid.md
+++ b/xmlui/src/components/TileGrid/TileGrid.md
@@ -319,6 +319,55 @@ This property only has an effect when `itemsSelectable` is `true`.
 
 %-PROP-END
 
+%-PROP-START hideSelectionCheckboxes
+
+If `true`, hides the per-tile selection checkboxes while keeping all selection logic intact.
+Tiles can still be selected by clicking, via the API (`selectId`, `selectAll`), or with keyboard shortcuts.
+
+This is useful when you want click-based selection without the visual checkbox overlay.
+
+```xmlui copy /hideSelectionCheckboxes="true"/
+<App>
+  <TileGrid
+    data="{[...]}"
+    itemWidth="120px"
+    itemHeight="80px"
+    itemsSelectable="true"
+    hideSelectionCheckboxes="true"
+  >
+    <VStack padding="8px" horizontalAlignment="center" verticalAlignment="center">
+      <Text fontWeight="bold">{$item.name}</Text>
+    </VStack>
+  </TileGrid>
+</App>
+```
+
+```xmlui-pg name="Example: hideSelectionCheckboxes"
+<App>
+  <TileGrid
+    data="{[
+      {id: 1, name: 'Apples', category: 'fruits'},
+      {id: 2, name: 'Bananas', category: 'fruits'},
+      {id: 3, name: 'Carrots', category: 'vegetables'},
+      {id: 4, name: 'Spinach', category: 'vegetables'},
+      {id: 5, name: 'Milk', category: 'dairy'},
+      {id: 6, name: 'Cheese', category: 'dairy'}
+    ]}"
+    itemWidth="120px"
+    itemHeight="80px"
+    itemsSelectable="true"
+    hideSelectionCheckboxes="true"
+  >
+    <VStack padding="8px" horizontalAlignment="center" verticalAlignment="center">
+      <Text fontWeight="bold">{$item.name}</Text>
+      <Text color="gray">{$item.category}</Text>
+    </VStack>
+  </TileGrid>
+</App>
+```
+
+%-PROP-END
+
 %-PROP-START checkboxPosition
 
 Controls where the per-tile selection checkbox is placed relative to the tile corner.

--- a/xmlui/src/components/TileGrid/TileGrid.module.scss
+++ b/xmlui/src/components/TileGrid/TileGrid.module.scss
@@ -33,6 +33,7 @@ $outlineOffset-item-TileGrid--focus: createThemeVar("outlineOffset-item-#{$compo
     position: relative;
     width: 100%;
     height: 100%;
+    outline: none;
   }
 
   .tileRow {

--- a/xmlui/src/components/TileGrid/TileGrid.spec.ts
+++ b/xmlui/src/components/TileGrid/TileGrid.spec.ts
@@ -399,6 +399,88 @@ test.describe("Selection", () => {
 });
 
 // =============================================================================
+// hideSelectionCheckboxes property
+// =============================================================================
+
+test.describe("hideSelectionCheckboxes property", () => {
+  test("hides checkboxes when true", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <TileGrid
+        data="{[{id:1,name:'A'},{id:2,name:'B'},{id:3,name:'C'}]}"
+        itemWidth="120px"
+        itemHeight="80px"
+        itemsSelectable="true"
+        hideSelectionCheckboxes="true"
+      >
+        <Text>{$item.name}</Text>
+      </TileGrid>
+    `);
+    const checkboxes = page.getByRole("checkbox");
+    await expect(checkboxes).toHaveCount(0);
+  });
+
+  test("selection still works via click when checkboxes are hidden", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <TileGrid
+        data="{[{id:1,name:'A'},{id:2,name:'B'},{id:3,name:'C'}]}"
+        itemWidth="120px"
+        itemHeight="80px"
+        itemsSelectable="true"
+        hideSelectionCheckboxes="true"
+      >
+        <Text>{$item.name}</Text>
+      </TileGrid>
+    `);
+    const cells = page.getByRole("gridcell");
+    await cells.nth(0).click();
+    await expect(cells.nth(0)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Ctrl+click multi-selection works when checkboxes are hidden", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <TileGrid
+        data="{[{id:1,name:'A'},{id:2,name:'B'},{id:3,name:'C'}]}"
+        itemWidth="120px"
+        itemHeight="80px"
+        itemsSelectable="true"
+        hideSelectionCheckboxes="true"
+      >
+        <Text>{$item.name}</Text>
+      </TileGrid>
+    `);
+    const cells = page.getByRole("gridcell");
+    await cells.nth(0).click();
+    await cells.nth(1).click({ modifiers: ["Meta"] });
+    await expect(cells.nth(0)).toHaveAttribute("aria-selected", "true");
+    await expect(cells.nth(1)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("checkboxes are visible when hideSelectionCheckboxes is false (default)", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <TileGrid
+        data="{[{id:1,name:'A'},{id:2,name:'B'}]}"
+        itemWidth="120px"
+        itemHeight="80px"
+        itemsSelectable="true"
+      >
+        <Text>{$item.name}</Text>
+      </TileGrid>
+    `);
+    const checkboxes = page.getByRole("checkbox");
+    await expect(checkboxes.first()).toBeVisible();
+  });
+});
+
+// =============================================================================
 // STEP 6: Keyboard Shortcuts + Double-click
 // =============================================================================
 

--- a/xmlui/src/components/TileGrid/TileGrid.tsx
+++ b/xmlui/src/components/TileGrid/TileGrid.tsx
@@ -69,6 +69,12 @@ export const TileGridMd = createMetadata({
         `The named variable must reference an object; the grid will read from and write to its ` +
         `\`selectedIds\` property. A runtime error is signalled if the value is not a valid JavaScript variable name.`,
     ),
+    hideSelectionCheckboxes: {
+      description:
+        "If `true`, hides selection checkboxes. Selection logic still works via click, API, and keyboard.",
+      valueType: "boolean",
+      defaultValue: defaultProps.hideSelectionCheckboxes,
+    },
     checkboxPosition: {
       description:
         "Controls the position of the per-tile selection checkbox relative to the tile, " +
@@ -222,6 +228,7 @@ export const tileGridComponentRenderer = createComponentRenderer(
         enableMultiSelection={extractValue.asOptionalBoolean(node.props.enableMultiSelection)}
         syncWithAppState={syncAdapter}
         checkboxPosition={extractValue.asOptionalString(node.props.checkboxPosition) as any}
+        hideSelectionCheckboxes={extractValue.asOptionalBoolean(node.props.hideSelectionCheckboxes)}
         idKey={idKey}
         itemUserSelect={extractValue.asOptionalString(node.props.itemUserSelect)}
         onSelectionDidChange={lookupEventHandler("selectionDidChange")}

--- a/xmlui/src/components/TileGrid/TileGridNative.tsx
+++ b/xmlui/src/components/TileGrid/TileGridNative.tsx
@@ -102,6 +102,7 @@ export type TileGridProps = {
   enableMultiSelection?: boolean;
   syncWithAppState?: any;
   checkboxPosition?: CheckboxPosition;
+  hideSelectionCheckboxes?: boolean;
   idKey?: string;
   itemUserSelect?: string;
   itemRenderer?: (item: any, index: number, count: number, selected: boolean) => ReactNode;
@@ -135,6 +136,7 @@ export const defaultProps = {
   itemsSelectable: false,
   enableMultiSelection: true,
   checkboxPosition: "topStart" as CheckboxPosition,
+  hideSelectionCheckboxes: false,
   idKey: "id",
   itemUserSelect: "none",
 };
@@ -154,6 +156,7 @@ export const TileGridNative = memo(
       itemsSelectable = defaultProps.itemsSelectable,
       enableMultiSelection = defaultProps.enableMultiSelection,
       checkboxPosition = defaultProps.checkboxPosition,
+      hideSelectionCheckboxes = defaultProps.hideSelectionCheckboxes,
       itemUserSelect = defaultProps.itemUserSelect,
       syncWithAppState,
       onSelectionDidChange,
@@ -252,11 +255,29 @@ export const TileGridNative = memo(
       }
     }, [focusedTileIndex, cols]);
 
+    // Refs for values used inside the component API so the effect doesn't re-run
+    // when data/idKey change (which would trigger registerComponentApi on every render).
+    const itemsRef = useRef(items);
+    itemsRef.current = items;
+    const idKeyRef = useRef(idKey);
+    idKeyRef.current = idKey;
+
     useEffect(() => {
       registerComponentApi?.({
-        clearSelection: () => selectionApi.clearSelection(),
+        clearSelection: () => {
+          selectionApi.clearSelection();
+          setFocusedTileIndex(-1);
+        },
         selectAll: () => selectionApi.selectAll(),
-        selectId: (id: any) => selectionApi.selectId(id),
+        selectId: (id: any) => {
+          selectionApi.selectId(id);
+          // Move focus to the selected item (first if array).
+          const targetId = String(Array.isArray(id) ? id[0] : id);
+          const idx = itemsRef.current.findIndex(
+            (item) => String(item[idKeyRef.current]) === targetId,
+          );
+          setFocusedTileIndex(idx >= 0 ? idx : -1);
+        },
         getSelectedItems: () => selectionApi.getSelectedItems(),
         getSelectedIds: () => selectionApi.getSelectedIds(),
       });
@@ -376,7 +397,7 @@ export const TileGridNative = memo(
         tabIndex={itemsSelectable ? 0 : undefined}
         onKeyDown={itemsSelectable ? handleKeyDown : undefined}
       >
-        {!loading && rows.length > 0 && (
+        {!loading && rows.length > 0 && containerWidth > 0 && (
           <Virtualizer
             ref={virtualizerRef}
             scrollRef={outerRef}
@@ -407,10 +428,17 @@ export const TileGridNative = memo(
                       onClick={
                         itemsSelectable
                           ? (e) => {
-                              setFocusedTileIndex(globalIndex);
+                              const isCtrl = e.metaKey || e.ctrlKey;
+                              // Ctrl/Cmd+Click on an already-selected tile deselects it;
+                              // clear focus so no outline remains (matches Table behaviour).
+                              if (isCtrl && isSelected) {
+                                setFocusedTileIndex(-1);
+                              } else {
+                                setFocusedTileIndex(globalIndex);
+                              }
                               toggleRow(item, {
                                 shiftKey: e.shiftKey,
-                                metaKey: e.metaKey || e.ctrlKey,
+                                metaKey: isCtrl,
                               });
                             }
                           : undefined
@@ -424,19 +452,28 @@ export const TileGridNative = memo(
                       {itemsSelectable && isSelected && (
                         <div className={styles.selectedIndicator} />
                       )}
-                      {itemsSelectable && (
+                      {itemsSelectable && !hideSelectionCheckboxes && (
                         <div
                           className={classnames(
                             styles.checkboxOverlay,
                             styles[checkboxPosition],
                           )}
                           onMouseDown={(e) => e.preventDefault()}
+                          onClick={(e) => e.stopPropagation()}
                         >
                           <Toggle
                             tabIndex={-1}
                             aria-label={`Select ${item[idKey] ?? globalIndex}`}
                             value={isSelected}
-                            onDidChange={() => toggleRow(item, { metaKey: true })}
+                            onDidChange={() => {
+                              // When unchecking via checkbox, clear focus (matches Table behaviour).
+                              if (isSelected) {
+                                setFocusedTileIndex(-1);
+                              } else {
+                                setFocusedTileIndex(globalIndex);
+                              }
+                              toggleRow(item, { metaKey: true });
+                            }}
                           />
                         </div>
                       )}

--- a/xmlui/src/components/Toggle/Toggle.tsx
+++ b/xmlui/src/components/Toggle/Toggle.tsx
@@ -42,6 +42,8 @@ type ToggleProps = {
   registerComponentApi?: RegisterComponentApiFn;
   inputRenderer?: (contextVars: any, input?: ReactNode) => ReactNode;
   forceHover?: boolean;
+  tabIndex?: number;
+  "aria-label"?: string;
 };
 
 export const defaultProps: Pick<
@@ -78,6 +80,8 @@ export const Toggle = forwardRef(function Toggle(
     registerComponentApi,
     inputRenderer,
     forceHover = false,
+    tabIndex,
+    "aria-label": ariaLabel,
     ...rest
   }: ToggleProps,
   forwardedRef: ForwardedRef<HTMLInputElement>,
@@ -178,6 +182,8 @@ export const Toggle = forwardRef(function Toggle(
           role={variant}
           checked={legitValue}
           disabled={!enabled}
+          tabIndex={tabIndex}
+          aria-label={ariaLabel}
           required={required}
           readOnly={readOnly}
           aria-readonly={readOnly}
@@ -215,6 +221,8 @@ export const Toggle = forwardRef(function Toggle(
     style,
     id,
     enabled,
+    tabIndex,
+    ariaLabel,
     handleOnBlur,
     handleOnFocus,
     onInputChange,


### PR DESCRIPTION
…ckboxes prop

- TileGridNative: fix 1-column flash on mount by gating Virtualizer on containerWidth > 0
- TileGridNative: fix focus ring not clearing on Ctrl+Click deselect
- TileGridNative: fix checkbox click bubbling to tileWrapper (add stopPropagation)
- TileGridNative: fix focus tracking in clearSelection/selectId API methods
- TileGridNative: use itemsRef/idKeyRef to stabilize registerComponentApi effect deps
- TileGridNative: add hideSelectionCheckboxes prop (hides checkboxes, keeps selection logic)
- TileGrid.module.scss: remove browser outline from tileGridWrapper container
- Toggle: expose tabIndex and aria-label props (used by TileGrid checkbox overlay)
- useRowSelection: fix render-loop — use useRef for onSelectionDidChange callback so the effect only re-runs when selectedItems changes, not on every parent render
- TileGrid.md: document hideSelectionCheckboxes prop with example
- TileGrid.spec.ts: add 4 tests for hideSelectionCheckboxes