### PR TITLE
Wire Inspector icon color through theme system

### DIFF
--- a/.changeset/fix-inspector-icon-theme.md
+++ b/.changeset/fix-inspector-icon-theme.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Wire Inspector icon color through theme system so it responds to theme changes

--- a/xmlui/src/components/Inspector/Inspector.module.scss
+++ b/xmlui/src/components/Inspector/Inspector.module.scss
@@ -6,12 +6,16 @@ $themeVars: ();
   @return t.getThemeVar($themeVars, $componentVariable);
 }
 
+$component: "Inspector";
+$color-icon-Inspector: createThemeVar("color-icon-#{$component}");
+
 @layer components {
   .iconButton {
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    color: $color-icon-Inspector;
   }
 
   .icon {

--- a/xmlui/src/components/Inspector/Inspector.tsx
+++ b/xmlui/src/components/Inspector/Inspector.tsx
@@ -39,6 +39,9 @@ export const InspectorMd = createMetadata({
     },
   },
   themeVars: parseScssVar(styles.themeVars),
+  defaultThemeVars: {
+    [`color-icon-${COMP}`]: "$color-surface-500",
+  },
 });
 
 export const inspectorComponentRenderer = createComponentRenderer(


### PR DESCRIPTION
## Summary
- The Inspector icon was inheriting `currentColor` (default text color), appearing darker than sibling toolbar icons
- Added `color-icon-Inspector` theme variable via `createThemeVar` in SCSS
- Set default to `$color-surface-500` via `defaultThemeVars` in metadata, matching other toolbar icons
- Icon now responds to theme changes (light/dark) and is overridable per-theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)