### PR TITLE
Docs: explain what xmlui build-lib does, link to source

### DIFF
--- a/website/content/docs/pages/wrap-component/extension-packaging.md
+++ b/website/content/docs/pages/wrap-component/extension-packaging.md
@@ -25,6 +25,18 @@ xmlui build-lib
 
 This produces a self-contained UMD `.js` file that externalizes React and the XMLUI runtime (already loaded by the host app). The bundle includes only the extension's own dependencies.
 
+## What `xmlui build-lib` does
+
+The implementation is ~80 lines of Vite/Rolldown config — see [`xmlui/src/nodejs/bin/build-lib.ts`](https://github.com/xmlui-org/xmlui/blob/main/xmlui/src/nodejs/bin/build-lib.ts). Reading it answers the toolchain questions that come up when wrapping your first component:
+
+- **Entry point** is hardcoded to `src/index.tsx`.
+- **Externals**: `react`, `react-dom`, `xmlui`, and `react/jsx-runtime` are not bundled — the host app already provides them.
+- **Auto-register footer**: the UMD bundle ends with `window.xmlui.standalone.registerExtension(...)`, which is why a `<script>` tag alone is enough.
+- **Watch mode** (`xmlui build-lib --watch`) emits ES with inline sourcemaps and rebuilds on change.
+- **Override hooks**: a `vite.config-overrides.ts` next to your `package.json` can supply additional Vite plugins or a custom logger.
+
+The build runs in your extension's own working directory and reads `package.json` for the bundle name (`${npm_package_name}.js` for UMD, `.mjs` for ES).
+
 ## Loading an extension
 
 In `index.html`, add a script tag:


### PR DESCRIPTION
## Summary

- Adds a "What `xmlui build-lib` does" section to the extension-packaging guide.
- Links the doc to the actual source at [`xmlui/src/nodejs/bin/build-lib.ts`](https://github.com/xmlui-org/xmlui/blob/main/xmlui/src/nodejs/bin/build-lib.ts) (~80 lines) so authors don't have to reverse-engineer it from `node_modules`.
- Surfaces the five things first-time extension authors actually need to know: hardcoded `src/index.tsx` entry, externals list, the `window.xmlui.standalone.registerExtension(...)` footer, watch-mode behavior, and the `vite.config-overrides.ts` hook.

## Context

Suggested by Raymond Yee after building [`xmlui-dnd-list`](https://github.com/rdhyee/xmlui-dnd-list) ([build log](https://github.com/rdhyee/xmlui-dnd-list/blob/main/BUILD_LOG.md)). Reading the bundled `build-lib` implementation answered every toolchain question he had — but only after he went looking for it in `node_modules`. Linking it from the docs saves the next author that hunt.

## Test plan

- [ ] Render the page on docs.xmlui.org and confirm headings/anchors render correctly.
- [ ] Verify the source link resolves to the current `main` of `xmlui-org/xmlui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
