### PR TITLE
fix(inspector): silence xs trace console mirror

### DIFF
--- a/xmlui/src/components-core/inspector/inspectorUtils.ts
+++ b/xmlui/src/components-core/inspector/inspectorUtils.ts
@@ -29,7 +29,6 @@
  * - `window._xsLastApiStatus` - Map of transactionId -> HTTP status code
  */
 
-import { loggerService } from "../../logging/LoggerService";
 import { currentContext, BOOT_TRACE_ID } from "../audit/correlation";
 import { processAuditEntry } from "../audit/pipeline";
 
@@ -461,13 +460,10 @@ export function createLogEntry(
 }
 
 /**
- * Log to console and loggerService with [xs] prefix.
+ * No-op. Inspector data is captured via pushXsLog; this previously also
+ * mirrored every trace to the browser console, which flooded devtools.
  */
-export function xsConsoleLog(...args: any[]): void {
-  const payload = ["[xs]", ...args];
-  loggerService.log(payload);
-  // console.log(...payload);
-}
+export function xsConsoleLog(..._args: any[]): void {}
 
 // =============================================================================
 // TRACE ID MANAGEMENT


### PR DESCRIPTION
## Summary
- make xsConsoleLog a no-op so xsVerbose writes stay in window._xsLogs without mirroring every trace event to DevTools
- keep Inspector export behavior intact through the existing pushXsLog sink

## Verification
- npx vitest run tests/components-core/inspector-logging.test.ts tests/components-core/inspector/handler-logging.test.ts
- npm run build:xmlui-standalone