### PR TITLE
fix: complete wrapComponent tracing and resolve standalone app issues

### DIFF
--- a/xmlui/src/components-core/action/APICall.tsx
+++ b/xmlui/src/components-core/action/APICall.tsx
@@ -14,14 +14,15 @@ function traceApiCall(
   details?: Record<string, any>,
 ) {
   if (appContext.appGlobals?.xsVerbose !== true) return;
+  const { _traceId, ...rest } = details || {};
   pushXsLog({
     ts: Date.now(),
     perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-    traceId: getCurrentTrace(),
+    traceId: _traceId || getCurrentTrace(),
     kind,
     url,
     method,
-    ...details,
+    ...rest,
   });
 }
 import type { AsyncFunction } from "../../abstractions/FunctionDefs";
@@ -395,7 +396,9 @@ export async function callApi(
       eventName: "progress",
     });
 
-    // Trace API call start
+    // Trace API call start — capture traceId before await so api:complete
+    // uses the same context (getCurrentTrace() may change after await)
+    const apiTraceId = getCurrentTrace();
     traceApiCall(appContext, "api:start", resolvedUrl, resolvedMethod, {
       transactionId: clientTxId,
       body: resolvedBody,
@@ -411,12 +414,13 @@ export async function callApi(
       onResponseHeaders,
     });
 
-    // Trace API call completion
+    // Trace API call completion — reuse traceId from start
     traceApiCall(appContext, "api:complete", resolvedUrl, resolvedMethod, {
       transactionId: clientTxId,
       body: resolvedBody,
       result,
       status: getLastApiStatus(clientTxId),
+      _traceId: apiTraceId,
     });
 
     const onSuccessFn = typeof onSuccess === "function"

--- a/xmlui/src/components-core/action/NavigateAction.tsx
+++ b/xmlui/src/components-core/action/NavigateAction.tsx
@@ -14,6 +14,7 @@ function resolveRelativePathname(pathname: string | number, currentPathname: str
   if (typeof pathname !== "string") return pathname;
   if (pathname.startsWith("/")) return pathname; // already absolute
   if (pathname === ".") return currentPathname; // stay on current page
+  if (pathname.startsWith("?")) return currentPathname + pathname; // query-only, preserve on current page
   if (pathname === "..") {
     const parts = currentPathname.split("/").filter(Boolean);
     parts.pop();

--- a/xmlui/src/components-core/inspector/inspectorUtils.ts
+++ b/xmlui/src/components-core/inspector/inspectorUtils.ts
@@ -202,7 +202,7 @@ export function pushXsLog(entry: XsLogEntry, xsLogMax: number = 200): void {
  * modals, toasts) is preserved.
  */
 export function splicePreservingInteractions(logs: any[], maxSize: number): void {
-  const preserved = new Set(["interaction", "navigate", "api:start", "api:complete", "api:error", "handler:start", "handler:complete", "modal:show", "modal:confirm", "modal:cancel", "toast", "submenu:open", "selection:change", "focus:change", "method:call"]);
+  const preserved = new Set(["interaction", "navigate", "api:start", "api:complete", "api:error", "handler:start", "handler:complete", "modal:show", "modal:confirm", "modal:cancel", "toast", "submenu:open", "selection:change", "focus:change", "method:call", "value:change"]);
   const keep: any[] = [];
   const evictable: any[] = [];
   for (const entry of logs) {

--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -672,7 +672,8 @@ export function AppContent({
 
       const inspectEl = withInspectId || closestInspect;
       const testIdEl = withTestId || closestTestId;
-      const nearest = inspectEl || testIdEl || target;
+      const componentTypeEl = target?.closest?.("[data-component-type]") as HTMLElement | null;
+      const nearest = inspectEl || testIdEl || componentTypeEl || target;
 
       const inspectId = inspectEl?.getAttribute?.("data-inspectid") || undefined;
       const testId = testIdEl?.getAttribute?.("data-testid") || undefined;

--- a/xmlui/src/components-core/wrapComponent.tsx
+++ b/xmlui/src/components-core/wrapComponent.tsx
@@ -1201,35 +1201,41 @@ export function wrapCompound<TMd extends ComponentMetadata>(
       const traceKind = xsVerbose ? eventNameToTraceKind(xmluiName) : undefined;
 
       if (xmluiName === "didChange" && isStateful) {
-        // didChange is special: StateWrapper's onChange calls this.
-        // It traces, calls updateState, and calls the XMLUI handler.
-        props.__onDidChange = (...args: any[]) => {
-          const traceId = traceKind ? pushTrace() : undefined;
-          try {
-            updateState({ value: args[0] });
-            let result: any;
-            if (handler) {
-              result = handler(...args);
+        // didChange for stateful components: native components call onDidChange(value)
+        // directly, so we intercept it here for tracing and XMLUI handler dispatch.
+        // When xsVerbose is off and no XMLUI handler, skip — native noop is fine.
+        if (traceKind || handler) {
+          props.onDidChange = (...args: any[]) => {
+            const traceId = traceKind ? pushTrace() : undefined;
+            try {
+              let result: any;
+              if (handler) {
+                result = handler(...args);
+              }
+              if (traceKind) {
+                pushXsLog(
+                  createLogEntry(traceKind, {
+                    component: type,
+                    componentLabel: node.uid || node.testId || undefined,
+                    displayLabel: traceDisplayLabel(traceKind, xmluiName, args),
+                    eventName: xmluiName,
+                    ariaName: ariaLabel,
+                    ownerFileId,
+                    ownerSource,
+                    ...extractFileMetadata(args),
+                  }),
+                );
+              }
+              return result;
+            } finally {
+              endTrace(traceId, traceKind);
             }
-            if (traceKind) {
-              pushXsLog(
-                createLogEntry(traceKind, {
-                  component: type,
-                  componentLabel: node.uid || node.testId || undefined,
-                  displayLabel: traceDisplayLabel(traceKind, xmluiName, args),
-                  eventName: xmluiName,
-                  ariaName: ariaLabel,
-                  ownerFileId,
-                  ownerSource,
-                  ...extractFileMetadata(args),
-                }),
-              );
-            }
-            return result;
-          } finally {
-            endTrace(traceId, traceKind);
-          }
-        };
+          };
+        }
+        // __onDidChange still needed for the StateWrapper onChange path
+        props.__onDidChange = props.onDidChange || ((...args: any[]) => {
+          updateState({ value: args[0] });
+        });
       } else {
         // Non-didChange events (gotFocus, lostFocus, ChangeListener didChange) pass through as native props
         props[reactPropName] = (...args: any[]) => {
@@ -1421,6 +1427,9 @@ export function wrapCompound<TMd extends ComponentMetadata>(
       undefined;
     if (ariaLabel) {
       props["aria-label"] = ariaLabel;
+    }
+    if (xsVerbose) {
+      props["data-component-type"] = type;
     }
 
     const rendered = <StateWrapper {...props} />;

--- a/xmlui/src/components/Inspector/InspectorNative.tsx
+++ b/xmlui/src/components/Inspector/InspectorNative.tsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 import styles from "./Inspector.module.scss";
 import type { RegisterComponentApiFn } from "../../abstractions/RendererDefs";
 import { COMPONENT_PART_KEY } from "../../components-core/theming/responsive-layout";
+import { normalizePath } from "../../components-core/utils/misc";
 import SearchCodeIcon from "../Icon/svg/l-search-code.svg?react";
 
 type Props = {
@@ -86,7 +87,7 @@ export function Inspector({
               </button>
             </div>
             <iframe
-              src={src}
+              src={normalizePath(src)}
               className={styles.iframe}
               data-testid="InspectorFrame"
             />

--- a/xmlui/src/components/NumberBox/NumberBoxNative.tsx
+++ b/xmlui/src/components/NumberBox/NumberBoxNative.tsx
@@ -137,6 +137,7 @@ export const NumberBox = forwardRef(function NumberBox(
     validationIconSuccess,
     validationIconError,
     invalidMessages,
+    "aria-label": ariaLabel,
     ...rest
   }: Props,
   forwardedRef: ForwardedRef<HTMLDivElement>,
@@ -618,6 +619,7 @@ export const NumberBox = forwardRef(function NumberBox(
         [styles.rtl]: direction === "rtl",
       })}
       ref={forwardedRef}
+      aria-label={ariaLabel}
       tabIndex={-1}
       onFocus={() => {
         inputRef.current?.focus();
@@ -682,6 +684,7 @@ export const NumberBox = forwardRef(function NumberBox(
               className={styles.spinnerButton}
               disabled={!enabled || readOnly}
               ref={upButton}
+              aria-label={ariaLabel ? `Increase ${ariaLabel}` : "Increase"}
             >
               <ThemedIcon name={spinnerUpIcon || "spinnerUp:NumberBox"} fallback="chevronup" size="sm" />
             </Button>
@@ -697,6 +700,7 @@ export const NumberBox = forwardRef(function NumberBox(
               className={styles.spinnerButton}
               disabled={!enabled || readOnly}
               ref={downButton}
+              aria-label={ariaLabel ? `Decrease ${ariaLabel}` : "Decrease"}
             >
               <ThemedIcon
                 name={spinnerDownIcon || "spinnerDown:NumberBox"}

--- a/xmlui/src/components/Toggle/Toggle.tsx
+++ b/xmlui/src/components/Toggle/Toggle.tsx
@@ -176,6 +176,7 @@ export const Toggle = forwardRef(function Toggle(
       <Part partId={PART_INPUT}>
         <input
           {...rest}
+          data-component-type="Toggle"
           id={id}
           ref={ref}
           type="checkbox"


### PR DESCRIPTION
The wrapComponent rollout (c1c7f80c) added tracing to all native components but left gaps. This commit closes them.

value:change tracing for wrapped input components:
- Wired props.onDidChange to a traced wrapper so native components existing onDidChange(value) calls emit value:change with ariaName
- Wrapper only created when xsVerbose is on or XMLUI handler exists
- Complete noop when tracing is off — zero overhead
- Added value:change to the preserved set in splicePreservingInteractions (events were being evicted from _xsLogs before export)

Interaction trace component resolution:
- AppContent: added closest("[data-component-type]") fallback so interactions on child elements resolve to the nearest wrapped component, not the raw DOM tag
- wrapComponent: set data-component-type on rendered props when xsVerbose is on, so all XMLUI-rendered wrapped components carry the attribute
- Toggle: added data-component-type="Toggle" directly since Table uses it as native JSX (bypasses ComponentAdapter)

NumberBox improvements:
- Spin buttons now carry aria-label="Increase/Decrease {label}" using the NumberBox aria-label from the wrapComponent cascade
- Extracted aria-label from rest props to prevent it being swallowed

APICall traceId leak:
- api:complete events were using getCurrentTrace() after await, inheriting stale trace contexts. Captured traceId before await and reuse it for completion. (DataLoader already had this pattern.)

NavigateAction query-string fix:
- resolveRelativePathname (fd643cb4) dropped query strings for paths like ?new=true by returning only .pathname from the URL API. Added early return for query-string-only paths.

Inspector __PUBLIC_PATH fix:
- Prepend __PUBLIC_PATH to xs-diff.html iframe src via normalizePath. Fixes 404 when app is served under a subpath. (Fixes #3099)