### PR TITLE
Fix APICall lifecycle handler scheduling

### DIFF
--- a/.changeset/api-lifecycle-scheduler-bypass.md
+++ b/.changeset/api-lifecycle-scheduler-bypass.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Prevent APICall lifecycle handlers from being delayed by FIFO handler scheduling when an API call is invoked from another event handler.

--- a/xmlui/src/components-core/action/APICall.tsx
+++ b/xmlui/src/components-core/action/APICall.tsx
@@ -8,7 +8,7 @@ import { pushXsLog, getCurrentTrace } from "../inspector/inspectorUtils";
 // --- Tracing helper for API calls
 function traceApiCall(
   appContext: AppContextObject,
-  kind: "api:start" | "api:complete" | "api:error",
+  kind: "api:start" | "api:complete" | "api:error" | "api:lifecycle",
   url: string,
   method: string,
   details?: Record<string, any>,
@@ -34,6 +34,8 @@ import type { ApiActionOptions, ApiOperationDef } from "../RestApiProxy";
 import RestApiProxy, { getLastApiStatus } from "../RestApiProxy";
 import { createAction } from "./actions";
 import { createContextVariableError } from "../EngineError";
+
+const apiLifecycleHandlerOptions = { schedulerBypass: true };
 
 function findQueryKeysToUpdate(updates: string | string[], queryClient: QueryClient) {
   const queryKeysToUpdate: Array<QueryKey> = [];
@@ -249,7 +251,10 @@ async function updateQueriesWithOptimisticValue({
     clientTxId,
     stateContext,
     extractParam(stateContext, optimisticValue, appContext),
-    lookupAction(getOptimisticValue, uid, { eventName: "getOptimisticValue" }),
+    lookupAction(getOptimisticValue, uid, {
+      eventName: "getOptimisticValue",
+      ...apiLifecycleHandlerOptions,
+    }),
   );
 
   await doOptimisticUpdate(optimisticValuesByQueryKeys, queryClient);
@@ -342,8 +347,28 @@ export async function callApi(
   const resolvedInvalidates = extractParam(stateContext, invalidates, appContext);
 
   const clientTxId = randomUUID();
-  const beforeRequestFn = lookupAction(onBeforeRequest, uid, { eventName: "beforeRequest" });
+  traceApiCall(appContext, "api:lifecycle", url as string, method || "GET", {
+    phase: "callApi:entered",
+    transactionId: clientTxId,
+    hasOnSuccess: !!onSuccess,
+    onSuccessKind: typeof onSuccess,
+  });
+  const beforeRequestFn = lookupAction(onBeforeRequest, uid, {
+    eventName: "beforeRequest",
+    ...apiLifecycleHandlerOptions,
+  });
+  traceApiCall(appContext, "api:lifecycle", url as string, method || "GET", {
+    phase: "beforeRequest:start",
+    transactionId: clientTxId,
+    schedulerBypass: true,
+    hasHandler: !!beforeRequestFn,
+  });
   const beforeRequestResult = await beforeRequestFn?.();
+  traceApiCall(appContext, "api:lifecycle", url as string, method || "GET", {
+    phase: "beforeRequest:end",
+    transactionId: clientTxId,
+    resultType: typeof beforeRequestResult,
+  });
   if (typeof beforeRequestResult === "boolean" && beforeRequestResult === false) {
     return;
   }
@@ -402,6 +427,7 @@ export async function callApi(
 
       const mockFn = lookupAction(onMockExecute, uid, {
         eventName: "mockExecute",
+        ...apiLifecycleHandlerOptions,
         context: {
           ...getCurrentState(),
           $pathParams: {},
@@ -427,6 +453,7 @@ export async function callApi(
       };
       const _onProgress = lookupAction(onProgress, uid, {
         eventName: "progress",
+        ...apiLifecycleHandlerOptions,
       });
 
       // Trace API call start — capture traceId before await so api:complete
@@ -459,9 +486,34 @@ export async function callApi(
 
     const onSuccessFn = typeof onSuccess === "function"
       ? onSuccess
-      : lookupAction(onSuccess, uid, { eventName: "success", context: getCurrentState() });
+      : lookupAction(onSuccess, uid, {
+        eventName: "success",
+        ...apiLifecycleHandlerOptions,
+        context: getCurrentState(),
+      });
+    const successStartedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+    traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+      phase: "success:start",
+      transactionId: clientTxId,
+      hasHandler: !!onSuccessFn,
+      handlerKind: typeof onSuccess,
+      schedulerBypass: typeof onSuccess === "function" ? "pre-resolved" : true,
+      status: getLastApiStatus(clientTxId),
+    });
     const onSuccessResult = await onSuccessFn?.(result, stateContext["$param"]);
+    traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+      phase: "success:end",
+      transactionId: clientTxId,
+      handlerKind: typeof onSuccess,
+      durationMs: (typeof performance !== "undefined" ? performance.now() : Date.now()) - successStartedAt,
+      resultType: typeof onSuccessResult,
+    });
 
+    traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+      phase: "queryUpdate:start",
+      transactionId: clientTxId,
+      queryKeyCount: queryKeysToUpdate.length,
+    });
     updateQueriesWithResult(
       queryKeysToUpdate,
       optimisticValuesByQueryKeys,
@@ -469,6 +521,11 @@ export async function callApi(
       appContext.queryClient!,
       result,
     );
+    traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+      phase: "queryUpdate:end",
+      transactionId: clientTxId,
+      queryKeyCount: queryKeysToUpdate.length,
+    });
 
     // An explicit `false` return from onSuccess opts out of invalidation.
     // Any other return value (including undefined/void) proceeds normally.
@@ -480,7 +537,17 @@ export async function callApi(
       // unmounts DataSource components before the invalidation triggers a
       // re-fetch. The react-query AbortController cancels any in-flight
       // requests from unmounted components, preventing wasted network traffic.
+      traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+        phase: "invalidate:schedule",
+        transactionId: clientTxId,
+        hasResolvedInvalidates: !!resolvedInvalidates,
+        hasUpdates: !!updates,
+      });
       setTimeout(() => {
+        traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+          phase: "invalidate:run",
+          transactionId: clientTxId,
+        });
         void invalidateQueries(resolvedInvalidates, appContext, state);
       }, 0);
     }
