### PR TITLE
docs: review first 5 articles in how-to

### DIFF
--- a/website/content/docs/pages/howto/persist-form-drafts-across-sessions.md
+++ b/website/content/docs/pages/howto/persist-form-drafts-across-sessions.md
@@ -5,7 +5,7 @@ Use persist on Form to auto-save in-progress input to localStorage so unsaved dr
 A blog post editor can take a long time to fill in. If the user accidentally refreshes the page or their browser crashes, all their unsaved text is gone. Setting `persist="true"` on the form silently snapshots the current field values to localStorage on every change and restores them on the next visit.
 
 ```xmlui-pg copy display name="Blog post editor with draft persistence"
----app display
+---app display /persist="true"/
 <App>
   <Button 
     variant="outlined" 
@@ -23,11 +23,11 @@ A blog post editor can take a long time to fill in. If the user accidentally ref
     saveLabel="Publish"
   >
     <TextBox label="Title" bindTo="title" required="true" />
-    <Select
-      label="Category"
-      bindTo="category"
-      data="{['general', 'tech', 'design']}"
-    />
+    <Select label="Category" bindTo="category">
+      <Items data="{['general', 'tech', 'design']}">
+        <Option value="{$item}" label="{$item}" />
+      </Items>
+    </Select>
     <TextArea label="Body" bindTo="body" required="true" />
   </Form>
 </App>

--- a/website/content/docs/pages/howto/reset-a-form-after-submission.md
+++ b/website/content/docs/pages/howto/reset-a-form-after-submission.md
@@ -5,7 +5,6 @@ Use dataAfterSubmit to clear or reset form fields, and completedNotificationMess
 A support ticket form should clear its fields after the user submits successfully so they can immediately start a new ticket. `dataAfterSubmit="clear"` does this automatically on a successful submit — no manual reset logic required.
 
 ```xmlui-pg copy display name="Support ticket form with auto-clear"
----app display
 <App>
   <Form
     data="{{ subject: '', description: '', priority: 'normal' }}"
@@ -15,11 +14,11 @@ A support ticket form should clear its fields after the user submits successfull
     saveLabel="Submit ticket"
   >
     <TextBox label="Subject" bindTo="subject" required="true" />
-    <Select
-      label="Priority"
-      bindTo="priority"
-      data="{['low', 'normal', 'high']}"
-    />
+    <Select label="Priority" bindTo="priority">
+      <Items data="{['low', 'normal', 'high']}">
+        <Option value="{$item}" label="{$item}" />
+      </Items>
+    </Select>
     <TextArea label="Description" bindTo="description" required="true" />
   </Form>
 </App>

--- a/website/content/docs/pages/howto/submit-a-form-with-file-uploads.md
+++ b/website/content/docs/pages/howto/submit-a-form-with-file-uploads.md
@@ -5,7 +5,6 @@ Use FileInput to include a file picker in a form, or use FileUploadDropZone for 
 A support ticket form has standard text fields plus an optional attachment. Adding `<FileInput>` as a direct child of the form places a file picker inline with the other fields. The file is included in the form data under its `bindTo` name when the form submits.
 
 ```xmlui-pg copy display name="Support ticket form with file attachment"
----app display
 <App>
   <Form
     data="{{ subject: '', description: '' }}"

--- a/website/content/docs/pages/howto/validate-a-field-inline-with-onvalidate.md
+++ b/website/content/docs/pages/howto/validate-a-field-inline-with-onvalidate.md
@@ -5,7 +5,6 @@ Attach an onValidate handler to an input component to show a custom error messag
 Built-in validators (`required`, `minLength`, `pattern`, etc.) cover most constraints, but sometimes a rule is hard to express declaratively — for example "must not start with a number", "must be all uppercase", or "must be a valid IBAN". `onValidate` lets you write that check as a function. Returning a non-empty string displays it as an error; returning `null` clears any existing error.
 
 ```xmlui-pg copy display name="Inline custom field validation"
----app display
 <App>
   <Form
     data="{{ username: '', promoCode: '' }}"
