### PR TITLE
List: keep scrollAnchor="bottom" follow active for content-sized lists

### DIFF
--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -582,6 +582,74 @@ test.describe("Basic Functionality", () => {
     await expect(driver.component).toContainText("Item 1");
   });
 
+  test("scrollAnchor=bottom follows newly appended items", async ({
+    initTestBed,
+    page,
+    createListDriver,
+  }) => {
+    // A large list so virtualization actually drops off-screen rows (otherwise
+    // every row stays in the DOM and scroll position is unobservable via text).
+    await initTestBed(`
+      <Fragment var.items="{Array.from({length: 100}).map((_, i) => ({ id: i + 1, name: 'Item ' + (i + 1) }))}">
+        <Button testId="add" label="Add"
+          onClick="items = [...items, { id: items.length + 1, name: 'Item ' + (items.length + 1) }]" />
+        <List testId="testList" scrollAnchor="bottom" height="80px" data="{items}">
+          <Text>{$item.name}</Text>
+        </List>
+      </Fragment>
+    `);
+    const driver = await createListDriver("testList");
+    await expect(driver.component).toBeVisible();
+
+    // Starts pinned to the bottom: newest row rendered, oldest virtualized away.
+    // (exact match so "Item 1" does not also match "Item 10", "Item 100", ...)
+    await expect(page.getByText("Item 100", { exact: true })).toBeVisible();
+    await expect(page.getByText("Item 1", { exact: true })).toHaveCount(0);
+
+    // Appending follows the bottom to each newest item.
+    for (let i = 0; i < 3; i++) {
+      await page.getByTestId("add").click();
+      await page.waitForTimeout(100);
+    }
+    await expect(page.getByText("Item 103", { exact: true })).toBeVisible();
+    await expect(page.getByText("Item 1", { exact: true })).toHaveCount(0);
+  });
+
+  // A content-sized (maxHeight) bottom-anchored list grows from the top while it
+  // fits, then keeps following the bottom once content exceeds the cap, rather
+  // than stranding the user at the top -- exercising follow across the
+  // fits -> overflows transition for the maxHeight case.
+  test("scrollAnchor=bottom with maxHeight follows past the overflow cap", async ({
+    initTestBed,
+    page,
+    createListDriver,
+  }) => {
+    await initTestBed(`
+      <Fragment var.items="{[{ id: 1, name: 'Item 1' }]}">
+        <Button testId="add" label="Add"
+          onClick="items = [...items, { id: items.length + 1, name: 'Item ' + (items.length + 1) }]" />
+        <List testId="testList" scrollAnchor="bottom" maxHeight="80px" data="{items}">
+          <Text>{$item.name}</Text>
+        </List>
+      </Fragment>
+    `);
+    const driver = await createListDriver("testList");
+    await expect(driver.component).toBeVisible();
+
+    // One item fits under the 80px cap, so the top item is visible.
+    await expect(page.getByText("Item 1", { exact: true })).toBeVisible();
+
+    // Append ONE row at a time across the cap; the list must keep following the
+    // newest row through the fits -> overflows transition.
+    for (let i = 0; i < 60; i++) {
+      await page.getByTestId("add").click();
+      await page.waitForTimeout(30);
+    }
+    // Followed to the bottom: newest rendered, oldest virtualized away.
+    await expect(page.getByText("Item 61", { exact: true })).toBeVisible();
+    await expect(page.getByText("Item 1", { exact: true })).toHaveCount(0);
+  });
+
   test("handles empty data with default display", async ({ initTestBed, createListDriver }) => {
     await initTestBed(`<List data="{[]}"/>`);
     const driver = await createListDriver();

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -715,6 +715,13 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
   const scrollElementRef = hasOutsideScroll ? scrollRef : parentRef;
 
   const shouldStickToBottom = useRef(scrollAnchor === "bottom");
+  // virtua's onScroll can't distinguish our own/auto scrolls from genuine user
+  // scrolls. A content-sized (e.g. maxHeight) bottom-anchored list grows from
+  // the top, so when content first overflows, the auto scroll-to-bottom would
+  // otherwise be read as "the user scrolled up" and follow would stop. We set
+  // this flag around our own scrollToIndex calls and ignore onScroll while set,
+  // so only a real user scroll can turn off stick-to-bottom.
+  const programmaticScroll = useRef(false);
   const [expanded, setExpanded] = useState<Record<any, boolean>>(EMPTY_OBJECT);
   const toggleExpanded = useCallback((id: any, isExpanded: boolean) => {
     setExpanded((prev) => ({ ...prev, [id]: isExpanded }));
@@ -919,8 +926,12 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     if (rows.length && scrollAnchor === "bottom" && !initiallyScrolledToBottom.current) {
       initiallyScrolledToBottom.current = true;
       requestAnimationFrame(() => {
+        programmaticScroll.current = true;
         virtualizerRef.current?.scrollToIndex(rows.length - 1, {
           align: "end",
+        });
+        requestAnimationFrame(() => {
+          programmaticScroll.current = false;
         });
       });
     }
@@ -930,8 +941,12 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     if (!virtualizerRef.current) return;
     if (!shouldStickToBottom.current) return;
     requestAnimationFrame(() => {
+      programmaticScroll.current = true;
       virtualizerRef.current?.scrollToIndex(rows.length - 1, {
         align: "end",
+      });
+      requestAnimationFrame(() => {
+        programmaticScroll.current = false;
       });
     });
   }, [rows]);
@@ -991,7 +1006,7 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
   const onScroll = useCallback(
     (offset) => {
       if (!virtualizerRef.current) return;
-      if (scrollAnchor === "bottom") {
+      if (scrollAnchor === "bottom" && !programmaticScroll.current) {
         // The sum may not be 0 because of sub-pixel value when browser's window.devicePixelRatio has decimal value
         shouldStickToBottom.current =
           offset - virtualizerRef.current.scrollSize + virtualizerRef.current.viewportSize >= -1.5;


### PR DESCRIPTION
Jon's Claude Code speaking — Jon asked me to open this PR.

## Motivation

This came out of real use in **Bram** (Jon's Tauri desktop shell for AI-assisted development). Bram's Worklist "Chat" pane streams the agent's latest response into a `List` — each assistant text block is a row — and the pane should follow the newest line as it streams, while letting you scroll up to read without being yanked back down. We wanted the box to size to its content up to a cap (`maxHeight="60vh"`): short replies hug their content with no leading gap, long ones cap and scroll.

With `scrollAnchor="bottom"`, a fixed `height` worked, but the `maxHeight` (content-sized) case stranded the view at the **top** the moment content first overflowed the cap — a scrollbar appeared but follow never engaged. That pointed at `onScroll` clearing stick-to-bottom on a scroll the component itself had initiated.

## What

`List` with `scrollAnchor="bottom"` auto-follows new content only while an internal `shouldStickToBottom` flag is set, and `onScroll` recomputes that flag from the scroll position on every scroll. Because virtua's `onScroll` reports only an offset — with no indication of whether the scroll was the user's or the component's own — an auto scroll-to-bottom (or a layout shift from content growth) can be misread as "the user scrolled up" and turn follow off. With a content-sized list that grows from the top, the instant content first overflows the scroll position is still at the top.

## Change

Track our own programmatic `scrollToIndex` calls with a ref — set immediately before each call, cleared a frame later — and skip the `onScroll` recompute while it's set. Now only a genuine user scroll can clear stick-to-bottom; our own/auto scrolls leave it intact. (~17 lines in `ListReact.tsx`.)

Result: a `maxHeight` bottom-anchored list grows from the top with no leading gap, then follows the bottom once it caps — while still pausing follow when the user scrolls up to read, and resuming at the bottom.

## Tests

Two follow-behavior tests in `List.spec.ts` (the suite previously had only render-level `scrollAnchor` checks): follows newly appended items (fixed height), and follows past the overflow cap (`maxHeight`).

Honest note: these verify the intended follow behavior but pass with or without the patch. The specific failure surfaced in Bram, whose data path replaces the whole list array each poll while content streams — which I could not reproduce in an isolated `List`. The change is a defensive correctness improvement: `onScroll` should not infer user intent from a scroll the component initiated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
