### PR TITLE
Make GridLayout browser-safe and restore docs route

### DIFF
--- a/packages/xmlui-grid-layout/src/GridLayoutRender.tsx
+++ b/packages/xmlui-grid-layout/src/GridLayoutRender.tsx
@@ -1,7 +1,101 @@
-import React, { memo, useState, useEffect, useCallback } from "react";
-import { Responsive, WidthProvider } from "react-grid-layout";
+import React, { memo, useState, useEffect, useCallback, useMemo } from "react";
+import * as ReactDOM from "react-dom";
+import reactGridLayoutUrl from "react-grid-layout/dist/react-grid-layout.min.js?url";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
 
-const ResponsiveGridLayout = WidthProvider(Responsive);
+type ReactGridLayoutGlobal = {
+  Responsive: React.ComponentType<any>;
+  WidthProvider: (component: React.ComponentType<any>) => React.ComponentType<any>;
+};
+
+let reactGridLayoutPromise: Promise<ReactGridLayoutGlobal> | null = null;
+
+async function loadReactGridLayout(): Promise<ReactGridLayoutGlobal> {
+  if (typeof window === "undefined") {
+    throw new Error("react-grid-layout is only available in the browser");
+  }
+
+  const win = window as typeof window & {
+    React?: typeof React;
+    ReactDOM?: typeof ReactDOM;
+    ReactGridLayout?:
+      | ReactGridLayoutGlobal
+      | (React.ComponentType<any> & ReactGridLayoutGlobal);
+  };
+
+  const getGridLayoutApi = () => {
+    const responsive = win.ReactGridLayout?.Responsive;
+    const widthProvider = win.ReactGridLayout?.WidthProvider;
+
+    if (responsive && widthProvider) {
+      return {
+        Responsive: responsive,
+        WidthProvider: widthProvider,
+      };
+    }
+
+    return null;
+  };
+
+  const existingApi = getGridLayoutApi();
+  if (existingApi) {
+    return existingApi;
+  }
+
+  if (!reactGridLayoutPromise) {
+    reactGridLayoutPromise = new Promise<ReactGridLayoutGlobal>((resolve, reject) => {
+      win.React ||= React;
+      win.ReactDOM ||= ReactDOM;
+
+      const existingScript = document.querySelector<HTMLScriptElement>(
+        "script[data-xmlui-react-grid-layout]",
+      );
+
+      const handleReady = () => {
+        const api = getGridLayoutApi();
+        if (api) {
+          resolve(api);
+        } else {
+          reactGridLayoutPromise = null;
+          reject(new Error("react-grid-layout loaded without expected globals"));
+        }
+      };
+
+      const handleError = () => {
+        reactGridLayoutPromise = null;
+        reject(new Error("Failed to load react-grid-layout"));
+      };
+
+      if (existingScript) {
+        if (existingScript.dataset.loaded === "true") {
+          handleReady();
+          return;
+        }
+        existingScript.addEventListener("load", handleReady, { once: true });
+        existingScript.addEventListener("error", handleError, { once: true });
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.src = reactGridLayoutUrl;
+      script.async = true;
+      script.dataset.xmluiReactGridLayout = "true";
+      script.addEventListener(
+        "load",
+        () => {
+          script.dataset.loaded = "true";
+          handleReady();
+        },
+        { once: true },
+      );
+      script.addEventListener("error", handleError, { once: true });
+      document.head.appendChild(script);
+    });
+  }
+
+  return reactGridLayoutPromise;
+}
 
 function flattenChildren(children: React.ReactNode): React.ReactNode[] {
   const flat: React.ReactNode[] = [];
@@ -70,6 +164,7 @@ export const GridLayoutRender = memo(function GridLayoutRender({
 
   const [resolvedGap, setResolvedGap] = useState(() => resolveCssLength(gap, 16));
   const [currentLayout, setCurrentLayout] = useState<any[]>(layout || []);
+  const [gridLayoutApi, setGridLayoutApi] = useState<ReactGridLayoutGlobal | null>(null);
 
   useEffect(() => {
     setResolvedGap(resolveCssLength(gap, 16));
@@ -78,6 +173,24 @@ export const GridLayoutRender = memo(function GridLayoutRender({
   useEffect(() => {
     if (layout) setCurrentLayout(layout);
   }, [layout]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadReactGridLayout()
+      .then((api) => {
+        if (!cancelled) {
+          setGridLayoutApi(api);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to initialize GridLayout", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleLayoutChange = useCallback((newLayout: any[]) => {
     setCurrentLayout(newLayout);
@@ -106,9 +219,29 @@ export const GridLayoutRender = memo(function GridLayoutRender({
 
   // Flatten children (unwrap XMLUI Items/template wrapper elements)
   const flatChildren = flattenChildren(children);
+  const ResponsiveGridLayout = useMemo(
+    () => (gridLayoutApi ? gridLayoutApi.WidthProvider(gridLayoutApi.Responsive) : null),
+    [gridLayoutApi],
+  );
 
   // react-grid-layout matches children to layout items by child.key.
   // Ensure each child div has a key and data-grid matching the layout.
+  if (!ResponsiveGridLayout) {
+    return (
+      <div className={className}>
+        {flatChildren.map((child, i) => {
+          const layoutItem = currentLayout[i];
+          const key = layoutItem?.i ?? `_gl_${i}`;
+          return (
+            <div key={key} style={{ overflow: "auto", marginBottom: resolvedGap }}>
+              {child}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   return (
     <ResponsiveGridLayout
       className={className}

--- a/website/content/docs/pages/wrap-component/_overview.md
+++ b/website/content/docs/pages/wrap-component/_overview.md
@@ -35,18 +35,16 @@ A wrapped component needs to respect the design system. Three strategies, depend
 
 ## Level 4: Layout
 
-XMLUI's core layout components -- HStack, VStack, FlowLayout -- handle most needs. But some layouts require algorithms the core doesn't provide. [Masonry](/docs/guides/wrap-component/masonry) wraps CSS multi-column layout for content feeds and galleries where items of varying height flow into columns. [GridLayout](/docs/guides/wrap-component/grid-layout) wraps react-grid-layout for draggable, resizable dashboard grids where items have explicit positions. Same wrapping pattern, very different layout engines.
+XMLUI's core layout components -- HStack, VStack, FlowLayout -- handle most needs. But some layouts require algorithms the core doesn't provide. [Masonry](/docs/guides/wrap-component/masonry) wraps CSS multi-column layout for content feeds and galleries where items of varying height flow into columns.
 
 ## The ecosystem unlocked
 
-XMLUI provides a solid core that wraps a curated set of React components for most basic needs. And it makes it straightforward for a React developer to wrap components that support a range of advanced uses. Here we show: charting (ECharts), rich-text editing (Tiptap), responsive multi-column layout (Masonry), and interactive dashboard grids (GridLayout) -- four very different libraries, all wrapped with the same pattern, all getting prop forwarding, semantic tracing, theming, and extension packaging for free. See [Extension packaging](/docs/guides/wrap-component/extension-packaging) for details on how to do the wrapping.
+XMLUI provides a solid core that wraps a curated set of React components for most basic needs. And it makes it straightforward for a React developer to wrap components that support a range of advanced uses. Here we show: charting (ECharts), rich-text editing (Tiptap), and responsive multi-column layout (Masonry) -- three very different libraries, all wrapped with the same pattern, all getting prop forwarding, semantic tracing, theming, and extension packaging for free. See [Extension packaging](/docs/guides/wrap-component/extension-packaging) for details on how to do the wrapping.
 
 **[ECharts](/docs/guides/wrap-component/echarts).** One of the most powerful charting libraries available -- time series with zoom, treemaps, donuts, toolbox interactions. Canvas-rendered, with option-level theming and comprehensive native event capture.
 
 **[Tiptap](/docs/guides/wrap-component/tiptap).** A headless rich-text editor built on ProseMirror. Every keystroke and format toggle is semantically classified into trace-friendly native events.
 
 **[Masonry](/docs/guides/wrap-component/masonry).** CSS multi-column layout for content feeds and galleries. Items of varying height flow into responsive columns -- no third-party dependency, just a lightweight wrapper around the browser's native column algorithm.
-
-**[GridLayout](/docs/guides/wrap-component/grid-layout).** Draggable, resizable dashboard grids via react-grid-layout. Items are positioned on an explicit column/row grid and can be rearranged by users at runtime. Drag and resize events are captured as native trace events.
 
 All of these ship as independent extension packages. Apps include only the components they need. See [Extension packaging](/docs/guides/wrap-component/extension-packaging) for details.

--- a/website/content/docs/pages/wrap-component/_overview.md
+++ b/website/content/docs/pages/wrap-component/_overview.md
@@ -35,16 +35,18 @@ A wrapped component needs to respect the design system. Three strategies, depend
 
 ## Level 4: Layout
 
-XMLUI's core layout components -- HStack, VStack, FlowLayout -- handle most needs. But some layouts require algorithms the core doesn't provide. [Masonry](/docs/guides/wrap-component/masonry) wraps CSS multi-column layout for content feeds and galleries where items of varying height flow into columns.
+XMLUI's core layout components -- HStack, VStack, FlowLayout -- handle most needs. But some layouts require algorithms the core doesn't provide. [Masonry](/docs/guides/wrap-component/masonry) wraps CSS multi-column layout for content feeds and galleries where items of varying height flow into columns. [GridLayout](/docs/guides/wrap-component/grid-layout) wraps a draggable, resizable dashboard grid for cases where the user needs to rearrange and resize panels.
 
 ## The ecosystem unlocked
 
-XMLUI provides a solid core that wraps a curated set of React components for most basic needs. And it makes it straightforward for a React developer to wrap components that support a range of advanced uses. Here we show: charting (ECharts), rich-text editing (Tiptap), and responsive multi-column layout (Masonry) -- three very different libraries, all wrapped with the same pattern, all getting prop forwarding, semantic tracing, theming, and extension packaging for free. See [Extension packaging](/docs/guides/wrap-component/extension-packaging) for details on how to do the wrapping.
+XMLUI provides a solid core that wraps a curated set of React components for most basic needs. And it makes it straightforward for a React developer to wrap components that support a range of advanced uses. Here we show: charting (ECharts), rich-text editing (Tiptap), responsive multi-column layout (Masonry), and dashboard grid layout (GridLayout) -- four very different libraries, all wrapped with the same pattern, all getting prop forwarding, semantic tracing, theming, and extension packaging for free. See [Extension packaging](/docs/guides/wrap-component/extension-packaging) for details on how to do the wrapping.
 
 **[ECharts](/docs/guides/wrap-component/echarts).** One of the most powerful charting libraries available -- time series with zoom, treemaps, donuts, toolbox interactions. Canvas-rendered, with option-level theming and comprehensive native event capture.
 
 **[Tiptap](/docs/guides/wrap-component/tiptap).** A headless rich-text editor built on ProseMirror. Every keystroke and format toggle is semantically classified into trace-friendly native events.
 
 **[Masonry](/docs/guides/wrap-component/masonry).** CSS multi-column layout for content feeds and galleries. Items of varying height flow into responsive columns -- no third-party dependency, just a lightweight wrapper around the browser's native column algorithm.
+
+**[GridLayout](/docs/guides/wrap-component/grid-layout).** Draggable, resizable dashboard layout built on `react-grid-layout`. Users can rearrange and resize cards, while XMLUI still provides the surrounding declarative structure.
 
 All of these ship as independent extension packages. Apps include only the components they need. See [Extension packaging](/docs/guides/wrap-component/extension-packaging) for details.

--- a/website/index.ts
+++ b/website/index.ts
@@ -3,124 +3,29 @@ import search from "xmlui-search";
 import helloWorld from "xmlui-hello-world";
 import websiteBlocks from "xmlui-website-blocks";
 import docsBlocks from "xmlui-docs-blocks";
+import echart from "xmlui-echart";
+import calendar from "xmlui-calendar";
+import gauge from "xmlui-gauge";
+import masonry from "xmlui-masonry";
+import tiptap from "xmlui-tiptap-editor";
 
 export const runtime = import.meta.glob(`/src/**`, { eager: true });
+const usedExtensions = [
+    search,
+    helloWorld,
+    websiteBlocks,
+    docsBlocks,
+    echart,
+    calendar,
+    gauge,
+    masonry,
+    tiptap,
+];
 
-const coreExtensions = [search, helloWorld, websiteBlocks, docsBlocks];
-
-const extensionLoaders = {
-    echart: () => import("xmlui-echart"),
-    calendar: () => import("xmlui-calendar"),
-    gauge: () => import("xmlui-gauge"),
-    masonry: () => import("xmlui-masonry"),
-    tiptap: () => import("xmlui-tiptap-editor"),
-    gridLayout: () => import("xmlui-grid-layout"),
-} as const;
-
-type ExtensionKey = keyof typeof extensionLoaders;
-
-const loadedExtensionKeys = new Set<ExtensionKey>();
-const loadedExtensions = [...coreExtensions];
-const loadPromises = new Map<ExtensionKey, Promise<void>>();
-
-function getRequiredExtensions(pathname: string): ExtensionKey[] {
-    const required = new Set<ExtensionKey>();
-
-    if (
-        pathname.includes("/xmlui-echart") ||
-        pathname.includes("/wrap-component/echarts") ||
-        pathname.includes("/use-echarts") ||
-        pathname.includes("/tutorial-05")
-    ) {
-        required.add("echart");
-    }
-    if (pathname.includes("/xmlui-calendar") || pathname.includes("/wrap-component/bigcalendar") || pathname.includes("/wrap-component/calendar-theme")) {
-        required.add("calendar");
-    }
-    if (pathname.includes("/xmlui-gauge") || pathname.includes("/wrap-component/gauge-theme")) {
-        required.add("gauge");
-    }
-    if (pathname.includes("/xmlui-masonry") || pathname.includes("/wrap-component/masonry") || pathname.includes("/build-a-responsive-masonry-layout")) {
-        required.add("masonry");
-    }
-    if (pathname.includes("/xmlui-tiptap-editor") || pathname.includes("/wrap-component/tiptap") || pathname.includes("/configure-a-tiptapeditor-toolbar")) {
-        required.add("tiptap");
-    }
-    if (pathname.includes("/xmlui-grid-layout") || pathname.includes("/wrap-component/grid-layout")) {
-        required.add("gridLayout");
-    }
-
-    return [...required];
-}
-
-async function ensureExtensionsForPath(pathname: string) {
-    const required = getRequiredExtensions(pathname);
-    const pendingLoads = required
-        .filter((key) => !loadedExtensionKeys.has(key))
-        .map((key) => {
-            const existing = loadPromises.get(key);
-            if (existing) return existing;
-
-            const promise = extensionLoaders[key]().then((module) => {
-                loadedExtensionKeys.add(key);
-                loadedExtensions.push(module.default ?? module);
-            });
-            loadPromises.set(key, promise);
-            return promise;
-        });
-
-    await Promise.all(pendingLoads);
-    return pendingLoads.length > 0;
-}
-
-let bootToken = 0;
-
-async function boot(currentRuntime: typeof runtime, pathname = window.location.pathname) {
-    const token = ++bootToken;
-    await ensureExtensionsForPath(pathname);
-    if (token !== bootToken) return;
-    startApp(currentRuntime, loadedExtensions);
-}
-
-function installNavigationWatcher(currentRuntime: typeof runtime) {
-    let lastPathname = window.location.pathname;
-
-    const syncForNavigation = async () => {
-        const nextPathname = window.location.pathname;
-        if (nextPathname === lastPathname) return;
-        lastPathname = nextPathname;
-
-        const loadedNewExtensions = await ensureExtensionsForPath(nextPathname);
-        if (loadedNewExtensions) {
-            void boot(currentRuntime, nextPathname);
-        }
-    };
-
-    const originalPushState = window.history.pushState.bind(window.history);
-    const originalReplaceState = window.history.replaceState.bind(window.history);
-
-    window.history.pushState = function (...args) {
-        const result = originalPushState(...args);
-        void syncForNavigation();
-        return result;
-    };
-
-    window.history.replaceState = function (...args) {
-        const result = originalReplaceState(...args);
-        void syncForNavigation();
-        return result;
-    };
-
-    window.addEventListener("popstate", () => {
-        void syncForNavigation();
-    });
-}
-
-installNavigationWatcher(runtime);
-void boot(runtime);
+startApp(runtime, usedExtensions);
 
 if (import.meta.hot) {
     import.meta.hot.accept((newModule) => {
-        void boot(newModule?.runtime ?? runtime);
+        startApp(newModule?.runtime ?? runtime, usedExtensions);
     });
 }

--- a/website/index.ts
+++ b/website/index.ts
@@ -6,6 +6,7 @@ import docsBlocks from "xmlui-docs-blocks";
 import echart from "xmlui-echart";
 import calendar from "xmlui-calendar";
 import gauge from "xmlui-gauge";
+import gridLayout from "xmlui-grid-layout";
 import masonry from "xmlui-masonry";
 import tiptap from "xmlui-tiptap-editor";
 
@@ -18,6 +19,7 @@ const usedExtensions = [
     echart,
     calendar,
     gauge,
+    gridLayout,
     masonry,
     tiptap,
 ];

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -298,10 +298,6 @@
                                 label="Masonry"
                                 to="/docs/guides/wrap-component/masonry"
                             />
-                            <NavLink
-                                label="GridLayout"
-                                to="/docs/guides/wrap-component/grid-layout"
-                            />
                         </NavGroup>
                         <NavGroup label="Ecosystem">
                             <NavLink
@@ -315,10 +311,6 @@
                             <NavLink
                                 label="Masonry"
                                 to="/docs/guides/wrap-component/masonry"
-                            />
-                            <NavLink
-                                label="GridLayout"
-                                to="/docs/guides/wrap-component/grid-layout"
                             />
                         </NavGroup>
                         <NavLink
@@ -1610,12 +1602,6 @@
                 <DocumentPage
                     showInspector="true"
                     content="{appGlobals.docsContent['pages/wrap-component/masonry.md']}"
-                />
-            </Page>
-            <Page url="/docs/guides/wrap-component/grid-layout">
-                <DocumentPage
-                    showInspector="true"
-                    content="{appGlobals.docsContent['pages/wrap-component/grid-layout.md']}"
                 />
             </Page>
             <Page url="/docs/guides/wrap-component/echarts">

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -298,6 +298,10 @@
                                 label="Masonry"
                                 to="/docs/guides/wrap-component/masonry"
                             />
+                            <NavLink
+                                label="GridLayout"
+                                to="/docs/guides/wrap-component/grid-layout"
+                            />
                         </NavGroup>
                         <NavGroup label="Ecosystem">
                             <NavLink
@@ -311,6 +315,10 @@
                             <NavLink
                                 label="Masonry"
                                 to="/docs/guides/wrap-component/masonry"
+                            />
+                            <NavLink
+                                label="GridLayout"
+                                to="/docs/guides/wrap-component/grid-layout"
                             />
                         </NavGroup>
                         <NavLink
@@ -1602,6 +1610,12 @@
                 <DocumentPage
                     showInspector="true"
                     content="{appGlobals.docsContent['pages/wrap-component/masonry.md']}"
+                />
+            </Page>
+            <Page url="/docs/guides/wrap-component/grid-layout">
+                <DocumentPage
+                    showInspector="true"
+                    content="{appGlobals.docsContent['pages/wrap-component/grid-layout.md']}"
                 />
             </Page>
             <Page url="/docs/guides/wrap-component/echarts">

--- a/xmlui/src/components/Slider/Slider.spec.ts
+++ b/xmlui/src/components/Slider/Slider.spec.ts
@@ -21,6 +21,42 @@ test.describe("Basic Functionality", () => {
     await expect(page.getByText("Volume")).toBeVisible();
   });
 
+  test("forwards title to the outer container", async ({ initTestBed, page }) => {
+    await initTestBed(`<Slider title="Pick a temperature" />`);
+    await expect(page.locator("[data-slider-container]")).toHaveAttribute("title", "Pick a temperature");
+  });
+
+  test("forwards inverted to the rendered slider", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Fragment>
+        <Slider testId="normal" width="200px" minValue="0" maxValue="100" initialValue="25" />
+        <Slider testId="inverted" width="200px" minValue="0" maxValue="100" initialValue="25" inverted="true" />
+      </Fragment>`);
+
+    const normalTrack = page.getByTestId("normal").locator("[data-track]");
+    const invertedTrack = page.getByTestId("inverted").locator("[data-track]");
+    const normalThumb = page.getByTestId("normal").getByRole("slider");
+    const invertedThumb = page.getByTestId("inverted").getByRole("slider");
+
+    const normalTrackBox = await normalTrack.boundingBox();
+    const invertedTrackBox = await invertedTrack.boundingBox();
+    const normalThumbBox = await normalThumb.boundingBox();
+    const invertedThumbBox = await invertedThumb.boundingBox();
+
+    expect(normalTrackBox).not.toBeNull();
+    expect(invertedTrackBox).not.toBeNull();
+    expect(normalThumbBox).not.toBeNull();
+    expect(invertedThumbBox).not.toBeNull();
+
+    const normalThumbCenter = normalThumbBox!.x + normalThumbBox!.width / 2;
+    const invertedThumbCenter = invertedThumbBox!.x + invertedThumbBox!.width / 2;
+    const normalTrackCenter = normalTrackBox!.x + normalTrackBox!.width / 2;
+    const invertedTrackCenter = invertedTrackBox!.x + invertedTrackBox!.width / 2;
+
+    expect(normalThumbCenter).toBeLessThan(normalTrackCenter);
+    expect(invertedThumbCenter).toBeGreaterThan(invertedTrackCenter);
+  });
+
   test("sets initialValue of field", async ({ initTestBed, page }) => {
     await initTestBed(`
         <Fragment>

--- a/xmlui/src/components/Slider/Slider.tsx
+++ b/xmlui/src/components/Slider/Slider.tsx
@@ -161,31 +161,34 @@ export const ThemedSlider = React.forwardRef<React.ElementRef<typeof Slider>, Th
 
 export const sliderComponentRenderer = wrapComponent(COMP, Slider, SliderMd, {
   // minValue, maxValue, minStepsBetweenThumbs are number-typed in metadata — asOptionalNumber throws
-  // for non-numeric strings (e.g. "invalid"). Exclude them so customRender handles via raw extractValue.
-  exclude: ["minValue", "maxValue", "minStepsBetweenThumbs"],
-  customRender: (_props, { node, extractValue, lookupEventHandler, lookupSyncCallback, classes, updateState, state, registerComponentApi }) => (
-    <Slider
-      validationStatus={extractValue(node.props.validationStatus)}
-      minStepsBetweenThumbs={extractValue(node.props?.minStepsBetweenThumbs)}
-      value={state.value}
-      initialValue={extractValue(node.props.initialValue)}
-      updateState={updateState}
-      onDidChange={lookupEventHandler("didChange")}
-      onFocus={lookupEventHandler("gotFocus")}
-      onBlur={lookupEventHandler("lostFocus")}
-      registerComponentApi={registerComponentApi}
-      classes={classes}
-      step={extractValue(node.props?.step)}
-      min={extractValue(node.props?.minValue)}
-      max={extractValue(node.props?.maxValue)}
-      enabled={extractValue.asOptionalBoolean(node.props?.enabled)}
-      autoFocus={extractValue.asOptionalBoolean(node.props.autoFocus)}
-      readOnly={extractValue.asOptionalBoolean(node.props.readOnly)}
-      required={extractValue.asOptionalBoolean(node.props.required)}
-      rangeStyle={extractValue(node.props?.rangeStyle)}
-      thumbStyle={extractValue(node.props?.thumbStyle)}
-      showValues={extractValue.asOptionalBoolean(node.props?.showValues)}
-      valueFormat={lookupSyncCallback(node.props?.valueFormat)}
-    />
-  ),
+  // for non-numeric strings (e.g. "invalid"). invalidMessages is handled by form wrappers and should
+  // not leak to the underlying slider DOM.
+  exclude: ["minValue", "maxValue", "minStepsBetweenThumbs", "invalidMessages"],
+  customRender: (props, { node, extractValue, lookupEventHandler, lookupSyncCallback, classes, updateState, state, registerComponentApi }) => {
+    const {
+      invalidMessages: _invalidMessages,
+      labelPosition: _labelPosition,
+      requireLabelMode: _requireLabelMode,
+      ...sliderProps
+    } = props;
+
+    return (
+      <Slider
+        {...sliderProps}
+        value={state.value}
+        initialValue={extractValue(node.props.initialValue)}
+        updateState={updateState}
+        onDidChange={lookupEventHandler("didChange")}
+        onFocus={lookupEventHandler("gotFocus")}
+        onBlur={lookupEventHandler("lostFocus")}
+        registerComponentApi={registerComponentApi}
+        classes={classes}
+        validationStatus={extractValue(node.props.validationStatus)}
+        minStepsBetweenThumbs={extractValue(node.props?.minStepsBetweenThumbs)}
+        min={extractValue(node.props?.minValue)}
+        max={extractValue(node.props?.maxValue)}
+        valueFormat={lookupSyncCallback(node.props?.valueFormat)}
+      />
+    );
+  },
 });


### PR DESCRIPTION
## Summary
- make `xmlui-grid-layout` browser-safe by loading `react-grid-layout` through a client-side UMD bridge instead of emitting runtime `require()` in the package `.mjs`
- restore `GridLayout` to the wrapping/theming docs nav, route, and overview now that the package can run in the browser again

## Why
`GridLayout` broke when we moved it into the docs site because the package output was not actually browser-safe. `react-grid-layout` is CommonJS-only, and our extension build was emitting an `.mjs` bundle that still contained Rolldown's runtime `require("react")` path. That only surfaced once the docs site actually imported and executed the extension in the browser.

The fix here is package-level, not another docs-site special case. The renderer now loads the library's browser build on the client, normalizes the exported API into a plain `{ Responsive, WidthProvider }` object, and keeps a simple fallback render until the grid library is ready.

## Verification
- rebuilt `packages/xmlui-grid-layout`
- manually verified `GridLayout` works again in the wrap/theme guide
- restored the docs route and nav entries after the package fix was in place