### PR TITLE
Fix missing api:start/api:complete events for startup DataSource fetches

### DIFF
--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -525,6 +525,11 @@ export function AppContent({
   // This ensures DataLoader can capture the trace when useQuery triggers fetches
   if (xsVerbose && typeof window !== "undefined") {
     const w = window as any;
+    // Initialize _xsLogs early so DataSource startup fetches are traced.
+    // Without this, pushXsLog() noops because _xsLogs doesn't exist yet.
+    if (!Array.isArray(w._xsLogs)) {
+      w._xsLogs = [];
+    }
     if (!w._xsStartupTrace) {
       w._xsStartupTrace = `startup-${Date.now().toString(36)}`;
     }


### PR DESCRIPTION
_xsLogs was only initialized inside the interaction listener (on first user click), so pushXsLog() silently dropped all trace events fired before any interaction -- including DataSource startup fetches.

Moves _xsLogs initialization to the early-render block that already sets up the startup trace ID, matching the existing comment intent.

## Test plan
- Load an app with xsVerbose: true and a DataSource that fetches on startup
- Open the Inspector and verify api:start / api:complete events appear in the first trace (before any user interaction)