### PR TITLE
fix: centralize _xsLogs writes, trace Select options, pass Table aria…

### DIFF
--- a/xmlui/src/components-core/action/NavigateAction.tsx
+++ b/xmlui/src/components-core/action/NavigateAction.tsx
@@ -2,7 +2,7 @@ import type { To } from "react-router-dom";
 import type { ActionExecutionContext } from "../../abstractions/ActionDefs";
 import { createUrlWithQueryParams } from "../../components/component-utils";
 import { createAction } from "./actions";
-import { getCurrentTrace } from "../inspector/inspectorUtils";
+import { getCurrentTrace, pushXsLog } from "../inspector/inspectorUtils";
 
 /**
  * Resolves a potentially relative navigation pathname to an absolute path, using
@@ -54,21 +54,16 @@ function navigate(
       })
     : resolvedPathname;
 
-  // Trace navigation event (only when xsVerbose is enabled)
-  if (appContext?.appGlobals?.xsVerbose === true && typeof window !== "undefined") {
-    const w = window as any;
-    if (Array.isArray(w._xsLogs)) {
-      w._xsLogs.push({
-        ts: Date.now(),
-        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-        traceId: getCurrentTrace(),
-        kind: "navigate",
-        from: location.pathname,
-        to: String(to),
-        queryParams,
-      });
-    }
-  }
+  // Trace navigation event — pushXsLog is a noop when xsVerbose is off
+  pushXsLog({
+    ts: Date.now(),
+    perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+    traceId: getCurrentTrace(),
+    kind: "navigate",
+    from: location.pathname,
+    to: String(to),
+    queryParams,
+  });
 
   // Use appContext.navigate if available (which includes willNavigate/didNavigate handlers)
   // Otherwise fall back to the direct navigate function.

--- a/xmlui/src/components-core/inspector/inspectorUtils.ts
+++ b/xmlui/src/components-core/inspector/inspectorUtils.ts
@@ -67,6 +67,20 @@ export function safeStringify(value: any): string {
 }
 
 /**
+ * Safely deep-clone a value, replacing circular references, functions,
+ * and DOM nodes with placeholder strings. Use when storing values in
+ * _xsLogs that will later be JSON.stringify'd during trace capture.
+ */
+export function safeClone<T>(value: T): T {
+  if (value == null || typeof value !== "object") return value;
+  try {
+    return JSON.parse(safeStringify(value));
+  } catch {
+    return "[uncloneable]" as any;
+  }
+}
+
+/**
  * Simple stringify for diff display (no circular reference handling needed).
  */
 export function simpleStringify(value: any): string {
@@ -187,8 +201,12 @@ export interface XsLogEntry {
 export function pushXsLog(entry: XsLogEntry, xsLogMax: number = 200): void {
   if (typeof window === "undefined") return;
   const w = window as any;
-  w._xsLogs = Array.isArray(w._xsLogs) ? w._xsLogs : [];
-  w._xsLogs.push(entry);
+  // _xsLogs is only initialized by AppContent when xsVerbose=true.
+  // If it doesn't exist, tracing is off — noop.
+  if (!Array.isArray(w._xsLogs)) return;
+  // Safe-clone the entry to prevent circular references from live objects
+  // (e.g., React Query cache) from poisoning _xsLogs and breaking JSON export.
+  w._xsLogs.push(safeClone(entry));
   if (Number.isFinite(xsLogMax) && xsLogMax > 0 && w._xsLogs.length > xsLogMax) {
     splicePreservingInteractions(w._xsLogs, xsLogMax);
   }

--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -885,7 +885,7 @@ export function AppContent({
       w._xsLastInteraction = { id: interactionId, ts: Date.now() };
       w._xsCurrentTrace = interactionId;
       lastEventTraceId = interactionId;
-      w._xsLogs.push({
+      pushXsLog({
         ts: Date.now(),
         perfTs,
         eventTs: logEventTs,
@@ -900,10 +900,7 @@ export function AppContent({
         ariaName: detail.ariaName,
         detail,
         text: safeStringify(detail),
-      });
-      if (Number.isFinite(xsLogMax) && xsLogMax > 0 && w._xsLogs.length > xsLogMax) {
-        splicePreservingInteractions(w._xsLogs, xsLogMax);
-      }
+      }, xsLogMax);
     };
 
     const types = ["click", "dblclick", "contextmenu", "keydown"];
@@ -920,19 +917,14 @@ export function AppContent({
   // --- Wrap toast to log calls to _xsLogs for test trace capture
   const tracedToast = useMemo(() => {
     function logToast(type: string, message: unknown) {
-      if (typeof window !== "undefined") {
-        const w = window as any;
-        if (Array.isArray(w._xsLogs)) {
-          w._xsLogs.push({
-            ts: Date.now(),
-            perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-            traceId: w._xsCurrentTrace,
-            kind: "toast",
-            toastType: type,
-            message: typeof message === "string" ? message : String(message),
-          });
-        }
-      }
+      pushXsLog({
+        ts: Date.now(),
+        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+        traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+        kind: "toast",
+        toastType: type,
+        message: typeof message === "string" ? message : String(message),
+      });
     }
     const wrapper: any = (message: unknown, opts?: any) => {
       logToast("default", message);
@@ -1084,20 +1076,15 @@ function signError(error: Error | string) {
   toast.error(message);
   // Always log to console so Playwright page.on('console') can capture it
   console.error("[xmlui]", message);
-  // Also log to _xsLogs when xsVerbose is active (same guard as ErrorBoundary).
-  if (typeof window !== "undefined") {
-    const w = window as any;
-    if (Array.isArray(w._xsLogs)) {
-      w._xsLogs.push({
-        ts: Date.now(),
-        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-        traceId: w._xsCurrentTrace,
-        kind: "error:runtime",
-        error: message,
-        stack: error instanceof Error ? error.stack : undefined,
-      });
-    }
-  }
+  // Also log to _xsLogs — pushXsLog is a noop when xsVerbose is off
+  pushXsLog({
+    ts: Date.now(),
+    perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+    traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+    kind: "error:runtime",
+    error: message,
+    stack: error instanceof Error ? error.stack : undefined,
+  });
 }
 
 /**

--- a/xmlui/src/components-core/rendering/ComponentAdapter.tsx
+++ b/xmlui/src/components-core/rendering/ComponentAdapter.tsx
@@ -14,7 +14,7 @@ import type {
 import type { LookupAsyncFn, LookupSyncFn } from "../../abstractions/ActionDefs";
 
 import { extractParam, resolveResponsiveWhen } from "../utils/extractParam";
-import { getCurrentTrace } from "../inspector/inspectorUtils";
+import { getCurrentTrace, pushXsLog } from "../inspector/inspectorUtils";
 import { useTheme } from "../theming/ThemeContext";
 import { useStyles } from "../theming/StyleContext";
 import type { StyleObjectType } from "../theming/StyleRegistry";
@@ -526,20 +526,16 @@ const ComponentAdapter = forwardRef(function ComponentAdapter(
   const logInteraction = useCallback(
     (interaction: string, detail?: Record<string, any>) => {
       if (!xsVerbose) return;
-      if (typeof window !== "undefined") {
-        const w = window as any;
-        w._xsLogs = Array.isArray(w._xsLogs) ? w._xsLogs : [];
-        w._xsLogs.push({
-          ts: Date.now(),
-          traceId: getCurrentTrace(),
-          kind: "interaction",
-          componentType: safeNode.type,
-          componentLabel: resolvedLabel,
-          uid: safeNode.uid,
-          interaction,
-          detail,
-        });
-      }
+      pushXsLog({
+        ts: Date.now(),
+        traceId: getCurrentTrace(),
+        kind: "interaction",
+        componentType: safeNode.type,
+        componentLabel: resolvedLabel,
+        uid: safeNode.uid,
+        interaction,
+        detail,
+      });
     },
     [xsVerbose, safeNode.type, resolvedLabel, safeNode.uid],
   );

--- a/xmlui/src/components-core/rendering/ErrorBoundary.tsx
+++ b/xmlui/src/components-core/rendering/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import React, { type ErrorInfo, type ReactNode } from "react";
 import styles from "./ErrorBoundary.module.scss";
 
 import type { ComponentLike } from "../../abstractions/ComponentDefs";
+import { pushXsLog } from "../inspector/inspectorUtils";
 
 // --- The properties of the ErrorBoundary component
 interface Props {
@@ -54,25 +55,17 @@ export class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("Uncaught error:", error, errorInfo, this.props.location);
 
-    // Trace the error if xsVerbose tracing is enabled
-    // Note: ErrorBoundary is a class component without access to appContext,
-    // so we check _xsLogs existence as a proxy for xsVerbose being enabled
-    if (typeof window !== "undefined") {
-      const w = window as any;
-      // _xsLogs is only initialized when xsVerbose=true in AppContent
-      if (Array.isArray(w._xsLogs)) {
-        w._xsLogs.push({
-          ts: Date.now(),
-          perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-          traceId: w._xsCurrentTrace,
-          kind: "error:boundary",
-          error: error.message,
-          stack: error.stack,
-          componentStack: errorInfo.componentStack,
-          location: this.props.location,
-        });
-      }
-    }
+    // Trace the error — pushXsLog is a noop when xsVerbose is off
+    pushXsLog({
+      ts: Date.now(),
+      perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+      traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+      kind: "error:boundary",
+      error: error.message,
+      stack: error.stack,
+      componentStack: errorInfo.componentStack,
+      location: this.props.location,
+    });
   }
 
   /**

--- a/xmlui/src/components-core/state/state-layers.ts
+++ b/xmlui/src/components-core/state/state-layers.ts
@@ -152,7 +152,7 @@ export function mergeComponentApis(
                     createLogEntry?.("method:call", {
                       component: componentKey,
                       componentLabel: componentKey,
-                      displayLabel: `${componentKey}.${methodName}(${args.map((a: any) => JSON.stringify(a)).join(", ")})`,
+                      displayLabel: `${componentKey}.${methodName}(${args.map((a: any) => { try { return JSON.stringify(a); } catch { return "[Object]"; } }).join(", ")})`,
                     }),
                   );
                   return result;

--- a/xmlui/src/components-core/wrapComponent.tsx
+++ b/xmlui/src/components-core/wrapComponent.tsx
@@ -451,7 +451,11 @@ function traceDisplayLabel(traceKind: string, xmluiName: string, args: any[]): s
       if (Array.isArray(next)) {
         return `${(prev || []).length} → ${next.length} items`;
       }
-      return `${JSON.stringify(prev)?.slice(0, 30)} → ${JSON.stringify(next)?.slice(0, 30)}`;
+      try {
+        return `${JSON.stringify(prev)?.slice(0, 30)} → ${JSON.stringify(next)?.slice(0, 30)}`;
+      } catch {
+        return `[object] → [object]`;
+      }
     }
     return String(val);
   }

--- a/xmlui/src/components/Accordion/AccordionNative.tsx
+++ b/xmlui/src/components/Accordion/AccordionNative.tsx
@@ -3,6 +3,7 @@ import * as RAccordion from "@radix-ui/react-accordion";
 import classnames from "classnames";
 
 import styles from "./Accordion.module.scss";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 
 import type { RegisterComponentApiFn } from "../../abstractions/RendererDefs";
 import { noop } from "../../components-core/constants";
@@ -169,20 +170,15 @@ export const AccordionComponent = forwardRef(function AccordionComponent(
         className={classnames(styles.root, classes?.[COMPONENT_PART_KEY], className)}
         onValueChange={(value) => {
           setExpandedItems(value);
-          if (typeof window !== "undefined") {
-            const w = window as any;
-            if (Array.isArray(w._xsLogs)) {
-              w._xsLogs.push({
-                ts: Date.now(),
-                perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-                traceId: w._xsCurrentTrace,
-                kind: "focus:change",
-                component: "Accordion",
-                displayLabel: Array.isArray(value) ? value.join(", ") : String(value),
-                expandedItems: value,
-              });
-            }
-          }
+          pushXsLog({
+            ts: Date.now(),
+            perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+            traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+            kind: "focus:change",
+            component: "Accordion",
+            displayLabel: Array.isArray(value) ? value.join(", ") : String(value),
+            expandedItems: value,
+          });
         }}
       >
         {children}

--- a/xmlui/src/components/DropdownMenu/DropdownMenuNative.tsx
+++ b/xmlui/src/components/DropdownMenu/DropdownMenuNative.tsx
@@ -16,6 +16,7 @@ import { COMPONENT_PART_KEY } from "../../components-core/theming/responsive-lay
 import type { RegisterComponentApiFn } from "../../abstractions/RendererDefs";
 import { useTheme } from "../../components-core/theming/ThemeContext";
 import { noop } from "../../components-core/constants";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 import type {
   IconPosition,
   ButtonVariant,
@@ -279,20 +280,17 @@ export const SubMenuItem = forwardRef<HTMLDivElement, SubMenuItemProps>(function
 
   const handleOpenChange = useCallback((isOpen: boolean) => {
     setOpen(isOpen);
-    if (isOpen && typeof window !== "undefined") {
-      const w = window as any;
-      if (Array.isArray(w._xsLogs)) {
-        w._xsLogs.push({
-          ts: Date.now(),
-          perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-          traceId: w._xsCurrentTrace,
-          kind: "submenu:open",
-          displayLabel: label,
-          componentLabel: label,
-          ariaRole: "menuitem",
-          ariaName: label,
-        });
-      }
+    if (isOpen) {
+      pushXsLog({
+        ts: Date.now(),
+        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+        traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+        kind: "submenu:open",
+        displayLabel: label,
+        componentLabel: label,
+        ariaRole: "menuitem",
+        ariaName: label,
+      });
     }
   }, [label]);
 

--- a/xmlui/src/components/ModalDialog/ConfirmationModalContextProvider.tsx
+++ b/xmlui/src/components/ModalDialog/ConfirmationModalContextProvider.tsx
@@ -12,6 +12,7 @@ import type { ButtonVariant, ButtonThemeColor } from "../abstractions";
 import { ThemedButton as Button } from "../Button/Button";
 import { ThemedStack as Stack } from "../Stack/Stack";
 import { Dialog } from "./Dialog";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 
 const ConfirmationModalContext = React.createContext({
   confirm: (title: string, message?: string, actionLabel?: string) => Promise.resolve(false),
@@ -76,7 +77,7 @@ export const ConfirmationModalContextProvider = ({ children }: Props) => {
         const modalButtons = typeof title === "string"
           ? [{ label: actionLabel || "Ok", value: true }]
           : title.buttons.map(b => ({ label: b.label, value: b.value }));
-        w._xsLogs.push({
+        pushXsLog({
           ts: Date.now(),
           perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
           traceId: w._xsCurrentTrace,
@@ -116,7 +117,7 @@ export const ConfirmationModalContextProvider = ({ children }: Props) => {
       if (w._xsPendingConfirmTrace) {
         w._xsCurrentTrace = w._xsPendingConfirmTrace;
       }
-      w._xsLogs.push({
+      pushXsLog({
         ts: Date.now(),
         perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
         traceId: w._xsCurrentTrace,
@@ -140,7 +141,7 @@ export const ConfirmationModalContextProvider = ({ children }: Props) => {
       if (w._xsPendingConfirmTrace) {
         w._xsCurrentTrace = w._xsPendingConfirmTrace;
       }
-      w._xsLogs.push({
+      pushXsLog({
         ts: Date.now(),
         perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
         traceId: w._xsCurrentTrace,

--- a/xmlui/src/components/NavGroup/NavGroupNative.tsx
+++ b/xmlui/src/components/NavGroup/NavGroupNative.tsx
@@ -37,6 +37,7 @@ import type { NavGroupMd } from "./NavGroup";
 import { useLocation } from "react-router-dom";
 import classnames from "classnames";
 import { NavGroupContext } from "./NavGroupContext";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 import { getAppLayoutOrientation } from "../App/AppNative";
 import { useAppContext } from "../../components-core/AppContext";
 
@@ -253,21 +254,16 @@ const ExpandableNavGroup = forwardRef(function ExpandableNavGroup(
     }
     setExpanded((prev) => {
       const newExpanded = !prev;
-      if (typeof window !== "undefined") {
-        const w = window as any;
-        if (Array.isArray(w._xsLogs)) {
-          w._xsLogs.push({
-            ts: Date.now(),
-            perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-            traceId: w._xsCurrentTrace,
-            kind: "focus:change",
-            component: "NavGroup",
-            displayLabel: label,
-            label,
-            expanded: newExpanded,
-          });
-        }
-      }
+      pushXsLog({
+        ts: Date.now(),
+        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+        traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+        kind: "focus:change",
+        component: "NavGroup",
+        displayLabel: label,
+        label,
+        expanded: newExpanded,
+      });
       return newExpanded;
     });
   };
@@ -377,21 +373,16 @@ const DropDownNavGroup = forwardRef(function DropDownNavGroup(
       onOpenChange={(open) => {
         if (renderCount) {
           setExpanded(open);
-          if (typeof window !== "undefined") {
-            const w = window as any;
-            if (Array.isArray(w._xsLogs)) {
-              w._xsLogs.push({
-                ts: Date.now(),
-                perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-                traceId: w._xsCurrentTrace,
-                kind: "focus:change",
-                component: "NavGroup",
-                displayLabel: label,
-                label,
-                expanded: open,
-              });
-            }
-          }
+          pushXsLog({
+            ts: Date.now(),
+            perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+            traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+            kind: "focus:change",
+            component: "NavGroup",
+            displayLabel: label,
+            label,
+            expanded: open,
+          });
         }
       }}
     >

--- a/xmlui/src/components/Select/SelectNative.tsx
+++ b/xmlui/src/components/Select/SelectNative.tsx
@@ -456,12 +456,26 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(function Select(
           : selectedValue;
       updateState({ value: newSelectedValue });
       onDidChange(newSelectedValue);
-      // Emit native trace event when xsVerbose tracing is active
-      // (window._xsLogs existence is the proxy, same as InspectorContext)
+      // Emit interaction + native trace events for option selection.
+      // The interaction event is needed because Radix Select handles selection
+      // internally without firing a DOM click that AppContent can capture.
+      // Gated on _xsLogs existence (proxy for xsVerbose) to avoid work when tracing is off.
       if (typeof window !== "undefined" && Array.isArray((window as any)._xsLogs)) {
         const selectedOption = options.find((o) => String(o.value) === String(selectedValue));
+        const optionLabel = selectedOption?.label || String(selectedValue);
+        pushXsLog({
+          ts: Date.now(),
+          perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+          traceId: (window as any)._xsCurrentTrace,
+          kind: "interaction",
+          interaction: "click",
+          componentType: "Select",
+          componentLabel: optionLabel,
+          ariaRole: "option",
+          ariaName: optionLabel,
+        });
         pushXsLog(createLogEntry("native:selection:change", {
-          displayLabel: selectedOption?.label || String(selectedValue),
+          displayLabel: optionLabel,
           value: newSelectedValue,
         }));
       }
@@ -937,6 +951,8 @@ function SelectOptionItem(option: Option & { isHighlighted?: boolean; itemIndex?
     <div
       ref={optionRef}
       role="option"
+      aria-label={label || value}
+      data-component-type="Option"
       aria-disabled={!enabled}
       aria-selected={selected}
       className={classnames(styles.multiSelectOption, {

--- a/xmlui/src/components/Select/SelectOption.tsx
+++ b/xmlui/src/components/Select/SelectOption.tsx
@@ -18,6 +18,8 @@ export const SelectOption = forwardRef<React.ElementRef<typeof Item>, Option>(
         className={classnames(className, styles.selectOption)}
         value={value}
         textValue={label}
+        aria-label={label || value}
+        data-component-type="Option"
         disabled={!enabled}
         onClick={(event) => {
           event.stopPropagation();

--- a/xmlui/src/components/Table/TableNative.tsx
+++ b/xmlui/src/components/Table/TableNative.tsx
@@ -1500,7 +1500,7 @@ export const Table = forwardRef(
           (paginationControlsLocation === "top" || paginationControlsLocation === "both") &&
           paginationControls}
 
-        <table className={styles.table} ref={tableRef}>
+        <table className={styles.table} ref={tableRef} aria-label={(rest as any)["aria-label"]}>
           {!hideHeader && (
             <>
               <thead

--- a/xmlui/src/components/Table/useRowSelection.tsx
+++ b/xmlui/src/components/Table/useRowSelection.tsx
@@ -6,6 +6,7 @@ import { useEvent } from "../../components-core/utils/misc";
 import { EMPTY_ARRAY } from "../../components-core/constants";
 import { usePrevious } from "../../components-core/utils/hooks";
 import { useSelectionContext } from "../SelectionStore/SelectionStoreNative";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 
 /**
  * An interval of selected items
@@ -557,20 +558,17 @@ export default function useRowSelection({
 
   useEffect(() => {
     void onSelectionDidChangeRef.current?.(selectedItems);
-    if (selectedItems.length > 0 && typeof window !== "undefined") {
-      const w = window as any;
-      if (Array.isArray(w._xsLogs)) {
-        w._xsLogs.push({
-          ts: Date.now(),
-          perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-          traceId: w._xsCurrentTrace,
-          kind: "selection:change",
-          component: "Table",
-          displayLabel: `${selectedItems.length} item${selectedItems.length !== 1 ? "s" : ""}`,
-          selectedIds: selectedItems.map((item: any) => item.id ?? item.key),
-          selectedCount: selectedItems.length,
-        });
-      }
+    if (selectedItems.length > 0) {
+      pushXsLog({
+        ts: Date.now(),
+        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+        traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+        kind: "selection:change",
+        component: "Table",
+        displayLabel: `${selectedItems.length} item${selectedItems.length !== 1 ? "s" : ""}`,
+        selectedIds: selectedItems.map((item: any) => item.id ?? item.key),
+        selectedCount: selectedItems.length,
+      });
     }
   }, [selectedItems]);
 

--- a/xmlui/src/components/Tabs/TabsNative.tsx
+++ b/xmlui/src/components/Tabs/TabsNative.tsx
@@ -22,6 +22,7 @@ import { TabContext, useTabContextValue } from "./TabContext";
 import classnames from "classnames";
 import { noop } from "../../components-core/constants";
 import { COMPONENT_PART_KEY } from "../../components-core/theming/responsive-layout";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 
 type Props = {
   id?: string;
@@ -164,22 +165,17 @@ export const Tabs = forwardRef(function Tabs(
                 tabContextValue.setActiveTabId(tab);
                 setActiveIndex(newIndex);
                 onDidChange?.(newIndex, tabItem.id || tabItem.innerId, tabItem?.label);
-                if (typeof window !== "undefined") {
-                  const w = window as any;
-                  if (Array.isArray(w._xsLogs)) {
-                    w._xsLogs.push({
-                      ts: Date.now(),
-                      perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-                      traceId: w._xsCurrentTrace,
-                      kind: "focus:change",
-                      component: "Tabs",
-                      displayLabel: tabItem?.label,
-                      tabIndex: newIndex,
-                      tabId: tabItem.id || tabItem.innerId,
-                      tabLabel: tabItem?.label,
-                    });
-                  }
-                }
+                pushXsLog({
+                  ts: Date.now(),
+                  perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+                  traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+                  kind: "focus:change",
+                  component: "Tabs",
+                  displayLabel: tabItem?.label,
+                  tabIndex: newIndex,
+                  tabId: tabItem.id || tabItem.innerId,
+                  tabLabel: tabItem?.label,
+                });
               }
             }}
             orientation="vertical"
@@ -243,22 +239,17 @@ export const Tabs = forwardRef(function Tabs(
             tabContextValue.setActiveTabId(tab);
             setActiveIndex(newIndex);
             onDidChange?.(newIndex, tabItem.id || tabItem.innerId, tabItem?.label);
-            if (typeof window !== "undefined") {
-              const w = window as any;
-              if (Array.isArray(w._xsLogs)) {
-                w._xsLogs.push({
-                  ts: Date.now(),
-                  perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-                  traceId: w._xsCurrentTrace,
-                  kind: "focus:change",
-                  component: "Tabs",
-                  displayLabel: tabItem?.label,
-                  tabIndex: newIndex,
-                  tabId: tabItem.id || tabItem.innerId,
-                  tabLabel: tabItem?.label,
-                });
-              }
-            }
+            pushXsLog({
+              ts: Date.now(),
+              perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+              traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+              kind: "focus:change",
+              component: "Tabs",
+              displayLabel: tabItem?.label,
+              tabIndex: newIndex,
+              tabId: tabItem.id || tabItem.innerId,
+              tabLabel: tabItem?.label,
+            });
           }
         }}
         orientation={orientation}

--- a/xmlui/src/components/Tree/TreeNative.tsx
+++ b/xmlui/src/components/Tree/TreeNative.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, memo, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { Virtualizer, type VirtualizerHandle } from "virtua";
 import classnames from "classnames";
+import { pushXsLog } from "../../components-core/inspector/inspectorUtils";
 import { COMPONENT_PART_KEY } from "../../components-core/theming/responsive-layout";
 import { ThemedIcon } from "../Icon/Icon";
 import { ThemedSpinner as Spinner } from "../Spinner/Spinner";
@@ -801,21 +802,16 @@ export const TreeComponent = memo((props: TreeComponentProps) => {
       }
 
       // Emit selection:change trace event
-      if (typeof window !== "undefined") {
-        const w = window as any;
-        if (Array.isArray(w._xsLogs)) {
-          w._xsLogs.push({
-            ts: Date.now(),
-            perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
-            traceId: w._xsCurrentTrace,
-            kind: "selection:change",
-            component: "Tree",
-            displayLabel: node ? node.name : null,
-            selectedId: node ? String(node.key) : null,
-            selectedName: node ? node.name : null,
-          });
-        }
-      }
+      pushXsLog({
+        ts: Date.now(),
+        perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+        traceId: typeof window !== "undefined" ? (window as any)._xsCurrentTrace : undefined,
+        kind: "selection:change",
+        component: "Tree",
+        displayLabel: node ? node.name : null,
+        selectedId: node ? String(node.key) : null,
+        selectedName: node ? node.name : null,
+      });
     },
     [
       treeItemsById,

--- a/xmlui/tests/components-core/inspectorUtils.test.ts
+++ b/xmlui/tests/components-core/inspectorUtils.test.ts
@@ -225,10 +225,9 @@ describe("inspectorUtils", () => {
       (window as any)._xsLogs = originalXsLogs;
     });
 
-    it("creates _xsLogs array if not exists", () => {
+    it("is a noop when _xsLogs does not exist (xsVerbose off)", () => {
       pushXsLog({ ts: 123, kind: "test" });
-      expect((window as any)._xsLogs).toBeDefined();
-      expect(Array.isArray((window as any)._xsLogs)).toBe(true);
+      expect((window as any)._xsLogs).toBeUndefined();
     });
 
     it("appends to existing _xsLogs array", () => {
@@ -238,6 +237,7 @@ describe("inspectorUtils", () => {
     });
 
     it("enforces max limit", () => {
+      (window as any)._xsLogs = []; // simulate xsVerbose on
       for (let i = 0; i < 10; i++) {
         pushXsLog({ ts: i, kind: "test" }, 5);
       }
@@ -247,7 +247,7 @@ describe("inspectorUtils", () => {
     });
 
     it("uses default max of 200", () => {
-      // Just verify it doesn't throw with many entries
+      (window as any)._xsLogs = []; // simulate xsVerbose on
       for (let i = 0; i < 250; i++) {
         pushXsLog({ ts: i, kind: "test" });
       }


### PR DESCRIPTION
…-label

pushXsLog centralization:
- Route all 17 direct w._xsLogs.push() calls through pushXsLog()
- pushXsLog is a complete noop when xsVerbose is off
- safeClone prevents circular references from poisoning _xsLogs
- state-layers: catch circular refs in method:call displayLabel

Table aria-label:
- Pass aria-label through to native <table> element

Select option tracing:
- Emit interaction event from toggleOption so distiller can generate Playwright selectors for option selections (Radix stopPropagation prevents AppContent from capturing option clicks)
- Add aria-label and data-component-type on option elements