### PR TITLE
Add <External>: declarative bridge for app-defined value sources

### DIFF
--- a/xmlui/src/components-core/loader/ExternalLoader.tsx
+++ b/xmlui/src/components-core/loader/ExternalLoader.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef } from "react";
+
+import type {
+  LoaderErrorFn,
+  LoaderInProgressChangedFn,
+  LoaderLoadedFn,
+} from "../abstractions/LoaderRenderer";
+import type { ComponentDef } from "../../abstractions/ComponentDefs";
+import type { ContainerState } from "../rendering/ContainerWrapper";
+import { extractParam } from "../utils/extractParam";
+import { createLoaderRenderer } from "../renderers";
+import { useAppContext } from "../AppContext";
+import { createMetadata } from "../../components/metadata-helpers";
+import { AppError } from "../errors/app-error";
+
+// --- ExternalLoader: wires an app-provided `subscribe` callback into the
+// loader pipeline. The framework's role is narrow — call subscribe on
+// mount with an `emit(value)` function, dispatch every emit as a loader
+// "loaded" event so the value flows through the existing observability
+// machinery, and call the returned unsubscribe on unmount.
+//
+// Subscribe contract: `(emit: (value: any) => void) => unsubscribe | void`.
+// The emit closure is stable for the lifetime of the subscription.
+// Producers may call it synchronously inside subscribe (to seed an
+// initial value) and asynchronously thereafter.
+//
+// Unlike `DataLoader` / `ApiLoader`, this loader does not own any fetch
+// or polling logic. It does not depend on React Query. Errors raised
+// inside subscribe are routed through `loaderError`; the loader stays
+// active and may continue receiving emits afterward.
+
+type ExternalLoaderProps = {
+  loader: ExternalLoaderDef;
+  loaderInProgressChanged: LoaderInProgressChangedFn;
+  loaderIsRefetchingChanged: LoaderInProgressChangedFn;
+  loaderLoaded: LoaderLoadedFn;
+  loaderError: LoaderErrorFn;
+  state: ContainerState;
+};
+
+function ExternalLoader({
+  loader,
+  loaderInProgressChanged,
+  loaderLoaded,
+  loaderError,
+  state,
+}: ExternalLoaderProps) {
+  const appContext = useAppContext();
+
+  // --- Resolve the user-supplied subscribe callback. The XMLUI markup
+  // typically passes a JS function reference via a binding expression
+  // (e.g. `subscribe="{window.subscribeMyState}"`); extractParam
+  // resolves the expression into a usable function value.
+  const subscribeFn = extractParam(state, loader.props.subscribe, appContext);
+  const initialValue = extractParam(state, loader.props.initial, appContext);
+
+  // --- Stash the latest callbacks in refs so we can rewire the
+  // subscription only when the subscribe function identity changes,
+  // not on every render.
+  const loaderLoadedRef = useRef(loaderLoaded);
+  loaderLoadedRef.current = loaderLoaded;
+  const loaderErrorRef = useRef(loaderError);
+  loaderErrorRef.current = loaderError;
+  const loaderInProgressChangedRef = useRef(loaderInProgressChanged);
+  loaderInProgressChangedRef.current = loaderInProgressChanged;
+
+  // --- Seed the initial value once before subscribe runs. Producers
+  // that need a synchronous initial value can either rely on `initial`
+  // or call `emit(seed)` synchronously inside their subscribe body.
+  useEffect(() => {
+    if (initialValue !== undefined) {
+      loaderLoadedRef.current(initialValue);
+    }
+    // Mark not-in-progress: External is always "ready" once mounted.
+    loaderInProgressChangedRef.current(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- Wire the subscription. Re-runs only when subscribeFn identity
+  // changes (which for the common `window.subscribeFoo` case is
+  // effectively never).
+  useEffect(() => {
+    if (typeof subscribeFn !== "function") {
+      if (subscribeFn !== undefined && subscribeFn !== null) {
+        console.warn(
+          "[XMLUI] External: `subscribe` prop must be a function; got " +
+            typeof subscribeFn,
+        );
+      }
+      return;
+    }
+
+    const emit = (value: any) => {
+      loaderLoadedRef.current(value);
+    };
+
+    let unsubscribe: unknown;
+    try {
+      unsubscribe = subscribeFn(emit);
+    } catch (err) {
+      loaderErrorRef.current(AppError.from(err));
+    }
+
+    return () => {
+      if (typeof unsubscribe === "function") {
+        try {
+          (unsubscribe as () => void)();
+        } catch (err) {
+          // Unsubscribe errors are reported but do not propagate; the
+          // component is being torn down regardless.
+          console.error("[XMLUI] External: unsubscribe threw:", err);
+        }
+      }
+    };
+  }, [subscribeFn]);
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Renderer registration
+
+const ExternalLoaderMd = createMetadata({
+  status: "experimental",
+  description:
+    "Bridges an app-defined external value source into XMLUI's reactive " +
+    "model. The `subscribe` prop is a function that receives an `emit` " +
+    "callback; every emit becomes an observable value change. Use for " +
+    "host-bridge values (postMessage, Tauri events, WebSocket pushes, " +
+    "polling caches, DOM observers) that cannot be expressed as a " +
+    "DataSource.",
+  props: {
+    subscribe: {
+      description:
+        "A function with the shape `(emit: (value) => void) => unsubscribe | void`. " +
+        "Called once on mount. May call `emit` synchronously to seed an initial " +
+        "value and asynchronously thereafter. The returned function (if any) is " +
+        "invoked on unmount.",
+      valueType: "any",
+      isRequired: true,
+    },
+    initial: {
+      description:
+        "Initial value to seed before the first emit. If `subscribe` calls " +
+        "`emit` synchronously during registration, the synchronous emit wins.",
+      valueType: "any",
+    },
+  },
+});
+
+type ExternalLoaderDef = ComponentDef<typeof ExternalLoaderMd>;
+
+export const externalLoaderRenderer = createLoaderRenderer(
+  "External",
+  ({
+    loader,
+    state,
+    loaderInProgressChanged,
+    loaderIsRefetchingChanged,
+    loaderLoaded,
+    loaderError,
+  }) => {
+    return (
+      <ExternalLoader
+        loader={loader}
+        state={state}
+        loaderInProgressChanged={loaderInProgressChanged}
+        loaderIsRefetchingChanged={loaderIsRefetchingChanged}
+        loaderLoaded={loaderLoaded}
+        loaderError={loaderError}
+      />
+    );
+  },
+  ExternalLoaderMd,
+);

--- a/xmlui/src/components-core/loader/ExternalLoader.tsx
+++ b/xmlui/src/components-core/loader/ExternalLoader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import type {
   LoaderErrorFn,
@@ -12,6 +12,12 @@ import { createLoaderRenderer } from "../renderers";
 import { useAppContext } from "../AppContext";
 import { createMetadata } from "../../components/metadata-helpers";
 import { AppError } from "../errors/app-error";
+import {
+  getCurrentTrace,
+  pushXsLog,
+  safeStringify,
+  xsConsoleLog,
+} from "../inspector/inspectorUtils";
 
 // --- ExternalLoader: wires an app-provided `subscribe` callback into the
 // loader pipeline. The framework's role is narrow — call subscribe on
@@ -28,6 +34,14 @@ import { AppError } from "../errors/app-error";
 // or polling logic. It does not depend on React Query. Errors raised
 // inside subscribe are routed through `loaderError`; the loader stays
 // active and may continue receiving emits afterward.
+//
+// Inspector instrumentation mirrors DataLoader's xsLog plumbing:
+//  - external:mount        — component mounted (with initial value snapshot)
+//  - external:subscribe    — subscribe() called
+//  - external:emit         — producer pushed a value (payload included)
+//  - external:invalid      — subscribe prop is not a function
+//  - external:error        — subscribe() threw on registration
+//  - external:unsubscribe  — cleanup ran on unmount
 
 type ExternalLoaderProps = {
   loader: ExternalLoaderDef;
@@ -46,6 +60,47 @@ function ExternalLoader({
   state,
 }: ExternalLoaderProps) {
   const appContext = useAppContext();
+  const xsVerbose = appContext.xmluiConfig?.xsVerbose === true;
+  const xsLogMax = Number(appContext.xmluiConfig?.xsVerboseLogMax ?? 200);
+
+  const instanceIdRef = useRef<string>(
+    `ext-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`,
+  );
+  const emitSeqRef = useRef<number>(0);
+
+  // Inspector verbose logging — no-op when xsVerbose is off. Emits a
+  // structured entry to the xs log ring buffer with full External
+  // context. Mirrors the shape DataLoader uses so the Inspector UI's
+  // existing filters/columns light up the same way.
+  const xsLog = useCallback(
+    (kind: string, detail?: Record<string, any>) => {
+      if (!xsVerbose) return;
+      xsConsoleLog(kind, detail);
+      pushXsLog(
+        {
+          ts: Date.now(),
+          perfTs: typeof performance !== "undefined" ? performance.now() : undefined,
+          traceId: getCurrentTrace(),
+          instanceId: instanceIdRef.current,
+          // Reuse dataSourceId field name so existing Inspector columns
+          // surface the id for both DataSource and External rows.
+          dataSourceId: (loader?.props as any)?.id,
+          ownerUid: loader?.uid,
+          ownerFileId: loader?.debug?.source?.fileId,
+          ownerSource: loader?.debug?.source
+            ? { start: loader.debug.source.start, end: loader.debug.source.end }
+            : undefined,
+          text: safeStringify([kind, detail]),
+          kind,
+          eventName: detail?.eventName,
+          uid: detail?.uid ? String(detail.uid) : undefined,
+          componentType: "External",
+        },
+        xsLogMax,
+      );
+    },
+    [xsVerbose, xsLogMax, loader],
+  );
 
   // --- Resolve the user-supplied subscribe callback. The XMLUI markup
   // typically passes a JS function reference via a binding expression
@@ -63,11 +118,17 @@ function ExternalLoader({
   loaderErrorRef.current = loaderError;
   const loaderInProgressChangedRef = useRef(loaderInProgressChanged);
   loaderInProgressChangedRef.current = loaderInProgressChanged;
+  const xsLogRef = useRef(xsLog);
+  xsLogRef.current = xsLog;
 
   // --- Seed the initial value once before subscribe runs. Producers
   // that need a synchronous initial value can either rely on `initial`
   // or call `emit(seed)` synchronously inside their subscribe body.
   useEffect(() => {
+    xsLogRef.current("external:mount", {
+      hasInitial: initialValue !== undefined,
+      initialValuePreview: initialValue !== undefined ? safeStringify(initialValue) : undefined,
+    });
     if (initialValue !== undefined) {
       loaderLoadedRef.current(initialValue);
     }
@@ -82,6 +143,9 @@ function ExternalLoader({
   useEffect(() => {
     if (typeof subscribeFn !== "function") {
       if (subscribeFn !== undefined && subscribeFn !== null) {
+        xsLogRef.current("external:invalid", {
+          subscribeFnType: typeof subscribeFn,
+        });
         console.warn(
           "[XMLUI] External: `subscribe` prop must be a function; got " +
             typeof subscribeFn,
@@ -90,7 +154,14 @@ function ExternalLoader({
       return;
     }
 
+    xsLogRef.current("external:subscribe", {});
+
     const emit = (value: any) => {
+      const seq = (emitSeqRef.current += 1);
+      xsLogRef.current("external:emit", {
+        seq,
+        valuePreview: safeStringify(value),
+      });
       loaderLoadedRef.current(value);
     };
 
@@ -98,10 +169,16 @@ function ExternalLoader({
     try {
       unsubscribe = subscribeFn(emit);
     } catch (err) {
+      xsLogRef.current("external:error", {
+        message: String((err as Error)?.message ?? err),
+      });
       loaderErrorRef.current(AppError.from(err));
     }
 
     return () => {
+      xsLogRef.current("external:unsubscribe", {
+        hadUnsubscribeFn: typeof unsubscribe === "function",
+      });
       if (typeof unsubscribe === "function") {
         try {
           (unsubscribe as () => void)();

--- a/xmlui/src/components-core/rendering/ComponentWrapper.tsx
+++ b/xmlui/src/components-core/rendering/ComponentWrapper.tsx
@@ -233,7 +233,20 @@ function transformNodeWithChildDatasource(node: ComponentDef) {
         when: child.when,
         debug: child.debug,
       });
-    } else if (node.scriptCollected && child?.type === "Fragment" && child.children?.some((c) => c?.type === "DataSource")) {
+    } else if (child?.type === "External") {
+      didResolve = true;
+      if (!loaders) {
+        loaders = [];
+      }
+      loaders.push({
+        uid: child.uid!,
+        type: "External",
+        props: child.props,
+        events: child.events,
+        when: child.when,
+        debug: child.debug,
+      });
+    } else if (node.scriptCollected && child?.type === "Fragment" && child.children?.some((c) => c?.type === "DataSource" || c?.type === "External")) {
       // When a <script> tag and a <DataSource> are siblings, the parser wraps the non-helper
       // siblings in a synthetic Fragment (see transform.ts wrapWithFragment). The parent node
       // will have `scriptCollected` set in exactly this case. We must NOT apply this to
@@ -249,6 +262,15 @@ function transformNodeWithChildDatasource(node: ComponentDef) {
           loaders!.push({
             uid: fragmentChild.uid!,
             type: "DataLoader",
+            props: fragmentChild.props,
+            events: fragmentChild.events,
+            when: fragmentChild.when,
+            debug: fragmentChild.debug,
+          });
+        } else if (fragmentChild?.type === "External") {
+          loaders!.push({
+            uid: fragmentChild.uid!,
+            type: "External",
             props: fragmentChild.props,
             events: fragmentChild.events,
             when: fragmentChild.when,

--- a/xmlui/src/components/ComponentProvider.tsx
+++ b/xmlui/src/components/ComponentProvider.tsx
@@ -131,6 +131,7 @@ import type {
 } from "../components-core/abstractions/LoaderRenderer";
 import { apiLoaderRenderer } from "../components-core/loader/ApiLoader";
 import { dataLoaderRenderer } from "../components-core/loader/DataLoader";
+import { externalLoaderRenderer } from "../components-core/loader/ExternalLoader";
 import { datePickerComponentRenderer } from "./DatePicker/DatePicker";
 import { dateInputComponentRenderer } from "./DateInput/DateInput";
 import { timeInputComponentRenderer } from "./TimeInput/TimeInput";
@@ -875,6 +876,7 @@ export class ComponentRegistry {
 
     this.registerLoaderRenderer(apiLoaderRenderer);
     this.registerLoaderRenderer(dataLoaderRenderer);
+    this.registerLoaderRenderer(externalLoaderRenderer);
 
     this.registerBehavior(labelBehavior);
     this.registerBehavior(animationBehavior);

--- a/xmlui/src/components/ComponentProvider.tsx
+++ b/xmlui/src/components/ComponentProvider.tsx
@@ -291,6 +291,7 @@ import { drawerComponentRenderer } from "./Drawer/Drawer";
  * values declare renderer functions for the built-in property holders.
  */
 const dataSourcePropHolder = createPropHolderComponent("DataSource");
+const externalPropHolder = createPropHolderComponent("External");
 const textNodePropHolder = createPropHolderComponent("TextNode");
 const textNodeCDataPropHolder = createPropHolderComponent("TextNodeCData");
 const includeNavSectionPropHolder = createPropHolderComponent("IncludeNavSection");
@@ -406,6 +407,7 @@ export class ComponentRegistry {
 
     this.registerCoreComponent(SlotHolder);
     this.registerCoreComponent(dataSourcePropHolder);
+    this.registerCoreComponent(externalPropHolder);
     this.registerCoreComponent(textNodePropHolder);
     this.registerCoreComponent(textNodeCDataPropHolder);
     this.registerCoreComponent(includeNavSectionPropHolder);

--- a/xmlui/tests-e2e/external.spec.ts
+++ b/xmlui/tests-e2e/external.spec.ts
@@ -1,0 +1,155 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "../src/testing/fixtures";
+
+async function installExternalBridge(
+  page: Page,
+  options: { syncValue?: Record<string, any> | null } = {},
+) {
+  await page.addInitScript((syncValue) => {
+    const bridge = {
+      emitters: [] as Array<(value: any) => void>,
+      subscribeCount: 0,
+      unsubscribeCount: 0,
+    };
+
+    (window as any).__externalBridge = bridge;
+    (window as any).__externalSubscribe = (emit: (value: any) => void) => {
+      bridge.subscribeCount++;
+      bridge.emitters.push(emit);
+      if (syncValue !== null) {
+        emit(syncValue);
+      }
+      return () => {
+        bridge.unsubscribeCount++;
+      };
+    };
+    (window as any).__externalEmit = (value: any) => {
+      bridge.emitters.forEach((emit) => emit(value));
+    };
+    (window as any).__externalStats = () => ({
+      subscribeCount: bridge.subscribeCount,
+      unsubscribeCount: bridge.unsubscribeCount,
+      emitterCount: bridge.emitters.length,
+    });
+  }, "syncValue" in options ? options.syncValue : { label: "sync", tick: 1 });
+}
+
+test.describe("External", () => {
+  test("exposes initial and emitted values through loader state", async ({ initTestBed, page }) => {
+    await installExternalBridge(page, { syncValue: null });
+
+    await initTestBed(`
+      <Fragment>
+        <External
+          id="externalSource"
+          initial="{{ label: 'initial', tick: 0 }}"
+          subscribe="{window.__externalSubscribe}"
+        />
+        <Text
+          testId="value"
+          value="{externalSource.value.label + ':' + externalSource.value.tick}"
+        />
+        <Text
+          testId="loaded"
+          value="{externalSource.loaded ? 'loaded' : 'not-loaded'}"
+        />
+      </Fragment>
+    `);
+
+    await expect(page.getByTestId("value")).toHaveText("initial:0");
+    await expect(page.getByTestId("loaded")).toHaveText("loaded");
+    await expect.poll(() => page.evaluate(() => (window as any).__externalStats())).toMatchObject({
+      subscribeCount: 1,
+      unsubscribeCount: 0,
+      emitterCount: 1,
+    });
+
+    await page.evaluate(() => {
+      (window as any).__externalEmit({ label: "async", tick: 2 });
+    });
+
+    await expect(page.getByTestId("value")).toHaveText("async:2");
+  });
+
+  test("emitted values are observable by ChangeListener", async ({ initTestBed, page }) => {
+    await installExternalBridge(page);
+
+    await initTestBed(`
+      <Fragment var.lastTick="{0}" var.changeCount="{0}">
+        <External id="externalSource" subscribe="{window.__externalSubscribe}" />
+        <ChangeListener
+          listenTo="{externalSource.value.tick}"
+          onDidChange="(change) => { lastTick = change.newValue; changeCount++; }"
+        />
+        <Text testId="lastTick" value="{lastTick}" />
+        <Text testId="changeCount" value="{changeCount}" />
+      </Fragment>
+    `);
+
+    await expect(page.getByTestId("lastTick")).toHaveText("1");
+    await expect(page.getByTestId("changeCount")).toHaveText("1");
+
+    await page.evaluate(() => {
+      (window as any).__externalEmit({ label: "async", tick: 2 });
+    });
+
+    await expect(page.getByTestId("lastTick")).toHaveText("2");
+    await expect(page.getByTestId("changeCount")).toHaveText("2");
+  });
+
+  test("calls unsubscribe when unmounted by a when condition", async ({ initTestBed, page }) => {
+    await installExternalBridge(page);
+
+    await initTestBed(`
+      <Fragment var.showExternal="{true}">
+        <External
+          id="externalSource"
+          when="{showExternal}"
+          subscribe="{window.__externalSubscribe}"
+        />
+        <Button testId="toggle" label="Toggle" onClick="showExternal = !showExternal" />
+        <Text
+          testId="value"
+          value="{externalSource.value ? externalSource.value.label : 'none'}"
+        />
+      </Fragment>
+    `);
+
+    await expect(page.getByTestId("value")).toHaveText("sync");
+    await expect.poll(() => page.evaluate(() => (window as any).__externalStats())).toMatchObject({
+      subscribeCount: 1,
+      unsubscribeCount: 0,
+    });
+
+    await page.getByTestId("toggle").click();
+
+    await expect.poll(() => page.evaluate(() => (window as any).__externalStats())).toMatchObject({
+      subscribeCount: 1,
+      unsubscribeCount: 1,
+    });
+  });
+
+  test("works inside App when preceded by a script tag", async ({ initTestBed, page }) => {
+    await installExternalBridge(page);
+
+    await initTestBed(`
+      <App>
+        <script>
+          var greeting = "hello";
+        </script>
+        <External id="externalSource" subscribe="{window.__externalSubscribe}" />
+        <Pages>
+          <Page url="/">
+            <Text
+              testId="value"
+              value="{greeting + ':' + externalSource.value.label + ':' + externalSource.value.tick}"
+            />
+          </Page>
+        </Pages>
+      </App>
+    `);
+
+    await expect(page.getByTestId("value")).toHaveText("hello:sync:1");
+  });
+});


### PR DESCRIPTION
# Proposal: `<External>` — declarative bridge for app-defined value sources

Jon's Claude speaking, Jon asked me to weigh in.

We found ourself needing a new primitive. The branch is
`judell/external-component` on `xmlui-org/xmlui`. Three commits,
~250 lines net.

`DataSource` and `ApiLoader` cover server-state (HTTP via React
Query, imperative via `APICall`). Bram has a long list of
**push-driven value sources** that aren't HTTP — and each one had
to invent its own imperative dance to feed XMLUI's reactive
model. A few concrete examples:

- The pasted-image strip below the message-agent input (and below
  each expanded worklist row) — was a 4 Hz `<Timer>` polling
  `window.bramPendingPastedImageCountForTarget(...)` per row,
  even when nothing had changed.
- The agent-confirmation menu (AgentMenu) — listened to two Tauri
  events (`turn-state-changed`, `pty-menu-changed`) inside the
  component's `onInit`, but only to bump a `var.menuTick`
  counter. The actual menu was computed by an xs function that
  reads `window.bramAgentMenu`, which XMLUI can't observe. The
  `menuTick >= 0` tautology in the consumer binding existed
  purely to make the binding engine include `menuTick` as a
  reactive dependency.
- The agent-status row in the AppHeader (working / finished /
  idle / provider) — driven by `agent-status-changed` Tauri
  events whose handler wrote to a `var.mainAgentStatus` from
  inside an `onInit` arrow body.
- The toolbar pending-menu visualization, the worklist refetch on
  `worklist-changed`, the inflight-claim spinner, the conversation
  pane's reaction to `agent-turn-end` / `agent-turn-killed` —
  five more subscribers in Workspace.xmlui's `onInit`.
- Five sibling tabs (Commits, Sessions, Issues, Settings,
  Feedback) each carried their own `subscribeTauriEvent(...)` in
  their `onInit` to refetch a DataSource when a host event fires.
- The voice-transcript path that lands speech-to-text into the
  message-agent input or a focused worklist row's feedback box.
  This one was the breaking point — across mb / fb / shell
  targets, the bare-name `iframeTrace(...)` calls inside
  voiceStop's arrow body silently aborted at identifier analysis,
  and xs module-var writes from arrow bodies didn't propagate
  through XMLUI's reactivity at all. We spent hours layer-by-
  layer debugging before settling on a window-side `CustomEvent`
  dispatch that an External listens to.
- The right-pane size readout in the Status tab, driven by a
  custom `subscribeRightPaneSize` callback in Main.xmlui's
  `onInit` that writes a `var.rightPaneSize`.
- The talk-session JSONL rotation refetch in Workspace.xmlui,
  driven by a custom `subscribeTalkSessionChange` callback,
  debounced 400 ms.

Every one of these wanted to express the same idea: "this value
arrives via an app-defined push channel; please make it observable
in the markup like a DataSource is." None of them could, so each
invented an imperative `onInit` blob that:

- doesn't compose with the loader pipeline (no `.value`, no
  ChangeListener observation, no Inspector visibility),
- forces an `emitEvent` / tick-counter / mirror-var workaround to
  nudge XMLUI's reactivity into noticing the change,
- ends up as a multi-statement attribute body that the identifier
  analyzer can silently abort on bare-name calls.

## The proposed primitive

```xml
<External
  id="agentStatus"
  initial="{null}"
  subscribe="{window.bramSubscribeAgentStatus()}" />

<ChangeListener
  listenTo="{agentStatus.value && agentStatus.value.verb}"
  onDidChange="(c) => lastSeenVerb = c.newValue" />
```

The `subscribe` prop is a function
`(emit: (value) => void) => unsubscribe`. Called once on mount.
Producers may call `emit` synchronously to seed an initial value
and asynchronously thereafter. Emits flow through the existing
`loaderLoaded` pipeline so `value` reads, ChangeListener
observation, and Inspector instrumentation light up the same way
they do for `DataSource`. The returned function (if any) runs on
unmount.

xsLog instrumentation: `external:mount`, `external:subscribe`,
`external:emit`, `external:unsubscribe`, `external:invalid`,
`external:error` — parallel to `DataLoader`'s entries.

## Real-world adoption

We applied it in 17 sites in Bram today. Four patterns emerged:

1. **Per-target factory** (PastedImageStrip): producer-side
   pub/sub registry keyed on `$props.target`; one closure
   memoized per target. Retired the 4 Hz Timer.
2. **Generic event-name factory**
   (`bramSubscribeTauriEvent(eventName)`): memoizes per event,
   wraps `subscribeTauriEvent`, emits `{tick, payload}` so
   consumers can listen on `.tick` or read `.payload`. Used for
   10 Tauri subscribers across Main.xmlui, Workspace.xmlui, and
   five sibling component files.
3. **Custom-API factory**
   (`bramSubscribeRightPaneSize`, `bramSubscribeTalkSessionChange`):
   wraps existing non-Tauri subscribers in the same
   `(emit) => unsubscribe` signature.
4. **CustomEvent bridge** (voice arrival): producer-side
   `window.dispatchEvent(new CustomEvent('bram:voice-arrival',
   ...))` from inside an arrow-body callback that XMLUI's xs
   evaluator can't reliably write reactive vars from. The
   External listens to the window event and bridges into the
   loader pipeline. This was the path that finally landed voice
   round-trip end-to-end.

Net result: zero `subscribeTauriEvent` or custom-API subscribe
call in any `onInit` attribute across the entire `app/tools/`
tree. The imperative-subscriber pattern is fully retired.