@@ -87,40 +86,9 @@ Built-in validators (`required`, `minLength`, `pattern`, etc.) cover most constr
 />
 ```
 
-**`customValidationsDebounce` delays `onValidate` without affecting built-ins**: When `onValidate` makes an API call, add `customValidationsDebounce` (milliseconds) so it fires only after the user pauses typing. Built-in validators are unaffected and still run immediately:
-
-```xmlui
-<TextBox
-  bindTo="username"
-  required="true"
-  minLength="3"
-  customValidationsDebounce="400"
-  onValidate="async (v) => {
-    const { taken } = await checkUsername(v);
-    return taken ? 'Already in use.' : null;
-  }"
-/>
-```
-
-**`onValidate` can be `async`**: Return a `Promise<string | null>`. The form waits for the promise before deciding whether to submit:
-
-```xmlui
-<TextBox
-  bindTo="email"
-  pattern="email"
-  customValidationsDebounce="500"
-  onValidate="async (v) => {
-    if (!v) return null;
-    const exists = await api.emailExists(v);
-    return exists ? 'Already registered.' : null;
-  }"
-/>
-```
-
 ---
 
 **See also**
-- [TextBox component](/docs/reference/components/TextBox) — `onValidate`, `validationMode`, `customValidationsDebounce`, and built-in validators
-- [Add an async uniqueness check](/docs/howto/add-an-async-uniqueness-check) — async `onValidate` with debounce
+- [TextBox component](/docs/reference/components/TextBox) — `onValidate`, `validationMode`, and built-in validators
 - [Show validation on blur, not on type](/docs/howto/show-validation-on-blur-not-on-type) — controlling when errors appear
 - [Validate dependent fields together](/docs/howto/validate-dependent-fields-together) — cross-field validation with `onWillSubmit`

--- a/website/content/docs/pages/howto/validate-dependent-fields-together.md
+++ b/website/content/docs/pages/howto/validate-dependent-fields-together.md
@@ -1,11 +1,16 @@
 # Validate dependent fields together
 
-Use onWillSubmit to cross-validate two fields before submission, or onValidate on the input component to show an inline error.
+Use `onWillSubmit` to cross-validate fields at submit time, or `onValidate` on an input component when the user needs an inline field error.
 
-A registration form has a Password field and a Confirm Password field. The form must not submit, and the user must see a clear error, when the two values disagree. `onWillSubmit` intercepts the data just before submission — returning `false` cancels it. For instant feedback as the user types, `onValidate` on the dependent field achieves the same check at the field level.
+A registration form has a Password field and a Confirm Password field. The form must not submit, and the user must see a clear error, when the two values disagree.
+
+The submit-time pattern uses `onWillSubmit` because it receives both `data` and `allData`. `data` is the payload that will be submitted, with `noSubmit` fields removed. `allData` still includes every form field, so it is the right argument to read when a helper field such as Confirm Password has `noSubmit="true"`.
+
+## Validate before submit
+
+Use this pattern when the user can finish the form first and see the mismatch when they press Save.
 
 ```xmlui-pg copy display name="Cross-field password validation"
----app display
 <App>
   <Form
     data="{{ username: '', password: '', confirmPassword: '' }}"
