### PR TITLE
test: use built-in clipboard in e2e tests, account for Mac when using…

### DIFF
--- a/.ai/xmlui/testing-conventions.md
+++ b/.ai/xmlui/testing-conventions.md
@@ -67,6 +67,35 @@ const { testStateDriver } = await initTestBed(`
 `);
 ```
 
+### Clipboard
+
+`initTestBed` returns a `clipboard` helper that provides a test-safe wrapper around the browser clipboard. It intercepts `navigator.clipboard` so tests work consistently without real browser permissions. Line endings are normalized to `\n` on all platforms (Windows Chromium returns `\r\n` from the real API).
+
+```typescript
+const { clipboard } = await initTestBed(`<ComponentName />`);
+```
+
+| Method | Description |
+|--------|-------------|
+| `clipboard.read()` | Returns the current clipboard text as a string (`\r\n` normalized to `\n`) |
+| `clipboard.write(text)` | Writes `text` to the clipboard |
+| `clipboard.clear()` | Clears the clipboard (writes empty string) |
+| `clipboard.copy(locator)` | Focuses `locator`, selects all text, presses `ControlOrMeta+C` |
+| `clipboard.paste(locator)` | Focuses `locator`, presses `ControlOrMeta+V` |
+
+**Important:** only `writeText` / `readText` are mocked. Calling `navigator.clipboard.write()` or `navigator.clipboard.read()` (the binary variants) throws inside the test bed. Use `clipboard.read()` (not `page.evaluate(() => navigator.clipboard.readText())`) so line-ending normalization is applied.
+
+```typescript
+test("copies content to clipboard", async ({ initTestBed, page }) => {
+  const { clipboard } = await initTestBed(
+    `<Share markdownContent="# Hello\nWorld" />`,
+    EXT,
+  );
+  await page.getByRole("button", { name: "Copy page" }).click();
+  expect(await clipboard.read()).toBe("# Hello\nWorld");
+});
+```
+
 ### Event testing
 
 Capture event results via `testState` context variable + `expect.poll()`:

--- a/xmlui/src/components/DateInput/DateInput.spec.ts
+++ b/xmlui/src/components/DateInput/DateInput.spec.ts
@@ -1734,7 +1734,7 @@ test.describe("Keyboard behavior: Ctrl+A select all", () => {
     await expect(driver.yearInput).toBeFocused();
 
     // Ctrl+A should jump focus to the first field (month in MM/dd/yyyy)
-    await page.keyboard.press("Control+a");
+    await page.keyboard.press("ControlOrMeta+a");
     await expect(driver.monthInput).toBeFocused();
   });
 
@@ -1751,7 +1751,7 @@ test.describe("Keyboard behavior: Ctrl+A select all", () => {
     await driver.monthInput.focus();
     await expect(driver.monthInput).toBeFocused();
 
-    await page.keyboard.press("Control+a");
+    await page.keyboard.press("ControlOrMeta+a");
     await page.keyboard.press("Backspace");
 
     await expect(driver.monthInput).toHaveValue("");
@@ -1772,7 +1772,7 @@ test.describe("Keyboard behavior: Ctrl+A select all", () => {
     await driver.dayInput.focus();
     await expect(driver.dayInput).toBeFocused();
 
-    await page.keyboard.press("Control+a");
+    await page.keyboard.press("ControlOrMeta+a");
     await page.keyboard.press("Delete");
 
     await expect(driver.monthInput).toHaveValue("");
@@ -1786,7 +1786,7 @@ test.describe("Keyboard behavior: Ctrl+A select all", () => {
     page,
   }) => {
     await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
-    await initTestBed(`<DateInput testId="dateInput" dateFormat="MM/dd/yyyy" initialValue="05/25/2024" />`);
+    const { clipboard } = await initTestBed(`<DateInput testId="dateInput" dateFormat="MM/dd/yyyy" initialValue="05/25/2024" />`);
     const driver = await createDateInputDriver("dateInput");
 
     await expect(driver.monthInput).toBeVisible();
@@ -1794,10 +1794,10 @@ test.describe("Keyboard behavior: Ctrl+A select all", () => {
     await driver.monthInput.focus();
     await expect(driver.monthInput).toBeFocused();
 
-    await page.keyboard.press("Control+a");
-    await page.keyboard.press("Control+c");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+c");
 
-    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    const clipboardText = await clipboard.read();
     expect(clipboardText).toBe("05/25/2024");
   });
 
@@ -1814,7 +1814,7 @@ test.describe("Keyboard behavior: Ctrl+A select all", () => {
     await driver.monthInput.focus();
     await expect(driver.monthInput).toBeFocused();
 
-    await page.keyboard.press("Control+a");
+    await page.keyboard.press("ControlOrMeta+a");
     // Typing a digit after Ctrl+A should not clear all fields
     await page.keyboard.press("3");
 

--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -2841,11 +2841,7 @@ test.describe("Keyboard Shortcuts", () => {
 
       const table = page.getByTestId("table");
       await expect(table).toBeVisible();
-
-      // Press the platform-appropriate key: Cmd+A on macOS, Ctrl+A elsewhere
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
 
       await expect.poll(testStateDriver.testState).toEqual({
         action: "selectAll",
@@ -2875,9 +2871,7 @@ test.describe("Keyboard Shortcuts", () => {
       await firstRow.click();
 
       // Press the platform-appropriate key
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
 
       const result = await testStateDriver.testState();
       expect(result.selectedItemsLength).toBeGreaterThanOrEqual(0);
@@ -2903,7 +2897,7 @@ test.describe("Keyboard Shortcuts", () => {
       const input = page.getByTestId("input").getByRole("textbox");
       await input.focus();
       await expect(input).toBeFocused();
-      await page.keyboard.press("Control+A");
+      await page.keyboard.press("ControlOrMeta+A");
 
       // Should not trigger table's selectAll
       await expect.poll(testStateDriver.testState).not.toEqual("selectAll triggered");
@@ -2932,10 +2926,7 @@ test.describe("Keyboard Shortcuts", () => {
       const table = page.getByTestId("table");
       await expect(table).toBeVisible();
 
-      // Press the platform-appropriate key
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
       await page.waitForTimeout(100);
 
       // Verify that all items are selected in the context
@@ -3017,9 +3008,7 @@ test.describe("Keyboard Shortcuts", () => {
         </Table>
       `);
 