@@ -496,6 +563,10 @@ export async function callApi(
     } else if (loadingToastId) {
       toast.dismiss(loadingToastId);
     }
+    traceApiCall(appContext, "api:lifecycle", resolvedUrl, resolvedMethod, {
+      phase: "callApi:return",
+      transactionId: clientTxId,
+    });
     return result;
   } catch (e: any) {
     // Trace API call error
@@ -510,6 +581,7 @@ export async function callApi(
     }
     const onErrorFn = lookupAction(onError, uid, {
       eventName: "error",
+      ...apiLifecycleHandlerOptions,
     });
     const result = await onErrorFn?.(e, stateContext["$param"]);
     const errorMessage = extractParam(

--- a/xmlui/src/components/APICall/APICall.spec.ts
+++ b/xmlui/src/components/APICall/APICall.spec.ts
@@ -1223,6 +1223,38 @@ test.describe("Basic Functionality", () => {
       await expect.poll(testStateDriver.testState, { timeout: 2000 }).toEqual("executed");
     });
 
+    test("runs lifecycle handlers promptly from a multi-statement parent handler", async ({
+      initTestBed,
+      createButtonDriver,
+    }) => {
+      const { testStateDriver } = await initTestBed(
+        `
+        <Fragment
+          var.startedAt="{0}"
+          var.successElapsed="{null}">
+          <APICall
+            id="api"
+            url="/api/test"
+            onSuccess="() => { successElapsed = Date.now() - startedAt; testState = successElapsed; }" />
+          <Button
+            testId="trigger"
+            onClick="startedAt = Date.now(); successElapsed = null; api.execute()"
+            label="Execute" />
+        </Fragment>
+      `,
+        {
+          apiInterceptor: basicApiInterceptor,
+          appGlobals: { strictDeterminism: true, defaultHandlerTimeoutMs: 5000 },
+        },
+      );
+
+      const button = await createButtonDriver("trigger");
+      await button.click();
+
+      await expect.poll(testStateDriver.testState, { timeout: 1000 }).toEqual(expect.any(Number));
+      expect(await testStateDriver.testState()).toBeLessThan(1000);
+    });
+
     test("accepts parameters", async ({ initTestBed, createButtonDriver }) => {
       const { testStateDriver } = await initTestBed(
         `

--- a/xmlui/src/components/APICall/APICall.tsx
+++ b/xmlui/src/components/APICall/APICall.tsx
@@ -418,11 +418,11 @@ export const apiCallRenderer = createComponentRenderer(
         node={node as any}
         uid={uid}
         updateState={updateState}
-        onSuccess={lookupEventHandler("success")}
-        onStatusUpdate={lookupEventHandler("statusUpdate")}
-        onTimeout={lookupEventHandler("timeout")}
-        onPollingStart={lookupEventHandler("pollingStart")}
-        onPollingComplete={lookupEventHandler("pollingComplete")}
+        onSuccess={lookupEventHandler("success", { schedulerBypass: true })}
+        onStatusUpdate={lookupEventHandler("statusUpdate", { schedulerBypass: true })}
+        onTimeout={lookupEventHandler("timeout", { schedulerBypass: true })}
+        onPollingStart={lookupEventHandler("pollingStart", { schedulerBypass: true })}
+        onPollingComplete={lookupEventHandler("pollingComplete", { schedulerBypass: true })}
         hasMockExecute={!!node.events?.mockExecute}
       />
     );

--- a/xmlui/src/components/APICall/APICallReact.tsx
+++ b/xmlui/src/components/APICall/APICallReact.tsx
@@ -8,6 +8,7 @@ import type { ApiActionComponent } from "../../components/APICall/APICall";
 import { evalBinding } from "../../components-core/script-runner/eval-tree-sync";
 import { Parser } from "../../parsers/scripting/Parser";
 import toast from "react-hot-toast";
+import { getCurrentTrace, pushXsLog } from "../../components-core/inspector/inspectorUtils";
 
 interface Props {
   registerComponentApi: RegisterComponentApiFn;
@@ -28,6 +29,28 @@ interface DeferredState {
   progress: number;
   attempts: number;
   startTime?: number;
+}
+
+function traceApiComponent(
+  executionContext: ActionExecutionContext | undefined,
+  node: ApiActionComponent,
+  phase: string,
+  details?: Record<string, any>,
+) {
+  const appContext = executionContext?.appContext;
+  if (appContext?.appGlobals?.xsVerbose !== true) return;
+  pushXsLog({
+    ts: Date.now(),
+    perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+    traceId: getCurrentTrace(),
+    kind: "api:component",
+    component: "APICall",
+    phase,
+    url: node.props?.url,
+    method: node.props?.method || defaultProps.method,
+    uid: String(node.uid || ""),
+    ...details,
+  });
 }
 
 export const defaultProps = {
@@ -530,10 +553,21 @@ export const APICallReact = memo(function APICallReact({ registerComponentApi, n
 
       // Store execution context for cancel() method
       executionContextRef.current = executionContext;
+      traceApiComponent(executionContext, node, "execute:start", {
+        deferredMode: (node.props as any)?.deferredMode === "true" || (node.props as any)?.deferredMode === true,
+      });
       
       // Set inProgress before starting
       if (updateState) {
+        traceApiComponent(executionContext, node, "state:update", {
+          inProgress: true,
+          reason: "execute:start",
+        });
         updateState({ inProgress: true });
+        traceApiComponent(executionContext, node, "state:update-dispatched", {
+          inProgress: true,
+          reason: "execute:start",
+        });
       }
       
       // Detect deferred mode early so we can adjust behaviour for the initial POST
@@ -571,6 +605,7 @@ export const APICallReact = memo(function APICallReact({ registerComponentApi, n
             resolveBindingExpressions: true,
           },
         );
+        traceApiComponent(executionContext, node, "callApi:resolved");
 
         // Store result in ref for cancel() method
         lastResultRef.current = result;
@@ -578,18 +613,36 @@ export const APICallReact = memo(function APICallReact({ registerComponentApi, n
         // In deferred mode keep inProgress=true and loaded=false until polling finishes.
         if (updateState) {
           if (deferredMode) {
+            traceApiComponent(executionContext, node, "state:update", {
+              reason: "callApi:resolved:deferred",
+              loaded: false,
+            });
             updateState({
               lastResult: result,
               lastError: undefined,
               lastResponseHeaders: capturedResponseHeaders,
             });
+            traceApiComponent(executionContext, node, "state:update-dispatched", {
+              reason: "callApi:resolved:deferred",
+              loaded: false,
+            });
           } else {
+            traceApiComponent(executionContext, node, "state:update", {
+              inProgress: false,
+              loaded: true,
+              reason: "callApi:resolved",
+            });
             updateState({ 
               inProgress: false, 
               loaded: true, 
               lastResult: result,
               lastError: undefined,
               lastResponseHeaders: capturedResponseHeaders,
+            });
+            traceApiComponent(executionContext, node, "state:update-dispatched", {
+              inProgress: false,
+              loaded: true,
+              reason: "callApi:resolved",
             });
           }
         }
@@ -631,10 +684,21 @@ export const APICallReact = memo(function APICallReact({ registerComponentApi, n
       } catch (error) {
         // Store error and update state on failure
         if (updateState) {
+          traceApiComponent(executionContext, node, "state:update", {
+            inProgress: false,
+            loaded: true,
+            reason: "callApi:error",
+            error: error instanceof Error ? error.message : String(error),
+          });
           updateState({ 
             inProgress: false,
             loaded: true,
             lastError: error,
+          });
+          traceApiComponent(executionContext, node, "state:update-dispatched", {
+            inProgress: false,
+            loaded: true,
+            reason: "callApi:error",
           });
         }
         throw error;


### PR DESCRIPTION
## Problem

Bram hit a user-visible delay after posting a GitHub issue comment through XMLUI's `APICall` component. The comment appeared, but the APICall-driven spinner stayed active for several seconds after the backend had already confirmed the request.

The affected flow was:

```xmlui
<APICall
  id="commentIssueCall"
  url="/__issue/comment"
  method="post"
  onSuccess="closeCommentBox.setValue(''); issueDetail.refetch(); issues.refetch()" />
```

## Evidence Before

Inspector and Bram traces showed the backend was not the source of the spinner delay:

- `POST /__issue/comment` returned `200` at `18:23:11.242`, duration `1033ms`.
- The first success-triggered `GET /__issues` did not start until `18:23:14.729`, about `3.5s` later.
- The expected `issueDetail.refetch()` did not run promptly in that success path; the next `GET /__issue?number=154` was the normal 30s poll at `18:23:24.665`.

That pointed at APICall lifecycle handler scheduling rather than network/API latency.

## Fix

APICall lifecycle handlers now bypass strict FIFO handler scheduling:

- `callApi()` resolves `getOptimisticValue`, `beforeRequest`, `mockExecute`, `progress`, `success`, and `error` handlers with `schedulerBypass: true`.
- The `APICall` component renderer also passes `schedulerBypass: true` when pre-resolving component lifecycle events such as `success`, `statusUpdate`, `timeout`, `pollingStart`, and `pollingComplete`.

The second point was the missing piece for this bug: `<APICall onSuccess=...>` pre-resolves the success handler in the component renderer and passes it to `callApi()` as a function, so bypassing only inside `callApi()` did not cover the component event path.

This PR also adds verbose Inspector trace markers around APICall lifecycle phases and component `inProgress` updates so future timing issues show whether delay is in network completion, lifecycle handler execution, invalidation, or state propagation.

## Evidence After

After rebuilding the standalone XMLUI runtime and retesting the same Bram flow, the trace showed the expected immediate sequence:

- `18:28:53.226` APICall sets `inProgress=true`.
- `18:28:54.492` `POST /__issue/comment` completes with status `200`.
- `18:28:54.492` `success:start` fires immediately.
- `18:28:54.515` `issueDetail.refetch()` starts.
- `18:28:54.528` `issues.refetch()` starts.
- `18:28:54.540` `success:end`, duration `48ms`.
- `18:28:54.540` APICall dispatches `inProgress=false`.
- `18:28:54.551` click handler completes.

Bram's backend trace agreed: the POST exited at `18:28:54.488`, then `GET /__issue` started at `18:28:54.517` and `GET /__issues` started at `18:28:54.529`.

## Verification

- `npm -w xmlui run test:e2e -- APICall.spec.ts --grep "runs lifecycle handlers promptly"`
- `npm -w xmlui run test:e2e -- APICall.spec.ts` was run earlier during this debugging cycle and passed before the final component-renderer bypass addition.
