### PR TITLE
Fix missing trace events for startup DataSource fetches

### DIFF
--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -525,6 +525,11 @@ export function AppContent({
   // This ensures DataLoader can capture the trace when useQuery triggers fetches
   if (xsVerbose && typeof window !== "undefined") {
     const w = window as any;
+    // Initialize _xsLogs early so DataSource startup fetches are traced.
+    // Without this, pushXsLog() noops because _xsLogs doesn't exist yet.
+    if (!Array.isArray(w._xsLogs)) {
+      w._xsLogs = [];
+    }
     if (!w._xsStartupTrace) {
       w._xsStartupTrace = `startup-${Date.now().toString(36)}`;
     }


### PR DESCRIPTION
## Summary

- `_xsLogs` was only initialized on first user interaction (click/keydown), so `pushXsLog()` silently dropped all trace events fired during startup — including DataSource API calls
- Move `_xsLogs = []` initialization to the early-render block in AppContent that already sets up the startup trace ID (matching the existing comment's stated intent)

## How it was found

While testing the new Claude Code plugin's `/xmlui-setup` skill, we scaffolded an `xmlui-weather` app, added tracing (config.json + xs-diff.html + xmlui-parser.es.js + Inspector), and exported a trace. The trace showed button clicks and state changes but zero `api:start`/`api:complete` events for the DataSource fetching from wttr.in.

Root cause: the DataSource fetch fires during startup, before any user interaction. The interaction listener in AppContent (line 853) creates `_xsLogs` on the first click — too late for startup fetches.

## Before/After

**Before:** Trace from weather app shows only interaction events, no API calls:
```
0 interaction          click Get Weather
1 handler:start        click Button
2 state:changes        errorMessage cleared
3 handler:complete     click Button (20ms)
```

**After:** Trace captures the full startup sequence including DataSource fetch:
```
0 state:changes        DataSource:weatherData
1 api:start            GET https://wttr.in/Santa Rosa, CA
2 api:complete         GET https://wttr.in/Santa Rosa, CA (current_condition, nearest_area, request, weather)
3 state:changes        DataSource:weatherData loaded
4 component:vars:init  Main
```

Generated with [Claude Code](https://claude.com/claude-code)