### PR TITLE
Add fitContent prop to App for iframe embedding (RFC)

### DIFF
--- a/xmlui/src/components/App/App.module.scss
+++ b/xmlui/src/components/App/App.module.scss
@@ -312,6 +312,35 @@ $scrollPaddingBlockPage: createThemeVar("scroll-padding-block-Pages");
       }
     }
 
+    // fitContent: app sizes itself to its content's natural height rather
+    // than filling its container's viewport. Intended for iframe embedding
+    // or use as a block within a larger page. Takes precedence over
+    // scrollWholePage's viewport pinning and all per-layout rules; the host
+    // page becomes the sole scroll container. Nothing inside the app should
+    // create a height-bounded scroll container.
+    //
+    // !important is used deliberately: this is an escape-hatch mode that
+    // must override the layout-specific cascade (e.g. .horizontal.sticky's
+    // min-height: 100%). Trying to out-specificity every layout combination
+    // would be brittle.
+    &.fitContent {
+      height: auto !important;
+      min-height: 0 !important;
+      max-height: none !important;
+      overflow: visible !important;
+
+      .mainContentRow,
+      .mainContentArea,
+      .pagesContainer,
+      .pageContentContainer,
+      .pageContentContainer > :global(.xmlui-page-root) {
+        height: auto !important;
+        min-height: 0 !important;
+        max-height: none !important;
+        overflow: visible !important;
+      }
+    }
+
     &:not(.scrollWholePage) {
       overflow: clip; // clip (not hidden) — prevents this element from acting as a scroll container,
       // so focus-driven scrollIntoView cannot scroll appContainer. overflow:hidden creates a scroll

--- a/xmlui/src/components/App/App.tsx
+++ b/xmlui/src/components/App/App.tsx
@@ -61,6 +61,15 @@ export const AppMd = createMetadata({
       valueType: "boolean",
       defaultValue: defaultProps.scrollWholePage,
     },
+    fitContent: {
+      description:
+        `When \`true\`, the app sizes itself to its content's natural height rather than ` +
+        `filling its container's viewport. Intended for embedding an app inside an iframe ` +
+        `or as a block within a larger page: the host page becomes the sole scroll container. ` +
+        `This overrides \`scrollWholePage\`'s viewport pinning.`,
+      valueType: "boolean",
+      defaultValue: defaultProps.fitContent,
+    },
     noScrollbarGutters: {
       description:
         "This boolean property specifies whether the scrollbar gutters should be hidden.",
@@ -249,6 +258,7 @@ function AppNode({ node, extractValue, renderChild, classes, lookupEventHandler,
     ? extractValue.asOptionalBoolean(Footer.props.sticky, true)
     : true;
   const scrollWholePage = extractValue.asOptionalBoolean(node.props.scrollWholePage, true);
+  const fitContent = extractValue.asOptionalBoolean(node.props.fitContent, false);
 
   // When scrollWholePage is false, pageContentContainer is a vertical flex container
   // Pass layout context so children can properly resolve star sizing
@@ -257,6 +267,7 @@ function AppNode({ node, extractValue, renderChild, classes, lookupEventHandler,
   return (
     <AppComponent
       scrollWholePage={scrollWholePage}
+      fitContent={fitContent}
       noScrollbarGutters={extractValue.asOptionalBoolean(node.props.noScrollbarGutters, false)}
       classes={classes}
       layout={extractValue(node.props.layout)}

--- a/xmlui/src/components/App/AppNative.tsx
+++ b/xmlui/src/components/App/AppNative.tsx
@@ -587,6 +587,11 @@ export function App({
       })}
       style={styleWithHelpers}
       ref={shouldContainerScroll ? pageScrollRef : undefined}
+      // Stable hook for embedding code: when fitContent is on, parent pages
+      // (e.g. iframe hosts auto-resizing the embed) can find this element via
+      // [data-xmlui-app-fit-content] without depending on hashed CSS module
+      // class names.
+      data-xmlui-app-fit-content={fitContent ? "true" : undefined}
       {...rest}
     >
       {config.useVerticalFullHeaderStructure ? (

--- a/xmlui/src/components/App/AppNative.tsx
+++ b/xmlui/src/components/App/AppNative.tsx
@@ -88,6 +88,7 @@ type Props = {
   loggedInUser?: any;
   scrollWholePage: boolean;
   noScrollbarGutters?: boolean;
+  fitContent?: boolean;
   onReady?: () => void;
   onMessageReceived?: (data: any, event: MessageEvent) => void;
   onKeyDown?: (event: KeyboardEvent) => void;
@@ -116,6 +117,7 @@ export const defaultProps: Pick<
   Props,
   | "scrollWholePage"
   | "noScrollbarGutters"
+  | "fitContent"
   | "defaultTone"
   | "defaultTheme"
   | "autoDetectTone"
@@ -131,6 +133,7 @@ export const defaultProps: Pick<
 > = {
   scrollWholePage: true,
   noScrollbarGutters: false,
+  fitContent: false,
   defaultTone: undefined,
   defaultTheme: undefined,
   autoDetectTone: false,
@@ -183,6 +186,7 @@ export function App({
   loggedInUser,
   scrollWholePage = defaultProps.scrollWholePage,
   noScrollbarGutters = defaultProps.noScrollbarGutters,
+  fitContent = defaultProps.fitContent,
   onReady = defaultProps.onReady,
   onMessageReceived = defaultProps.onMessageReceived,
   onKeyDown = defaultProps.onKeyDown,
@@ -485,7 +489,8 @@ export function App({
     classes?.[COMPONENT_PART_KEY],
     styles.appContainer,
     {
-      [styles.scrollWholePage]: scrollWholePage,
+      [styles.scrollWholePage]: scrollWholePage && !fitContent,
+      [styles.fitContent]: fitContent,
       [styles.noScrollbarGutters]: noScrollbarGutters,
       [styles.noFooter]: !footerSticky,
       "media-large": mediaSize.largeScreen,

--- a/xmlui/src/components/ModalDialog/ModalDialog.module.scss
+++ b/xmlui/src/components/ModalDialog/ModalDialog.module.scss
@@ -25,7 +25,7 @@ $marginBottom-title-ModalDialog: createThemeVar("Dialog:marginBottom-title-#{$co
 
 @layer components {
   .overlay {
-    position: absolute;
+    position: fixed;
     display: grid;
     place-items: center;
     overflow-y: auto;


### PR DESCRIPTION

## Context

I have an XMLUI app (the [community calendar](https://github.com/judell/community-calendar)) that gets embedded as an iframe inside other people's pages — currently [bsquarebulletin.com/calendar-test](https://bsquarebulletin.com/calendar-test/) and [bloomingtononline.com/events](https://bloomingtononline.com/events/). Both host pages give the iframe a fixed pixel height (`height="1800"` etc.). When the calendar has more events than fit in that fixed height, two things go wrong:

1. The iframe scrolls internally **and** the host page scrolls, so users get a double-scroll experience and tend to get lost.
2. Pagination buttons at the bottom of the calendar (e.g. "Later") are very hard to reach because they live below the iframe's internal viewport.

The standard fix is to make the iframe auto-grow to its content height via `postMessage`, so the host page becomes the only scroll container. But that only works if `document.documentElement.scrollHeight` actually reflects the content's natural height — and inside an XMLUI app it doesn't, because the `App` component pins itself to the viewport via `scrollWholePage` (and via `.appContainer { height: 100% }` and per-layout `min-height: 100%` rules).

## What this PR does

Adds a new opt-in `App` prop, `fitContent` (default `false`). When set, the app sizes itself to its content's natural height instead of filling its container's viewport. The host page becomes the sole scroll container and `documentElement.scrollHeight` reflects real content height.

Implementation is intentionally minimal:

- **`AppNative.tsx`**: new `fitContent?: boolean` prop, defaults to `false`. Adds `_fitContent_` to the wrapper class list when set, and suppresses `_scrollWholePage_` so the two are mutually exclusive (`scrollWholePage && !fitContent`).
- **`App.tsx`**: prop metadata + `extractValue` plumbing.
- **`App.module.scss`**: a single new `&.fitContent` rule scoped under `.appContainer` that forces `height: auto; min-height: 0; overflow: visible` on the appContainer and a few key children (`mainContentRow`, `mainContentArea`, `pagesContainer`, `pageContentContainer`, `xmlui-page-root`).

The `!important` on the override rules is deliberate — `fitContent` is by design an escape hatch from the layout-specific cascade (e.g. `.horizontal.sticky` has `min-height: 100%`, with 3-class specificity that beats `.appContainer.fitContent`'s 2). Trying to out-specificity every layout combination would be brittle. I'm not happy about it but I want to flag it explicitly for review.

Existing apps that never set `fitContent` get exactly the original behavior — the only relevant code change for them is `scrollWholePage && !fitContent`, which collapses to `scrollWholePage`.

## Demo

Live at https://judell.github.io/community-calendar/embed-demo.html

(GitHub Pages may take a minute or two to publish after the corresponding community-calendar commit lands; the page won't exist when this PR is first created but should appear shortly.)

Open the demo and scroll: a single host-page scroll passes through the calendar from top to bottom with no internal iframe scrollbar, no nested gestures, no trapped pagination. The iframe in the demo opts in via `?autoheight=true`; the calendar's `Main.xmlui` reads `window.ccAutoHeight` (set by `index.html` from that URL param) and passes it to `<App fitContent="...">`. A tiny postMessage sender in `index.html` polls `documentElement.scrollHeight` briefly and reports it to the parent.

## Questions for review

I would value your judgement on any of these:

1. **Is this even the right shape?** Should this be a value of an existing prop (e.g. `scrollWholePage="content-flow"` or a new `layout="flow"` value) rather than a new boolean? I went with a new opt-in boolean for additivity, but I can see arguments for folding it into the existing taxonomy.

2. **The `!important` problem.** Is there a cleaner way to defeat the layout-specific cascade? I considered enumerating every combination (`.appContainer.horizontal.fitContent`, `.appContainer.horizontal.sticky.fitContent`, etc.) but it felt brittle against future layout additions. Open to a refactor of the layout cascade if you have one in mind.

3. **Side effects I might be missing.** With `fitContent`, the document is allowed to grow past viewport. That could interact with: virtualized `List` (which seems to render fine but I want to confirm), focus-driven `scrollIntoView` (which currently relies on the appContainer being a scroll container), sticky headers, the sheet/drawer overlay, anything that uses `100dvh`. I've only tested the calendar use case — I haven't probed every layout × `fitContent` combination.

4. **Test coverage.** I haven't added tests. What would you want to see exercised? E2E playwright tests in an iframe context, or unit tests on the wrapper class list?

5. **Naming.** `fitContent` vs `flowHeight` vs `embedded` vs `blockFlow`? I'd take a better name happily.

6. **Mutual exclusivity with `scrollWholePage`.** Right now `fitContent="true"` silently overrides any explicit `scrollWholePage="true"`. Should it warn at parse time, or is silent override fine since `fitContent` is the more specific opt-in?

The community-calendar side of this experiment is at https://github.com/judell/community-calendar/commit/HEAD (commit message "Add iframe auto-height embed mode"). Bundles a rebuilt `xmlui-standalone.umd.js` containing this PR's changes — that's the temporary "vendored fork" situation I'm hoping this PR will eventually replace.

No urgency on a decision — happy to iterate, redesign, or scrap and try a different approach entirely if you think this is the wrong path.
