### PR TITLE
fix: vite config define import.meta.env attrs 

### DIFF
--- a/xmlui/src/nodejs/bin/build-lib.ts
+++ b/xmlui/src/nodejs/bin/build-lib.ts
@@ -34,9 +34,8 @@ export const buildLib = async ({
       extensions: [".js", ".ts", ".jsx", ".tsx", ".json", ".xmlui", ".xmlui.xs", ".xs"],
     },
     define: {
-      "process.env": {
-        NODE_ENV: env.NODE_ENV,
-      },
+      "process.env.NODE_ENV": JSON.stringify(env.NODE_ENV),
+      "import.meta.env.NODE_ENV": JSON.stringify(env.NODE_ENV),
     },
     build: {
       emptyOutDir: false,

--- a/xmlui/src/nodejs/bin/build.ts
+++ b/xmlui/src/nodejs/bin/build.ts
@@ -106,6 +106,10 @@ export const build = async ({
       "import.meta.env.VITE_BUILD_MODE": JSON.stringify(buildMode),
       "import.meta.env.VITE_DEV_MODE": false,
       "import.meta.env.VITE_MOCK_ENABLED": withMock,
+      // Pre-built lib replacements (see vite.config.ts lib build for context).
+      "__XMLUI_BUILD_MODE__": JSON.stringify(buildMode),
+      "__XMLUI_DEV_MODE__": "false",
+      "__XMLUI_STANDALONE__": "false",
       "import.meta.env.VITE_APP_VERSION": JSON.stringify(process.env.VITE_APP_VERSION),
 
       "import.meta.env.VITE_USED_COMPONENTS_App": JSON.stringify(

--- a/xmlui/src/nodejs/bin/build.ts
+++ b/xmlui/src/nodejs/bin/build.ts
@@ -6,6 +6,7 @@ import { existsSync } from "fs";
 import { glob } from "glob";
 import type { InlineConfig } from "vite";
 import { build as viteBuild } from "vite";
+import { createXmluiAppDefines } from "./xmluiEnv";
 import { getViteConfig } from "./viteConfig";
 import * as fs from "node:fs";
 import { pathToFileURL } from "node:url";
@@ -103,14 +104,13 @@ export const build = async ({
       flatDistUiPrefix,
     })),
     define: {
-      "import.meta.env.VITE_BUILD_MODE": JSON.stringify(buildMode),
-      "import.meta.env.VITE_DEV_MODE": false,
-      "import.meta.env.VITE_MOCK_ENABLED": withMock,
-      // Pre-built lib replacements (see vite.config.ts lib build for context).
-      "__XMLUI_BUILD_MODE__": JSON.stringify(buildMode),
-      "__XMLUI_DEV_MODE__": "false",
-      "__XMLUI_STANDALONE__": "false",
-      "import.meta.env.VITE_APP_VERSION": JSON.stringify(process.env.VITE_APP_VERSION),
+      ...createXmluiAppDefines({
+        buildMode,
+        devMode: false,
+        standalone: false,
+        mockEnabled: withMock,
+        appVersion: process.env.VITE_APP_VERSION,
+      }),
 
       "import.meta.env.VITE_USED_COMPONENTS_App": JSON.stringify(
         process.env.VITE_USED_COMPONENTS_App,

--- a/xmlui/src/nodejs/bin/ssg.ts
+++ b/xmlui/src/nodejs/bin/ssg.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { build } from "./build";
 import { getViteConfig } from "./viteConfig";
+import { createXmluiAppDefines } from "./xmluiEnv";
 import { parse } from "node-html-parser";
 import { discoverRoutes } from "../discoverRoutes";
 import { XMLUI_SSG_DATA_ATTRIBUTES } from "../../components-core/rendering/ssgEnv";
@@ -133,7 +134,9 @@ function mergeAttributesIntoElement(
     return;
   }
 
-  const attributeSource = parse(`<${selector} ${attributesMarkup}></${selector}>`).querySelector(selector);
+  const attributeSource = parse(`<${selector} ${attributesMarkup}></${selector}>`).querySelector(
+    selector,
+  );
 
   if (!attributeSource) {
     return;
@@ -586,12 +589,14 @@ async function runDebugSsgServer() {
     },
     define: {
       ...viteConfig.define,
-      "import.meta.env.VITE_BUILD_MODE": '"ALL"',
-      "import.meta.env.VITE_DEV_MODE": true,
-      "import.meta.env.VITE_STANDALONE": process.env.VITE_STANDALONE,
-      "import.meta.env.VITE_MOCK_ENABLED": true,
-      "import.meta.env.VITE_INCLUDE_ALL_COMPONENTS": '"true"',
-      "import.meta.env.VITE_USER_COMPONENTS_Inspect": '"true"',
+      ...createXmluiAppDefines({
+        buildMode: "ALL",
+        devMode: true,
+        standalone: false,
+        mockEnabled: true,
+        includeAllComponents: true,
+        inspectUserComponents: true,
+      }),
     },
     plugins: [...basePlugins, ssgDebugPlugin],
   } as InlineConfig);
@@ -727,9 +732,12 @@ export const ssg = async ({
       },
       define: {
         ...viteConfig.define,
-        "import.meta.env.VITE_BUILD_MODE": JSON.stringify("INLINE_ALL"),
-        "import.meta.env.VITE_DEV_MODE": false,
-        "import.meta.env.VITE_MOCK_ENABLED": false,
+        ...createXmluiAppDefines({
+          buildMode: "INLINE_ALL",
+          devMode: false,
+          standalone: false,
+          mockEnabled: false,
+        }),
         "import.meta.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "production"),
       },
       build: {

--- a/xmlui/src/nodejs/bin/start.ts
+++ b/xmlui/src/nodejs/bin/start.ts
@@ -45,6 +45,11 @@ export const start = async ({ port, withMock = true, proxy }: XmlUiStartOptions)
         "import.meta.env.VITE_MOCK_ENABLED": withMock,
         "import.meta.env.VITE_INCLUDE_ALL_COMPONENTS": '"true"',
         "import.meta.env.VITE_USER_COMPONENTS_Inspect": '"true"',
+        // Pre-built lib replacements: the lib build remaps import.meta.env.VITE_* to
+        // these opaque identifiers so they survive Rolldown's static analysis.
+        __XMLUI_BUILD_MODE__: '"ALL"',
+        __XMLUI_DEV_MODE__: "true",
+        __XMLUI_STANDALONE__: "false",
       },
     } as InlineConfig);
 

--- a/xmlui/src/nodejs/bin/start.ts
+++ b/xmlui/src/nodejs/bin/start.ts
@@ -1,5 +1,6 @@
 import type { InlineConfig } from "vite";
 import { createServer } from "vite";
+import { createXmluiAppDefines } from "./xmluiEnv";
 import { getViteConfig } from "./viteConfig";
 
 type XmlUiStartOptions = {
@@ -39,17 +40,14 @@ export const start = async ({ port, withMock = true, proxy }: XmlUiStartOptions)
       },
       define: {
         ...viteConfig.define,
-        "import.meta.env.VITE_BUILD_MODE": '"ALL"',
-        "import.meta.env.VITE_DEV_MODE": true,
-        "import.meta.env.VITE_STANDALONE": process.env.VITE_STANDALONE,
-        "import.meta.env.VITE_MOCK_ENABLED": withMock,
-        "import.meta.env.VITE_INCLUDE_ALL_COMPONENTS": '"true"',
-        "import.meta.env.VITE_USER_COMPONENTS_Inspect": '"true"',
-        // Pre-built lib replacements: the lib build remaps import.meta.env.VITE_* to
-        // these opaque identifiers so they survive Rolldown's static analysis.
-        __XMLUI_BUILD_MODE__: '"ALL"',
-        __XMLUI_DEV_MODE__: "true",
-        __XMLUI_STANDALONE__: "false",
+        ...createXmluiAppDefines({
+          buildMode: "ALL",
+          devMode: true,
+          standalone: false,
+          mockEnabled: withMock,
+          includeAllComponents: true,
+          inspectUserComponents: true,
+        }),
       },
     } as InlineConfig);
 

--- a/xmlui/src/nodejs/bin/xmluiEnv.ts
+++ b/xmlui/src/nodejs/bin/xmluiEnv.ts
@@ -1,0 +1,122 @@
+type XmluiBuildMode = "CONFIG_ONLY" | "INLINE_ALL" | "ALL";
+
+type XmluiBooleanLike = boolean | string | undefined | null;
+
+export type XmluiRuntimeFlags = {
+  buildMode: XmluiBuildMode;
+  devMode: boolean;
+  standalone: boolean;
+};
+
+export type XmluiAppDefineOptions = XmluiRuntimeFlags & {
+  mockEnabled?: XmluiBooleanLike;
+  mockWorkerLocation?: string;
+  includeAllComponents?: XmluiBooleanLike;
+  inspectUserComponents?: XmluiBooleanLike;
+  appVersion?: string;
+  additionalDefines?: Record<string, string | boolean | number | undefined>;
+};
+
+export const XMLUI_PRESERVED_DEFINE_KEYS = {
+  buildMode: "import.meta.__XMLUI_BUILD_MODE__",
+  devMode: "import.meta.__XMLUI_DEV_MODE__",
+  standalone: "import.meta.__XMLUI_STANDALONE__",
+} as const;
+
+export const XMLUI_RUNTIME_ENV_KEYS = {
+  buildMode: "import.meta.env.VITE_BUILD_MODE",
+  devMode: "import.meta.env.VITE_DEV_MODE",
+  standalone: "import.meta.env.VITE_STANDALONE",
+  mockEnabled: "import.meta.env.VITE_MOCK_ENABLED",
+  mockWorkerLocation: "import.meta.env.VITE_MOCK_WORKER_LOCATION",
+  includeAllComponents: "import.meta.env.VITE_INCLUDE_ALL_COMPONENTS",
+  inspectUserComponents: "import.meta.env.VITE_USER_COMPONENTS_Inspect",
+  appVersion: "import.meta.env.VITE_APP_VERSION",
+} as const;
+
+export function normalizeXmluiBoolean(value: XmluiBooleanLike, fallback = false): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value == null) {
+    return fallback;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === "") {
+    return fallback;
+  }
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return fallback;
+}
+
+export function toDefineBoolean(value: XmluiBooleanLike, fallback = false): boolean {
+  return normalizeXmluiBoolean(value, fallback);
+}
+
+export function toDefineString(value: string | undefined | null): string {
+  return JSON.stringify(value ?? "");
+}
+
+export function createXmluiModeDefines(flags: XmluiRuntimeFlags): Record<string, string | boolean> {
+  return {
+    [XMLUI_RUNTIME_ENV_KEYS.buildMode]: JSON.stringify(flags.buildMode),
+    [XMLUI_RUNTIME_ENV_KEYS.devMode]: flags.devMode,
+    [XMLUI_RUNTIME_ENV_KEYS.standalone]: flags.standalone,
+
+    [XMLUI_PRESERVED_DEFINE_KEYS.buildMode]: JSON.stringify(flags.buildMode),
+    [XMLUI_PRESERVED_DEFINE_KEYS.devMode]: String(flags.devMode),
+    [XMLUI_PRESERVED_DEFINE_KEYS.standalone]: String(flags.standalone),
+  };
+}
+
+export function createXmluiAppDefines(
+  options: XmluiAppDefineOptions,
+): Record<string, string | boolean | number | undefined> {
+  const {
+    buildMode,
+    devMode,
+    standalone,
+    mockEnabled,
+    mockWorkerLocation,
+    includeAllComponents,
+    inspectUserComponents,
+    appVersion,
+    additionalDefines,
+  } = options;
+
+  return {
+    ...createXmluiModeDefines({ buildMode, devMode, standalone }),
+    [XMLUI_RUNTIME_ENV_KEYS.mockEnabled]: toDefineBoolean(mockEnabled, false),
+    ...(mockWorkerLocation
+      ? {
+          [XMLUI_RUNTIME_ENV_KEYS.mockWorkerLocation]: JSON.stringify(mockWorkerLocation),
+        }
+      : {}),
+    [XMLUI_RUNTIME_ENV_KEYS.includeAllComponents]: JSON.stringify(
+      String(normalizeXmluiBoolean(includeAllComponents, false)),
+    ),
+    [XMLUI_RUNTIME_ENV_KEYS.inspectUserComponents]: JSON.stringify(
+      String(normalizeXmluiBoolean(inspectUserComponents, false)),
+    ),
+    ...(appVersion !== undefined
+      ? {
+          [XMLUI_RUNTIME_ENV_KEYS.appVersion]: JSON.stringify(appVersion),
+        }
+      : {}),
+    ...additionalDefines,
+  };
+}
+
+export function createXmluiLibPreserveDefines(): Record<string, string> {
+  return {
+    [XMLUI_RUNTIME_ENV_KEYS.devMode]: XMLUI_PRESERVED_DEFINE_KEYS.devMode,
+    [XMLUI_RUNTIME_ENV_KEYS.buildMode]: XMLUI_PRESERVED_DEFINE_KEYS.buildMode,
+    [XMLUI_RUNTIME_ENV_KEYS.standalone]: XMLUI_PRESERVED_DEFINE_KEYS.standalone,
+  };
+}

