### PR TITLE
fix: allow draft blog posts to be previewed via direct URL

### DIFF
--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -635,7 +635,7 @@
                 url="/blog/:slug"
             >
                 <script>
-                    var post = appGlobals.posts.find(p => p.slug === $routeParams.slug)
+                    var post = appGlobals.allPosts.find(p => p.slug === $routeParams.slug)
                 </script>
                 <BlogPage
                     when="{post}"

--- a/website/src/config.ts
+++ b/website/src/config.ts
@@ -5,6 +5,7 @@ import {
   staticSearchData,
   prefetchedContent,
   posts,
+  allPosts,
   shikiHighlighter,
   highlight,
   getLocalIcons,
@@ -46,6 +47,7 @@ const App: StandaloneAppDescription = {
     staticSearchData,
     prefetchedContent,
     posts,
+    allPosts,
     codeHighlighter: {
       availableLangs: shikiHighlighter.getLoadedLanguages(),
       highlight,

--- a/website/utils/index.ts
+++ b/website/utils/index.ts
@@ -92,9 +92,8 @@ const staticSearchData: SearchItemData[] = [
   }),
 ];
 
-// Build posts array from blogFrontmatter so it doesn't need to be maintained manually in index.html
-const posts = Object.entries(blogFrontmatter)
-  .filter(([, fm]) => !fm.draft)
+// Build allPosts (including drafts, for direct URL preview) and posts (excluding drafts, for listing)
+const allPosts = Object.entries(blogFrontmatter)
   .map(([key, fm]) => ({
     title: fm.title,
     slug: fm.slug ?? key.replace("/blog/", ""),
@@ -103,16 +102,16 @@ const posts = Object.entries(blogFrontmatter)
     date: fm.date,
     image: fm.image,
     tags: fm.tags,
+    draft: !!fm.draft,
   }));
+
+const posts = allPosts.filter((p) => !p.draft);
 
 const prefetchedContent: Record<string, any> = {};
 
-// Filter out drafts from the main blogContent as well, so they don't show up in the UI
-blogContent = Object.fromEntries(
-  Object.entries(blogContent).filter(([key]) => {
-    return !(blogFrontmatter[`/blog/${key}`]?.draft === true);
-  }),
-);
+// NOTE: We intentionally do NOT filter drafts from blogContent here.
+// Draft posts are excluded from the posts array (used by BlogOverview listing),
+// but their content remains available so they can be previewed via direct URL.
 // Populate prefetched blog content
 Object.keys(blogContent).forEach((fileName) => {
   prefetchedContent[`/blog/${fileName}.md`] = blogContent[fileName];
@@ -123,7 +122,7 @@ Object.keys(rawHomepageContent).forEach((filePath) => {
   prefetchedContent[`/pages/${fileName}`] = rawHomepageContent[filePath].default;
 });
 
-export { prefetchedContent, docsContent, staticSearchData, posts };
+export { prefetchedContent, docsContent, staticSearchData, posts, allPosts };
 
 // --- Icon loader utility
 


### PR DESCRIPTION
## Summary
- PR #3147 inadvertently filtered draft blog posts from both the listing **and** the page content/routing, making direct URL preview of drafts impossible
- Restored intended behavior: `draft: true` posts are hidden from the blog overview but remain accessible at `/blog/<slug>` for preview
- Added `allPosts` (includes drafts) alongside `posts` (excludes drafts); route lookup uses `allPosts`, listing uses `posts`

## Test plan
- [ ] Set `draft: true` on a blog post and verify it does **not** appear in the blog listing at `/blog`
- [ ] Navigate directly to `/blog/<slug>` for the draft post and verify it renders correctly
- [ ] Verify non-draft posts continue to appear in the listing and render normally
