### PR TITLE
Fix react/jsx-runtime globals mapping in build-lib

### DIFF
--- a/xmlui/src/nodejs/bin/build-lib.ts
+++ b/xmlui/src/nodejs/bin/build-lib.ts
@@ -68,7 +68,7 @@ export const buildLib = async ({
           globals: {
             react: "React",
             "react-dom": "ReactDOM",
-            jsx: "react/jsx-runtime",
+            "react/jsx-runtime": "jsxRuntime",
           },
         },
       },


### PR DESCRIPTION
## Summary

One-line fix to the Rolldown `output.globals` map in `xmlui/src/nodejs/bin/build-lib.ts`. The entry for `react/jsx-runtime` had key and value reversed, so the bundler always had to fall back to a default name for that global. The fix makes the mapping explicit and restores the contract with `xmlui-standalone.umd.js`.

```diff
   globals: {
     react: "React",
     "react-dom": "ReactDOM",
-    jsx: "react/jsx-runtime",
+    "react/jsx-runtime": "jsxRuntime",
   },
```

## Symptom

After the vite8 upgrade in #3313, every freshly-built extension UMD that uses JSX in the wrapper or renderer throws on first render:

```
Cannot read properties of undefined (reading 'jsx')
```

In Rolldown's build output you see:

```
[MISSING_GLOBAL_NAME] Warning: No name was provided for external module
"react/jsx-runtime" in "output.globals" – guessing "react_jsx_runtime".
```

`xmlui-standalone.umd.js` does not expose `window.react_jsx_runtime` — it has always exposed `window.jsxRuntime`. So the UMD wrapper that Rolldown emits binds an external to a global that doesn't exist.

## Root cause

The key direction in `globals` was wrong. The correct shape is `{ moduleId: globalName }`. The entry has been wrong for a long time (the original `"jsx": "react/jsx-runtime"` form has the same defect, just quoted differently — see commit 7c0d27a8 / PR #2102 for the most recent quoting change).

## Why it stayed latent until late April 2026

For months the build was silently relying on the bundler's default-name fallback for the un-mapped external:

- **Pre-vite8 (xmlui ≤ 0.12.20)** — Vite 7's Rollup-based output picked `jsxRuntime` as the default global for `react/jsx-runtime`. By happy accident this matched `window.jsxRuntime` exposed by `xmlui-standalone.umd.js`. Bug invisible.
- **Post-vite8 (xmlui ≥ 0.12.21)** — #3313 upgraded `vite 7.x → 8.x` and the bundler's default for the same external became `react_jsx_runtime` (underscore-mangled module path). Standalone never exposed that name, so the bug surfaced.

This is consistent with what we see in the field: extension UMDs in `judell/community-calendar` were checked in March 2026 (built pre-vite8) and continue to work because they reference `t.jsxRuntime`. Raymond Yee's `xmlui-dnd-list` was built May 2 2026 (post-vite8) and broke immediately. Every UMD built today is in the same state.

## Reproduction (verified)

Sequence run against current `main`:

1. `npx turbo run build:for-node --filter=xmlui --force`
2. `npx turbo run build:extension --filter=xmlui-masonry --force`
3. The `MISSING_GLOBAL_NAME` warning fires; `dist/xmlui-masonry.js` references `e.react_jsx_runtime`.
4. Drop the new bundle into a working `judell/community-calendar` deployment → page throws `Cannot read properties of undefined (reading 'jsx')` on first render.
5. With this fix applied, repeat steps 1-2: warning gone, bundle now references `e.jsxRuntime`, and the same community-calendar deployment loads cleanly.

## Reported by

[Raymond Yee](https://github.com/rdhyee), with a 15-line
`window.react_jsx_runtime` shim in his app's `index.html` to work around
the issue.

- Extension repo: https://github.com/rdhyee/xmlui-dnd-list
- Build narrative: https://github.com/rdhyee/xmlui-dnd-list/blob/main/BUILD_LOG.md

After this fix lands and a release ships, his shim becomes unnecessary.

## Out of scope (but worth a follow-up)

Rolldown still warns:

```
[MISSING_GLOBAL_NAME] Warning: No name was provided for external module
"xmlui" in "output.globals" – guessing "xmlui".
```

For `xmlui` the default mangling happens to match `window.xmlui`, so there's no functional break. Adding `"xmlui": "xmlui"` to the globals map would silence the warning and remove the same class of fragility.

## Test plan

- [ ] `pnpm --filter xmlui-masonry build:extension` (or any extension package) — confirm no `MISSING_GLOBAL_NAME` warning for `react/jsx-runtime`.
- [ ] Inspect rebuilt UMD: external should bind to `t.jsxRuntime`, not `t.react_jsx_runtime`.
- [ ] Drop rebuilt UMD into a separate app loaded via `<script>` tag and confirm first render no longer throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
