### PR TITLE
fix: change CustomIcon display style from inline-flex to inline-block…

### DIFF
--- a/xmlui/src/components/Icon/IconNative.tsx
+++ b/xmlui/src/components/Icon/IconNative.tsx
@@ -137,7 +137,7 @@ const CustomIcon = forwardRef(function CustomIcon(
     return (
       <span
         ref={ref as ForwardedRef<HTMLSpanElement>}
-        style={{ display: "inline-flex" }}
+        style={{ display: "inline-block" }}
         onClick={onClick}
         onKeyDown={handleKeyDown}
         tabIndex={onClick ? (tabIndex ?? 0) : tabIndex}


### PR DESCRIPTION
… to render build-it icons and external icons the same way