-      const isMac = process.platform === "darwin";
-      const copyKey = isMac ? "Meta+C" : "Control+C";
-      await page.keyboard.press(copyKey);
+      await page.keyboard.press("ControlOrMeta+C");
 
       await expect.poll(testStateDriver.testState).toEqual({
         action: "copy",
@@ -3046,9 +3035,7 @@ test.describe("Keyboard Shortcuts", () => {
       const firstRow = page.locator("tbody tr").first();
       await firstRow.click();
 
-      const isMac = process.platform === "darwin";
-      const copyKey = isMac ? "Meta+C" : "Control+C";
-      await page.keyboard.press(copyKey);
+      await page.keyboard.press("ControlOrMeta+C");
 
       const result = await testStateDriver.testState();
       expect(Array.isArray(result.items)).toBe(true);
@@ -3069,9 +3056,7 @@ test.describe("Keyboard Shortcuts", () => {
         </Table>
       `);
 
-      const isMac = process.platform === "darwin";
-      const cutKey = isMac ? "Meta+X" : "Control+X";
-      await page.keyboard.press(cutKey);
+      await page.keyboard.press("ControlOrMeta+X");
 
       await expect.poll(testStateDriver.testState).toEqual({
         action: "cut",
@@ -3097,9 +3082,7 @@ test.describe("Keyboard Shortcuts", () => {
       const firstRow = page.locator("tbody tr").first();
       await firstRow.click();
 
-      const isMac = process.platform === "darwin";
-      const pasteKey = isMac ? "Meta+V" : "Control+V";
-      await page.keyboard.press(pasteKey);
+      await page.keyboard.press("ControlOrMeta+V");
 
       const result = await testStateDriver.testState();
       expect(result.action).toBe("paste");
@@ -3130,9 +3113,7 @@ test.describe("Keyboard Shortcuts", () => {
       const firstRow = page.locator("tbody tr").first();
       await firstRow.click();
 
-      const isMac = process.platform === "darwin";
-      const pasteKey = isMac ? "Meta+V" : "Control+V";
-      await page.keyboard.press(pasteKey);
+      await page.keyboard.press("ControlOrMeta+V");
 
       // App-level handler must NOT count this as unhandled, because Table
       // called event.preventDefault() and the App handler checks defaultPrevented.
@@ -3217,9 +3198,7 @@ test.describe("Keyboard Shortcuts", () => {
       const firstRow = page.locator("tbody tr").first();
       await firstRow.click();
 
-      const isMac = process.platform === "darwin";
-      const copyKey = isMac ? "Meta+C" : "Control+C";
-      await page.keyboard.press(copyKey);
+      await page.keyboard.press("ControlOrMeta+C");
 
       const result = await testStateDriver.testState();
       expect(result.hasSelectedIds).toBe(true);
@@ -3253,9 +3232,7 @@ test.describe("Keyboard Shortcuts", () => {
       const firstRow = page.locator("tbody tr").first();
       await firstRow.click();
 
-      const isMac = process.platform === "darwin";
-      const copyKey = isMac ? "Meta+C" : "Control+C";
-      await page.keyboard.press(copyKey);
+      await page.keyboard.press("ControlOrMeta+C");
 
       const result = await testStateDriver.testState();
       expect(result.focusedRowData).not.toBeNull();
@@ -3292,9 +3269,7 @@ test.describe("Keyboard Shortcuts", () => {
       await page.waitForTimeout(50);
 
       // Use keyboard shortcut
-      const isMac = process.platform === "darwin";
-      const copyKey = isMac ? "Meta+C" : "Control+C";
-      await page.keyboard.press(copyKey);
+      await page.keyboard.press("ControlOrMeta+C");
 
       const result = await testStateDriver.testState();
       expect(result.action).toBe("copy");
@@ -3319,9 +3294,7 @@ test.describe("Keyboard Shortcuts", () => {
       `);
 
       // First use a keyboard shortcut (this might not do anything if no onSelectAll handler)
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
       await page.waitForTimeout(50);
 
       // Then try space key for selection
@@ -3353,9 +3326,7 @@ test.describe("Keyboard Shortcuts", () => {
       `);
 
       // CmdOrCtrl+A should be handled by our handler and prevented
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
 
       await expect.poll(testStateDriver.testState).toEqual("handled");
     });
@@ -3382,9 +3353,7 @@ test.describe("Keyboard Shortcuts", () => {
       await expect(table).toBeVisible();
 
       // Press the platform-appropriate key
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
       await page.waitForTimeout(100);
 
       // Should NOT have triggered the handler (testState remains null)
@@ -3435,9 +3404,7 @@ test.describe("Keyboard Shortcuts", () => {
       const table = page.getByTestId("table");
       await expect(table).toBeVisible();
 
-      const isMac = process.platform === "darwin";
-      const copyKey = isMac ? "Meta+C" : "Control+C";
-      await page.keyboard.press(copyKey);
+      await page.keyboard.press("ControlOrMeta+C");
       await page.waitForTimeout(100);
 
       // Should NOT have triggered the handler (testState remains null)
@@ -3461,9 +3428,7 @@ test.describe("Keyboard Shortcuts", () => {
       const table = page.getByTestId("table");
       await expect(table).toBeVisible();
 
-      const isMac = process.platform === "darwin";
-      const cutKey = isMac ? "Meta+X" : "Control+X";
-      await page.keyboard.press(cutKey);
+      await page.keyboard.press("ControlOrMeta+X");
       await page.waitForTimeout(100);
 
       // Should NOT have triggered the handler (testState remains null)
@@ -3487,9 +3452,7 @@ test.describe("Keyboard Shortcuts", () => {
       const table = page.getByTestId("table");
       await expect(table).toBeVisible();
 
-      const isMac = process.platform === "darwin";
-      const pasteKey = isMac ? "Meta+V" : "Control+V";
-      await page.keyboard.press(pasteKey);
+      await page.keyboard.press("ControlOrMeta+V");
       await page.waitForTimeout(100);
 
       // Should have triggered the handler
@@ -3515,9 +3478,7 @@ test.describe("Keyboard Shortcuts", () => {
       const table = page.getByTestId("table");
       await expect(table).toBeVisible();
 
-      const isMac = process.platform === "darwin";
-      const selectAllKey = isMac ? "Meta+A" : "Control+A";
-      await page.keyboard.press(selectAllKey);
+      await page.keyboard.press("ControlOrMeta+A");
       await page.waitForTimeout(100);
 
       // Should have triggered the handler

--- a/xmlui/src/components/TileGrid/TileGrid.spec.ts
+++ b/xmlui/src/components/TileGrid/TileGrid.spec.ts
@@ -351,7 +351,7 @@ test.describe("Selection", () => {
     const cells = page.getByRole("gridcell");
     await cells.nth(0).click();
     // Ctrl+click second tile to add to selection
-    await cells.nth(1).click({ modifiers: ["Meta"] });
+    await cells.nth(1).click({ modifiers: ["ControlOrMeta"] });
     // Both should be selected
     await expect(cells.nth(0)).toHaveAttribute("aria-selected", "true");
     await expect(cells.nth(1)).toHaveAttribute("aria-selected", "true");
@@ -475,7 +475,7 @@ test.describe("hideSelectionCheckboxes property", () => {
     `);
     const cells = page.getByRole("gridcell");
     await cells.nth(0).click();
-    await cells.nth(1).click({ modifiers: ["Meta"] });
+    await cells.nth(1).click({ modifiers: ["ControlOrMeta"] });
     await expect(cells.nth(0)).toHaveAttribute("aria-selected", "true");
     await expect(cells.nth(1)).toHaveAttribute("aria-selected", "true");
   });
@@ -519,8 +519,7 @@ test.describe("Keyboard Shortcuts", () => {
     await initTestBed(selectableMarkup);
     // Click first tile to give the grid focus
     await page.getByRole("gridcell").nth(0).click();
-    const isMac = process.platform === "darwin";
-    await page.keyboard.press(isMac ? "Meta+A" : "Control+A");
+    await page.keyboard.press("ControlOrMeta+A");
     const cells = page.getByRole("gridcell");
     await expect(cells.nth(0)).toHaveAttribute("aria-selected", "true");
     await expect(cells.nth(1)).toHaveAttribute("aria-selected", "true");
@@ -540,8 +539,7 @@ test.describe("Keyboard Shortcuts", () => {
       </TileGrid>
     `);
     await page.getByRole("gridcell").nth(0).click();
-    const isMac = process.platform === "darwin";
-    await page.keyboard.press(isMac ? "Meta+A" : "Control+A");
+    await page.keyboard.press("ControlOrMeta+A");
     await expect.poll(testStateDriver.testState).toEqual("fired");
   });
 


### PR DESCRIPTION
… mod key