@@ -30,61 +35,56 @@ A registration form has a Password field and a Confirm Password field. The form 
 </App>
 ```
 
+## Validate inline
+
+Use this pattern when the Confirm Password field should show its own validation message during editing.
+
+```xmlui-pg copy display name="Inline password match validation"
+<App>
+  <Form
+    var.pwd="{''}"
+    data="{{ username: '', password: '', confirmPassword: '' }}"
+    onSubmit="(data) => toast.success('Account created for ' + data.username)"
+    saveLabel="Create account"
+  >
+    <TextBox label="Username" bindTo="username" required="true" />
+    <PasswordInput
+      label="Password"
+      bindTo="password"
+      required="true"
+      onDidChange="(v) => { pwd = v; }"
+    />
+    <PasswordInput
+      label="Confirm Password"
+      bindTo="confirmPassword"
+      required="true"
+      noSubmit="true"
+      onValidate="(v) => v !== pwd ? 'Passwords do not match' : null"
+    />
+  </Form>
+</App>
+```
+
 ## Key points
 
-**`onWillSubmit` — gate submission with cross-field logic**: The handler receives two arguments: `data` (the form payload without noSubmit fields) and `allData` (all form fields including noSubmit ones). Return `false` to abort; return nothing (or the same object) to proceed. This is the right place for multi-field checks that cannot be expressed per-field. Use `allData` when you need to inspect noSubmit fields for validation:
+**Choose the approach by where the user should see the error**: Use `onWillSubmit` when the rule only needs to run before saving, when the message can be a toast or form-level error, or when the check depends on fields that are excluded from the payload with `noSubmit`. Use `onValidate` when the dependent field itself should show the error while the user is filling out the form.
 
-```xmlui
-<Form
-  onWillSubmit="(data, allData) => {
-    if (allData.password !== allData.confirmPassword) {
-      toast.error('Passwords do not match');
-      return false;
-    }
-  }"
-  onSubmit="(data) => saveUser(data)"
->
-  <PasswordInput bindTo="password" />
-  <PasswordInput bindTo="confirmPassword" noSubmit="true" />
-</Form>
-```
+**`onWillSubmit` - gate submission with cross-field logic**: The handler receives two arguments: `data` (the form payload without `noSubmit` fields) and `allData` (all form fields including `noSubmit` ones). Return `false` to abort; return nothing to proceed with the original payload. This is the right place for multi-field checks that cannot be expressed per-field. Use `allData` when you need to inspect helper fields that should not be submitted.
 
-**`noSubmit="true"` on the helper field**: The Confirm Password field is only for validation — it should not appear in the submitted data. Set `noSubmit="true"` so the framework strips it from the payload before calling `onSubmit`.
+**`noSubmit="true"` on the helper field**: The Confirm Password field is only for validation - it should not appear in the submitted data. Set `noSubmit="true"` so the framework strips it from the payload before calling `onSubmit`.
 
-**`onValidate` for immediate inline feedback**: Use `onValidate` on the dependent field to show the mismatch error inline as soon as the field loses focus. Store the reference password in a variable and compare in the handler:
-
-```xmlui
-<Form var.pwd="{''}" data="{{ password: '', confirmPassword: '' }}">
-  <PasswordInput
-    label="Password"
-    bindTo="password"
-    onValidate="(v) => { pwd = v; }"
-  />
-  <PasswordInput
-    label="Confirm Password"
-    bindTo="confirmPassword"
-    noSubmit="true"
-    onValidate="(v) => v !== pwd ? 'Passwords do not match' : null"
-  />
-</Form>
-```
+**`onValidate` for immediate inline feedback**: Use `onValidate` on the dependent field to show the mismatch error inline based on the chosen [validation mode](/docs/behaviors#validation). The handler receives only the current field value, so store the reference password in a shared variable with `onDidChange` and compare against that variable.
 
 **`onValidate` return value**: Return a non-empty string to show as the error message; return `null`, `undefined`, or nothing to signal the field is valid. The string appears below the field using the same styling as built-in validation errors.
 
-**`onWillSubmit` can transform the data**: Instead of returning `false`, return a modified object to submit different data than what the user filled in — useful for computing derived values or stripping helper fields before the server call:
-
-```xmlui
-<Form onWillSubmit="(data) => 
-  ({ ...data, fullName: data.firstName + ' ' + data.lastName })">
-  <TextBox bindTo="firstName" label="First name" />
-  <TextBox bindTo="lastName" label="Last name" />
-</Form>
-```
+**Keep transformation separate from validation**: `onWillSubmit` can also return a modified payload, but that is a separate use case. See [Transform form data before submission](/docs/howto/transform-form-data-before-submission) for examples that reshape submitted data.
 
 ---
 
-**See also**
-- [Form component](/docs/reference/components/Form) — `onWillSubmit`, `onSubmit`, and `data`
-- [TextBox component](/docs/reference/components/TextBox) — `onValidate`, `noSubmit`, and built-in validators
-- [PasswordInput component](/docs/reference/components/PasswordInput) — password field with the same validation API
-- [Handle Form willSubmit return values](/docs/howto/handle-form-willsubmit-return-values) — full return-value reference
+## See also
+
+- [Form component](/docs/reference/components/Form) - `onWillSubmit`, `onSubmit`, and `data`
+- [TextBox component](/docs/reference/components/TextBox) - `onValidate`, `noSubmit`, and built-in validators
+- [PasswordInput component](/docs/reference/components/PasswordInput) - password field with the same validation API
+- [Handle Form willSubmit return values](/docs/howto/handle-form-willsubmit-return-values) - full return-value reference
+- [Transform form data before submission](/docs/howto/transform-form-data-before-submission) - reshaping submitted data with `onWillSubmit`

--- a/xmlui/src/components/FileInput/FileInputReact.tsx
+++ b/xmlui/src/components/FileInput/FileInputReact.tsx
@@ -214,7 +214,7 @@ export const FileInput = memo(forwardRef(function FileInput(
       if (!parseAs) {
         loggerService.log(["[FileInput] No parseAs specified, passing files through"]);
         updateState({ value: acceptedFiles });
-        onDidChange(acceptedFiles);
+        onDidChange?.(acceptedFiles);
         return;
       }
 
@@ -347,7 +347,7 @@ export const FileInput = memo(forwardRef(function FileInput(
       loggerService.log(["[FileInput] Calling updateState with parseAsResult"]);
       updateState({ value: parseAsResult });
       loggerService.log(["[FileInput] Calling onDidChange with parseAsResult"]);
-      onDidChange(parseAsResult);
+      onDidChange?.(parseAsResult);
 
       loggerService.log(["[FileInput] onDrop completed"]);
 

--- a/xmlui/src/components/Form/Form.tsx
+++ b/xmlui/src/components/Form/Form.tsx
@@ -186,7 +186,7 @@ export const FormMd = createMetadata({
         "When `persist` is enabled and the user cancels the form, this property controls " +
         "whether the temporarily saved data is kept (`true`) or cleared (`false`, the default).",
       valueType: "boolean",
-      defaultValue: false,
+      defaultValue: defaultProps.keepOnCancel,
     },
     dataAfterSubmit: {
       description:
@@ -196,7 +196,7 @@ export const FormMd = createMetadata({
         "`\"clear\"` empties the form as if no `data` property were set.",
       availableValues: ["keep", "reset", "clear"],
       valueType: "string",
