### PR TITLE
fix: preserve query string in Actions.navigate for query-only paths

### DIFF
--- a/xmlui/src/components-core/action/NavigateAction.tsx
+++ b/xmlui/src/components-core/action/NavigateAction.tsx
@@ -14,6 +14,7 @@ function resolveRelativePathname(pathname: string | number, currentPathname: str
   if (typeof pathname !== "string") return pathname;
   if (pathname.startsWith("/")) return pathname; // already absolute
   if (pathname === ".") return currentPathname; // stay on current page
+  if (pathname.startsWith("?")) return currentPathname + pathname; // query-only, preserve on current page
   if (pathname === "..") {
     const parts = currentPathname.split("/").filter(Boolean);
     parts.pop();


### PR DESCRIPTION
resolveRelativePathname (introduced in fd643cb4) intercepts all navigate calls to resolve relative paths against the current page. However, query-string-only paths like '?new=true' fell through to the URL API fallback which only returned .pathname, silently dropping the query string.

Add an early return for paths starting with '?' that appends the query string to the current pathname, matching the behavior react-router provided before resolveRelativePathname was added.