--- a/xmlui/vite.config.ts
+++ b/xmlui/vite.config.ts
@@ -9,6 +9,7 @@ import { default as ViteXmlui } from "./src/nodejs/vite-xmlui-plugin";
 import dts from "vite-plugin-dts";
 import { libInjectCss } from "vite-plugin-lib-inject-css";
 import copy from "rollup-plugin-copy";
+import { createXmluiLibPreserveDefines } from "./src/nodejs/bin/xmluiEnv";
 // @ts-ignore
 import * as packageJson from "./package.json";
 
@@ -16,6 +17,7 @@ export default ({ mode = "lib" }) => {
   const env = loadEnv(mode, process.cwd(), "");
   let lib;
   let define;
+  const xmluiVersion = `${env.npm_package_version} (built ${new Date().toLocaleDateString("en-US")})`;
   let distSubDirName = "";
   switch (mode) {
     case "standalone": {
@@ -35,9 +37,7 @@ export default ({ mode = "lib" }) => {
         "import.meta.env.VITE_USED_COMPONENTS_TableEditor": JSON.stringify("false"),
         // "import.meta.env.VITE_USED_COMPONENTS_Charts": JSON.stringify("false"),
         // "import.meta.env.VITE_USER_COMPONENTS_Inspect": JSON.stringify("false"),
-        "import.meta.env.VITE_XMLUI_VERSION": JSON.stringify(
-          `${env.npm_package_version} (built ${new Date().toLocaleDateString("en-US")})`,
-        ),
+        "import.meta.env.VITE_XMLUI_VERSION": JSON.stringify(xmluiVersion),
       };
       break;
     }
@@ -101,14 +101,11 @@ export default ({ mode = "lib" }) => {
         },
         formats: ["es"] as any,
       };
-      // Remap the three mode-detection env vars to opaque identifiers so Rolldown
-      // cannot statically evaluate (and tree-shake) the branches in StandaloneApp.
-      // The consuming app's bundler (xmlui start / xmlui build) replaces these
-      // identifiers at its own build/serve time via the defines in start.ts / build.ts.
+      // Preserve only the XMLUI app-mode flags that must survive the framework lib build.
+      // They are replaced later by xmlui start / xmlui build / xmlui ssg.
       define = {
-        "import.meta.env.VITE_DEV_MODE": "__XMLUI_DEV_MODE__",
-        "import.meta.env.VITE_BUILD_MODE": "__XMLUI_BUILD_MODE__",
-        "import.meta.env.VITE_STANDALONE": "__XMLUI_STANDALONE__",
+        ...createXmluiLibPreserveDefines(),
+        "import.meta.env.VITE_XMLUI_VERSION": JSON.stringify(xmluiVersion),
       };
     }
   }