-      defaultValue: "keep",
+      defaultValue: defaultProps.dataAfterSubmit,
     },
   },
   events: {

--- a/xmlui/src/testing/website-example-utils.ts
+++ b/xmlui/src/testing/website-example-utils.ts
@@ -77,8 +77,3 @@ type ExtractedExample = {
   components?: string[];
   apiInterceptor?: ApiInterceptorDefinition;
 };
-
-type NamedExtractedExample = {
-  name: string;
-  example: ExtractedExample;
-};

--- a/xmlui/tests-e2e/persist-form-drafts-across-sessions.spec.ts
+++ b/xmlui/tests-e2e/persist-form-drafts-across-sessions.spec.ts
@@ -1,0 +1,114 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../website/content/docs/pages/howto/persist-form-drafts-across-sessions.md",
+  ),
+);
+
+test.describe("Blog post editor with draft persistence", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Blog post editor with draft persistence",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem("blog-post-draft");
+    });
+  });
+
+  test("initial state shows empty editor fields and default category", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("button", { name: "Reset the temporary form data" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Title" })).toHaveValue("");
+    await expect(page.getByRole("combobox", { name: "Category" })).toHaveText("general");
+    await expect(page.getByRole("textbox", { name: "Body" })).toHaveValue("");
+    await expect(page.getByRole("button", { name: "Publish" })).toBeVisible();
+  });
+
+  test("typing saves a draft to localStorage", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Title" }).fill("Reactive forms");
+    await page.getByRole("combobox", { name: "Category" }).click();
+    await page.getByRole("option", { name: "tech" }).click();
+    await page.getByRole("textbox", { name: "Body" }).fill("Draft body");
+
+    await expect
+      .poll(async () =>
+        await page.evaluate(() => {
+          const raw = localStorage.getItem("blog-post-draft");
+          return raw ? JSON.parse(raw) : null;
+        }),
+      )
+      .toEqual({
+        title: "Reactive forms",
+        category: "tech",
+        body: "Draft body",
+      });
+  });
+
+  test("saved draft is restored on the next load", async ({ initTestBed, page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "blog-post-draft",
+        JSON.stringify({
+          title: "Restored title",
+          category: "design",
+          body: "Restored body",
+        }),
+      );
+    });
+
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("textbox", { name: "Title" })).toHaveValue("Restored title");
+    await expect(page.getByRole("combobox", { name: "Category" })).toHaveText("design");
+    await expect(page.getByRole("textbox", { name: "Body" })).toHaveValue("Restored body");
+  });
+
+  test("reset temporary form data button clears the saved draft", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Title" }).fill("Temporary title");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("blog-post-draft")))
+      .not.toBeNull();
+
+    await page.getByRole("button", { name: "Reset the temporary form data" }).click();
+
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("blog-post-draft")))
+      .toBeNull();
+  });
+
+  test("successful publish clears visible fields and persisted draft", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Title" }).fill("Published post");
+    await page.getByRole("combobox", { name: "Category" }).click();
+    await page.getByRole("option", { name: "design" }).click();
+    await page.getByRole("textbox", { name: "Body" }).fill("Ready to publish.");
+    await page.getByRole("button", { name: "Publish" }).click();
+
+    await expect(page.getByRole("textbox", { name: "Title" })).toHaveValue("");
+    await expect(page.getByRole("textbox", { name: "Body" })).toHaveValue("");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("blog-post-draft")))
+      .toBeNull();
+  });
+});

