### PR TITLE
feat: enable xsVerbose tracing via localStorage opt-in

### DIFF
--- a/xmlui/src/components-core/StandaloneApp.tsx
+++ b/xmlui/src/components-core/StandaloneApp.tsx
@@ -234,10 +234,28 @@ function StandaloneApp({
   } = standaloneApp || {};
 
   const globalProps = useMemo(() => {
+    // Allow per-browser-session opt-in to xsVerbose via localStorage, so an
+    // in-app diagnostic toggle can flip tracing without editing config.json.
+    // Key namespace `xmlui:*` keeps the surface bounded and discoverable.
+    const lsOverrides: Record<string, any> = {};
+    if (typeof localStorage !== "undefined") {
+      try {
+        if (localStorage.getItem("xmlui:xsVerbose") === "true") {
+          lsOverrides.xsVerbose = true;
+        }
+        const lsLogMax = localStorage.getItem("xmlui:xsVerboseLogMax");
+        if (lsLogMax !== null && !Number.isNaN(Number(lsLogMax))) {
+          lsOverrides.xsVerboseLogMax = Number(lsLogMax);
+        }
+      } catch {
+        // localStorage may throw in sandboxed/private contexts; ignore.
+      }
+    }
     return {
       name: name,
       ...(appGlobals || {}),
       ...(globals || {}),
+      ...lsOverrides,
     };
   }, [appGlobals, globals, name]);
 


### PR DESCRIPTION
## Summary

- Adds localStorage opt-in for `xsVerbose` tracing so end users of embedded XMLUI deployments can flip diagnostics on without editing `config.json`.
- Injection happens at the canonical `appGlobals` assembly point in `StandaloneApp.tsx`, so every downstream gate (`AppContent`, `wrapComponent`, `CompoundComponent`, inspector helpers) picks it up unchanged.
- Strictly opt-in: only `xmlui:xsVerbose === "true"` flips tracing on; `"false"` does **not** override a config that has it on.

Refs #3435.

## How to use

In any browser session against an app built with this bundle:

```js
localStorage.setItem("xmlui:xsVerbose", "true");
// optional cap on the in-memory log buffer
localStorage.setItem("xmlui:xsVerboseLogMax", "500");
location.reload();
```

After reload, `window._xsLogs` is initialized and tracing is active.

To turn it off:

```js
localStorage.removeItem("xmlui:xsVerbose");
location.reload();
```

## Test plan

Verified against a minimal harness (`index.html` + `Main.xmlui` + `config.json` + freshly built bundle) driven by Playwright:

| Run | `xmlui:xsVerbose` | Expected | Result |
|---|---|---|---|
| 1 | unset | OFF | `_xsLogs` undefined, no startup trace ✓ |
| 2 | `"true"` | ON | `_xsLogs=[]`, startup trace string ✓ |
| 3 | `"false"` | OFF (strictly opt-in) | `_xsLogs` undefined ✓ |
| 4 | removed | OFF (baseline restored) | `_xsLogs` undefined ✓ |

Run 2 also exercised `xmlui:xsVerboseLogMax="42"` — flowed through `globalProps` with no errors.

## For @harrisonkrome / Reese

A built standalone bundle (`xmlui-standalone.umd.js`, the one used in the test runs above) is attached as a zip on this PR — drop it into your `index.html` setup as a drop-in replacement to try the localStorage flow without needing to build from source.

## Open question

Force-off path — should `localStorage.getItem("xmlui:xsVerbose") === "false"` *override* a `config.json` that has tracing on (so a user can opt out of a globally-enabled deployment)? Current behavior: localStorage is strictly opt-in, no override of `"false"`. Happy to add force-off semantics if useful.


[xmlui-standalone-xsverbose-localstorage.zip](https://github.com/user-attachments/files/28030117/xmlui-standalone-xsverbose-localstorage.zip)