--- a/xmlui/vite.config.ts
+++ b/xmlui/vite.config.ts
@@ -101,6 +101,15 @@ export default ({ mode = "lib" }) => {
         },
         formats: ["es"] as any,
       };
+      // Remap the three mode-detection env vars to opaque identifiers so Rolldown
+      // cannot statically evaluate (and tree-shake) the branches in StandaloneApp.
+      // The consuming app's bundler (xmlui start / xmlui build) replaces these
+      // identifiers at its own build/serve time via the defines in start.ts / build.ts.
+      define = {
+        "import.meta.env.VITE_DEV_MODE": "__XMLUI_DEV_MODE__",
+        "import.meta.env.VITE_BUILD_MODE": "__XMLUI_BUILD_MODE__",
+        "import.meta.env.VITE_STANDALONE": "__XMLUI_STANDALONE__",
+      };
     }
   }
 


### PR DESCRIPTION
while migrating from processs.env.xyz to import.meta.env.xyz, we missed the fact that the former were left in by vite in version 7 for vite build --mode lib, but the later were not. 

The import.meta.env.VITE_DEV_MODE and others in StandaloneApp.tsx were replaced with undefined when building the xmlui framework, while previously the process.env.VITE_DEV_MODE was not changed, it remained in the built code as it was, unchanged.

The later step, when we run xmlui start on a website, the "start" command replaced process.env.VITE_DEV_MODE with "true". Now it will also try to replace import.meta.env.VITE_DEV_MODE with "true", but it will not be found in the code because it has already been replaced with undefined. This PR fixes this issue by using import.meta.__XMLUI_something for that act like the process.env. mechanism did.