--- a/xmlui/tests-e2e/reset-a-form-after-submission.spec.ts
+++ b/xmlui/tests-e2e/reset-a-form-after-submission.spec.ts
@@ -1,0 +1,68 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../website/content/docs/pages/howto/reset-a-form-after-submission.md",
+  ),
+);
+
+test.describe("Support ticket form with auto-clear", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Support ticket form with auto-clear",
+  );
+
+  test("initial state shows empty ticket fields and normal priority", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("textbox", { name: "Subject" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Priority" })).toHaveText("normal");
+    await expect(page.getByRole("textbox", { name: "Description" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Submit ticket" })).toBeVisible();
+  });
+
+  test("submitting empty required fields shows validation errors", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("button", { name: "Submit ticket" }).click();
+
+    await expect(page.getByText("This field is required")).toHaveCount(2);
+  });
+
+  test("priority can be changed", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("combobox", { name: "Priority" }).click();
+    await page.getByRole("option", { name: "High" }).click();
+
+    await expect(page.getByRole("combobox", { name: "Priority" })).toHaveText("high");
+  });
+
+  test("successful submit clears the form", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Subject" }).fill("Printer is offline");
+    await page.getByRole("combobox", { name: "Priority" }).click();
+    await page.getByRole("option", { name: "High" }).click();
+    await page
+      .getByRole("textbox", { name: "Description" })
+      .fill("The front desk printer stopped responding.");
+    await page.getByRole("button", { name: "Submit ticket" }).click();
+
+    await expect(page.getByRole("textbox", { name: "Subject" })).toHaveValue("");
+    await expect(page.getByRole("textbox", { name: "Description" })).toHaveValue("");
+    await expect(page.getByRole("combobox", { name: "Priority" })).not.toHaveText("high");
+  });
+});

