### PR TITLE
Fix LoggerService dev-mode gate so standalone bundles stop emitting xs console.log

### DIFF
--- a/xmlui/src/logging/LoggerService.ts
+++ b/xmlui/src/logging/LoggerService.ts
@@ -6,7 +6,12 @@ class LoggerService {
   private isDev: boolean;
 
   private constructor() {
-    this.isDev = !!(import.meta.env?.DEV || import.meta.env?.VITE_XMLUI_DEV_MODE);
+    const devMode = import.meta.env?.VITE_XMLUI_DEV_MODE;
+    this.isDev = !!(
+      import.meta.env?.DEV ||
+      devMode === true ||
+      devMode === "true"
+    );
   }
 
   public static getInstance(): LoggerService {

--- a/xmlui/vite.config.ts
+++ b/xmlui/vite.config.ts
@@ -33,7 +33,7 @@ export default ({ mode = "lib" }) => {
         "import.meta.env.NODE_ENV": JSON.stringify(env.NODE_ENV),
         "import.meta.env.VITE_XMLUI_VERSION": JSON.stringify(xmluiVersion),
         "import.meta.env.VITE_XMLUI_BUILD_MODE": JSON.stringify("INLINE_ALL"),
-        "import.meta.env.VITE_XMLUI_DEV_MODE": JSON.stringify("false"),
+        "import.meta.env.VITE_XMLUI_DEV_MODE": "false",
         "import.meta.env.VITE_MOCK_ENABLED": "true",
         "import.meta.env.VITE_MOCK_WORKER_LOCATION": JSON.stringify("mockApi.js"),
         "import.meta.env.VITE_USED_COMPONENTS_XmluiCodeHightlighter": JSON.stringify("false"),


### PR DESCRIPTION
> **Jon's Claude speaking, Jon asked me to weigh in.** I'm an AI assistant working alongside Jon on Bram (an XMLUI-based desktop shell at https://github.com/judell/bram). While profiling Bram's perf today we traced a console.log firehose back to this repo. Jon reviewed everything below and asked me to file the PR.

## The bug

In standalone bundles, `LoggerService.log()` and every caller routed through it (notably the `xs` lifecycle traces in `handler-logging.ts` — `state:changes`, `handler:start`, `handler:complete`, `component:vars:init`) emit `console.log("[xmlui.log]", ...)` continuously during normal interaction. They should be gated off in production-mode bundles.

The gate exists. It's just broken in two places that interact.

**`xmlui/src/logging/LoggerService.ts:9`** evaluates:
```ts
this.isDev = !!(import.meta.env?.DEV || import.meta.env?.VITE_XMLUI_DEV_MODE);
```

**`xmlui/vite.config.ts:36`** defines (standalone mode):
```ts
"import.meta.env.VITE_XMLUI_DEV_MODE": JSON.stringify("false"),
```

`JSON.stringify("false")` inlines the **literal string** `"false"` into the bundle. The OR resolves to that string, and `!!"false"` is `true` because non-empty strings are truthy in JS. So `isDev` is `true` in every standalone build, every `loggerService.log()` call fires, and the `xs` trace stream fills the devtools console.

## How we noticed

Bram pipes iframe `console.log` calls into its own host trace via an interleave shim, where the volume was unmissable: ~4400 `[xmlui.log]` events in ~1.5 hours of normal interaction, ~13.7 MB of trace, max main-thread drift spiking to 7 seconds. In a vanilla XMLUI app the console output just sits in devtools, so the bug is silent until something tries to read or forward it.

## The fix (two commits, belt + suspenders)

**Commit 1 — `LoggerService.ts`**: make the predicate compare the flag value explicitly so a stringified `"false"` correctly resolves to `false`. Symmetric — also accepts boolean `true` or string `"true"` for opt-in:

```ts
const devMode = import.meta.env?.VITE_XMLUI_DEV_MODE;
this.isDev = !!(
  import.meta.env?.DEV ||
  devMode === true ||
  devMode === "true"
);
```

**Commit 2 — `vite.config.ts`**: inline the standalone flag as the literal boolean token `false` instead of `JSON.stringify("false")`:

```diff
- "import.meta.env.VITE_XMLUI_DEV_MODE": JSON.stringify("false"),
+ "import.meta.env.VITE_XMLUI_DEV_MODE": "false",
```

Matches the style of `"VITE_MOCK_ENABLED": "true"` further down the same block. The `lib` mode (line 113, `"import.meta.env.VITE_XMLUI_DEV_MODE": "import.meta.env.DEV"`) is unchanged and still inlines a real boolean.

Either commit alone fixes the standalone build. Together: the vite config no longer trips the predicate, and the predicate still resolves correctly if a future caller passes a stringified value.

## Regression context

Traced via `git log -S`:

| Date | Commit | What |
|---|---|---|
| 2026-04-30 | `2c5ca8662` / `b230d8074` | vite.config first defined `VITE_XMLUI_DEV_MODE` as `JSON.stringify("false")` for standalone |
| 2026-05-20 | `ad1536b33` | LoggerService gained `?.` optional-chaining (logic unchanged) |
| 2026-06-03 | `a79c91d7a` | LoggerService gained `!!()` wrapper (type cleaner; runtime still truthy on string `"false"`) |

Before 2026-04-30 the flag wasn't defined for standalone, so `import.meta.env?.VITE_XMLUI_DEV_MODE` was `undefined` (falsy) and `isDev` correctly resolved to `false`. The dormant bug has existed for ~5 weeks.

## Verification

- Inspected the rebuilt standalone bundle: `LoggerService` constructor compiles to `let e=\`false\`; this.isDev = e===!0 || e===\`true\`` → `false`. The gated `console.log` at the `log()` method is skipped.
- In Bram after copying the rebuilt umd in: `console.log` event volume in the host trace dropped from thousands per minute to four total across the next session (all benign — the XMLUI startup version banner, one per iframe init).
- `window._xsLogs` still accumulates per the `xsVerbose: true` appGlobal — `pushXsLog` in `handler-logging.ts:211` runs after the (now no-op) `xsConsoleLog` call, so verbose-logging consumers that read the buffer on demand are unaffected.

## Out of scope

Two other entries in the same standalone-mode `define` block use the same `JSON.stringify("false")` pattern: `VITE_USED_COMPONENTS_XmluiCodeHightlighter` and `VITE_USED_COMPONENTS_TableEditor`. Their downstream consumers may intentionally compare against the string, so I left them alone. Happy to look at those in a follow-up if you want — flag in review.
