### PR TITLE
fix(inspector): silence [xs] trace noise in browser console

### DIFF
--- a/xmlui/src/components-core/inspector/inspectorUtils.ts
+++ b/xmlui/src/components-core/inspector/inspectorUtils.ts
@@ -29,7 +29,6 @@
  * - `window._xsLastApiStatus` - Map of transactionId -> HTTP status code
  */
 
-import { loggerService } from "../../logging/LoggerService";
 import { currentContext, BOOT_TRACE_ID } from "../audit/correlation";
 
 // =============================================================================
@@ -418,13 +417,10 @@ export function createLogEntry(
 }
 
 /**
- * Log to console and loggerService with [xs] prefix.
+ * No-op. Inspector data is captured via pushXsLog; this previously also
+ * mirrored every trace to the browser console, which flooded devtools.
  */
-export function xsConsoleLog(...args: any[]): void {
-  const payload = ["[xs]", ...args];
-  loggerService.log(payload);
-  // console.log(...payload);
-}
+export function xsConsoleLog(..._args: any[]): void {}
 
 // =============================================================================
 // TRACE ID MANAGEMENT


### PR DESCRIPTION
## Summary
- `xsConsoleLog` in `inspectorUtils.ts` was mirroring every `[xs]` inspector trace event (`component:vars:init`, `handler:start`, `state:changes`, `handler:complete`, ...) through `loggerService.log`, which always calls `console.log("[xmlui.log]", ...)` in dev mode. Devtools was flooded with hundreds of messages per interaction.
- Made `xsConsoleLog` a no-op. The Inspector's Export button reads from the separate `pushXsLog` sink, which is always called immediately before `xsConsoleLog` at both call sites (`variable-logging.ts:256-257`, `handler-logging.ts:209-211`), so exported traces are unaffected.

## Test plan
- [ ] Open an XMLUI app in dev mode, interact with components, confirm no `[xmlui.log] [xs] ...` lines appear in devtools console
- [ ] Open the Inspector, reproduce an interaction, click Export, confirm the resulting `xs-trace-*.json` still contains the same trace events as before