--- a/xmlui/tests-e2e/submit-a-form-with-file-uploads.spec.ts
+++ b/xmlui/tests-e2e/submit-a-form-with-file-uploads.spec.ts
@@ -1,0 +1,109 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../website/content/docs/pages/howto/submit-a-form-with-file-uploads.md",
+  ),
+);
+
+test.describe("Support ticket form with file attachment", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Support ticket form with file attachment",
+  );
+
+  test("initial state shows ticket fields, optional attachment, and submit button", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("textbox", { name: "Subject" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Description" })).toBeVisible();
+    await expect(page.getByText("Attachment (optional)")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Browse" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Submit ticket" })).toBeVisible();
+  });
+
+  test("submitting empty required fields shows validation errors", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("button", { name: "Submit ticket" }).click();
+
+    await expect(page.getByText("This field is required")).toHaveCount(2);
+  });
+
+  test("submitting without an attachment reports none", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Subject" }).fill("Cannot log in");
+    await page.getByRole("textbox", { name: "Description" }).fill("Password reset fails.");
+    await page.getByRole("button", { name: "Submit ticket" }).click();
+
+    await expect(page.getByText("Ticket submitted. Attachment: none")).toBeVisible();
+  });
+
+  test("selected file is included in submitted form data", async ({
+    initTestBed,
+    page,
+    createFileInputDriver,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    const fileInput = await createFileInputDriver();
+
+    await page.getByRole("textbox", { name: "Subject" }).fill("Upload evidence");
+    await page.getByRole("textbox", { name: "Description" }).fill("Screenshot attached.");
+    await fileInput.getHiddenInput().setInputFiles({
+      name: "screenshot.png",
+      mimeType: "image/png",
+      buffer: Buffer.from("fake png"),
+    });
+    await expect.poll(() => fileInput.getSelectedFiles()).toBe("screenshot.png");
+    await page.getByRole("button", { name: "Submit ticket" }).click();
+
+    await expect(page.getByText("Ticket submitted. Attachment: screenshot.png")).toBeVisible();
+  });
+
+  test("dropping multiple files is rejected while a single dropped file is accepted", async ({
+    initTestBed,
+    page,
+    createFileInputDriver,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    const fileInput = await createFileInputDriver();
+    const dropTarget = fileInput.getContainer().locator('button[type="button"]').first();
+    const dataTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["first"], "first.png", { type: "image/png" }));
+      transfer.items.add(new File(["second"], "second.png", { type: "image/png" }));
+      return transfer;
+    });
+
+    await dropTarget.dispatchEvent("dragenter", { dataTransfer });
+    await dropTarget.dispatchEvent("dragover", { dataTransfer });
+    await dropTarget.dispatchEvent("drop", { dataTransfer });
+
+    await expect.poll(() => fileInput.getSelectedFiles()).toBe("");
+
+    const singleFileTransfer = await page.evaluateHandle(() => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["single"], "single.png", { type: "image/png" }));
+      return transfer;
+    });
+
+    await dropTarget.dispatchEvent("dragenter", { dataTransfer: singleFileTransfer });
+    await dropTarget.dispatchEvent("dragover", { dataTransfer: singleFileTransfer });
+    await dropTarget.dispatchEvent("drop", { dataTransfer: singleFileTransfer });
+
+    await expect.poll(() => fileInput.getSelectedFiles()).toBe("single.png");
+  });
+});

--- a/xmlui/tests-e2e/validate-a-field-inline-with-onvalidate.spec.ts
+++ b/xmlui/tests-e2e/validate-a-field-inline-with-onvalidate.spec.ts
@@ -1,0 +1,74 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../website/content/docs/pages/howto/validate-a-field-inline-with-onvalidate.md",
+  ),
+);
+
+test.describe("Inline custom field validation", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Inline custom field validation",
+  );
+
+  test("initial state shows empty fields and submit button", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("textbox", { name: "Username" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Promo code (optional)" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
+    await expect(page.getByText("Only lowercase letters, digits, and underscores")).not.toBeVisible();
+    await expect(page.getByText("Username must not start with a digit")).not.toBeVisible();
+    await expect(page.getByText("Promo codes must be entered in uppercase")).not.toBeVisible();
+  });
+
+  test("username rejects invalid characters", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Username" }).fill("Ada!");
+    await page.getByRole("textbox", { name: "Promo code (optional)" }).focus();
+
+    await expect(
+      page.getByText("Only lowercase letters, digits, and underscores are allowed."),
+    ).toBeVisible();
+  });
+
+  test("username rejects leading digits", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Username" }).fill("9ada");
+    await page.getByRole("textbox", { name: "Promo code (optional)" }).focus();
+
+    await expect(page.getByText("Username must not start with a digit.")).toBeVisible();
+  });
+
+  test("promo code rejects lowercase letters", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Promo code (optional)" }).fill("summer25");
+    await page.getByRole("textbox", { name: "Username" }).focus();
+
+    await expect(page.getByText("Promo codes must be entered in uppercase.")).toBeVisible();
+  });
+
+  test("valid values submit successfully", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Username" }).fill("alice_99");
+    await page.getByRole("textbox", { name: "Promo code (optional)" }).fill("SUMMER25");
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    await expect(
+      page.getByText('Submitted: {"username":"alice_99","promoCode":"SUMMER25"}'),
+    ).toBeVisible();
+    await expect(page.getByText("Only lowercase letters, digits, and underscores")).not.toBeVisible();
+    await expect(page.getByText("Promo codes must be entered in uppercase")).not.toBeVisible();
+  });
+});

--- a/xmlui/tests-e2e/validate-dependent-fields-together.spec.ts
+++ b/xmlui/tests-e2e/validate-dependent-fields-together.spec.ts
@@ -1,0 +1,105 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../website/content/docs/pages/howto/validate-dependent-fields-together.md",
+  ),
+);
+
+test.describe("Cross-field password validation", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Cross-field password validation",
+  );
+
+  test("initial state shows empty registration fields and submit button", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("textbox", { name: "Username" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Password", exact: true })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Confirm Password" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create account" })).toBeVisible();
+    await expect(page.getByText("Passwords do not match")).not.toBeVisible();
+  });
+
+  test("submitting mismatched passwords shows an error and blocks success", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Username" }).fill("Ada");
+    await page.getByRole("textbox", { name: "Password", exact: true }).fill("correct horse");
+    await page.getByRole("textbox", { name: "Confirm Password" }).fill("battery staple");
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
+    await expect(page.getByText("Account created for Ada")).not.toBeVisible();
+  });
+
+  test("submitting matching passwords creates the account", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Username" }).fill("Ada");
+    await page.getByRole("textbox", { name: "Password", exact: true }).fill("correct horse");
+    await page.getByRole("textbox", { name: "Confirm Password" }).fill("correct horse");
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(page.getByText("Account created for Ada")).toBeVisible();
+    await expect(page.getByText("Passwords do not match")).not.toBeVisible();
+  });
+});
+
+test.describe("Inline password match validation", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Inline password match validation",
+  );
+
+  test("initial state shows empty registration fields and submit button", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByRole("textbox", { name: "Username" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Password", exact: true })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Confirm Password" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create account" })).toBeVisible();
+    await expect(page.getByText("Passwords do not match")).not.toBeVisible();
+  });
+
+  test("leaving mismatched confirm password shows an inline error", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Password", exact: true }).fill("correct horse");
+    await page.getByRole("textbox", { name: "Confirm Password" }).fill("battery staple");
+    await page.getByRole("textbox", { name: "Username" }).focus();
+
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
+  });
+
+  test("matching passwords submit successfully", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await page.getByRole("textbox", { name: "Username" }).fill("Ada");
+    await page.getByRole("textbox", { name: "Password", exact: true }).fill("correct horse");
+    await page.getByRole("textbox", { name: "Confirm Password" }).fill("correct horse");
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(page.getByText("Account created for Ada")).toBeVisible();
+    await expect(page.getByText("Passwords do not match")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
validate-dependent-fields-together
validate-a-field-inline-with-onvalidate
reset-a-form-after-submission
persist-form-drafts-across-sessions
submit-a-form-with-file-uploads