### PR TITLE
List: public scroll event + robust scrollAnchor="bottom" follow

### DIFF
--- a/xmlui/src/components/List/List.md
+++ b/xmlui/src/components/List/List.md
@@ -1904,6 +1904,32 @@ item as its only argument.
 
 %-EVENT-END
 
+%-EVENT-START scroll
+
+This event fires as the user scrolls the list. The handler receives an object describing the
+current scroll state: `scrollTop` (the current scroll offset), `scrollHeight` (the total
+scrollable size), `viewportSize` (the visible size), and `atEnd` (`true` when the list is
+scrolled to within ~1.5px of the bottom).
+
+The event fires only for user-driven scrolls; the list's own programmatic scrolls and its
+`scrollAnchor="bottom"` auto-follow do **not** trigger it. This makes it suitable for
+implementing follow-newest plus read-pause: track `atEnd` from this event, and when new data
+arrives call [`scrollToBottom()`](#scrolltobottom) only while the user is still at the end.
+
+```xmlui copy {4}
+<App var.atBottom="{true}">
+  <Text>At bottom: {atBottom}</Text>
+  <List
+    data='{[...]}'
+    scrollAnchor="bottom"
+    onScroll="(e) => atBottom = e.atEnd">
+    <Text>{$item.name}</Text>
+  </List>
+</App>
+```
+
+%-EVENT-END
+
 %-EVENT-START selectAllAction
 
 ```xmlui copy {4}

--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -2365,3 +2365,70 @@ test.describe("groupBy with function", () => {
     await expect(headers.nth(1)).toContainText("Group: fruit");
   });
 });
+
+test.describe("scroll event", () => {
+  // A long, bounded list so the viewport actually scrolls. Built in JS as an
+  // array-literal expression (matching the other tests' `data="{[...]}"`
+  // style) rather than an in-markup Array.from, which the expression engine
+  // doesn't evaluate.
+  const longData =
+    "[" +
+    Array.from({ length: 50 }, (_, i) => `{id:${i},name:'Item ${i}'}`).join(",") +
+    "]";
+
+  test("scroll event fires on user scroll and reports scroll state", async ({
+    initTestBed,
+    createListDriver,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <List height="100px" data="{${longData}}"
+        onScroll="(e) => testState = { atEnd: e.atEnd, st: typeof e.scrollTop, sh: typeof e.scrollHeight, vs: typeof e.viewportSize }">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+
+    // User scroll to the bottom: event fires, atEnd is true, payload fully typed.
+    await driver.scrollTo("bottom");
+    await expect
+      .poll(async () => (await testStateDriver.testState())?.atEnd)
+      .toEqual(true);
+    const atBottom = await testStateDriver.testState();
+    expect(atBottom.st).toEqual("number");
+    expect(atBottom.sh).toEqual("number");
+    expect(atBottom.vs).toEqual("number");
+
+    // User scroll back to the top: atEnd flips to false.
+    await driver.scrollTo("top");
+    await expect
+      .poll(async () => (await testStateDriver.testState())?.atEnd)
+      .toEqual(false);
+  });
+
+  test("scroll event does not fire for the list's own programmatic scroll", async ({
+    initTestBed,
+    createListDriver,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <List height="100px" scrollAnchor="bottom" data="{${longData}}"
+        onScroll="(e) => testState = (testState || 0) + 1">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+
+    // scrollAnchor="bottom" pins to the end on mount — the list's own
+    // programmatic scroll. Confirm it actually landed at the bottom (so this
+    // isn't a vacuous test): the last item is rendered.
+    await expect(driver.component).toContainText("Item 49");
+    // That programmatic auto-follow must NOT have emitted the public event.
+    expect(await testStateDriver.testState()).toEqual(null);
+
+    // A genuine user scroll up DOES emit it. virtua can fire more than one
+    // tick for a single jump, so assert "fired" rather than an exact count.
+    await driver.scrollTo("top");
+    await expect
+      .poll(async () => (await testStateDriver.testState()) !== null)
+      .toBe(true);
+  });
+});

--- a/xmlui/src/components/List/List.tsx
+++ b/xmlui/src/components/List/List.tsx
@@ -246,6 +246,22 @@ export const ListMd = createMetadata({
         item: "The clicked list row item.",
       },
     },
+    scroll: {
+      description:
+        `This event fires as the user scrolls the list. The handler receives an object ` +
+        `describing the current scroll state. It is only fired for user-driven scrolls; ` +
+        `the list's own programmatic and auto-follow scrolls do not trigger it. Use it ` +
+        `together with the \`atEnd\` flag and the \`scrollToBottom()\` method to implement ` +
+        `follow-newest and read-pause behavior.`,
+      signature:
+        "scroll(event: { scrollTop: number, scrollHeight: number, viewportSize: number, atEnd: boolean }): void",
+      parameters: {
+        event:
+          "The scroll state: `scrollTop` (current scroll offset), `scrollHeight` (total " +
+          "scrollable size), `viewportSize` (visible size), and `atEnd` (true when scrolled " +
+          "to within ~1.5px of the bottom).",
+      },
+    },
     selectionDidChange: {
       description:
         `This event is triggered when the list's current selection changes. ` +
@@ -680,6 +696,7 @@ const ListWithSelection = memo(function ListWithSelection({
       onPasteAction={lookupEventHandler("pasteAction")}
       onDeleteAction={lookupEventHandler("deleteAction")}
       rowDoubleClick={lookupEventHandler("rowDoubleClick")}
+      onScroll={lookupEventHandler("scroll")}
       keyBindings={extractValue(node.props.keyBindings)}
       itemRenderer={stableItemRenderer}
       sectionRenderer={stableSectionRenderer}

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -948,15 +948,52 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     if (!virtualizerRef.current) return;
     if (!shouldStickToBottom.current) return;
     requestAnimationFrame(() => {
+      const v = virtualizerRef.current;
+      if (!v) return;
       programmaticScroll.current = true;
-      virtualizerRef.current?.scrollToIndex(rows.length - 1, {
-        align: "end",
-      });
+      // Scroll to the absolute bottom of the scrollable content rather than to
+      // the last item's end: while a newly appended item is still measuring
+      // (e.g. async Markdown streaming in), aligning to its current end can land
+      // a hair short of the true bottom. scrollTo(scrollSize) clamps to the real
+      // bottom regardless of item boundaries or trailing space.
+      v.scrollTo(v.scrollSize);
       requestAnimationFrame(() => {
         programmaticScroll.current = false;
       });
     });
   }, [rows]);
+
+  // Re-assert stick-to-bottom when the content GROWS while we are following.
+  // The effect above fires on `rows` (data) changes, but children that lay out
+  // asynchronously — Markdown, images, fold/unfold — keep growing *after* that
+  // scroll, below the fold. virtua's onScroll fires only on real scroll (not on
+  // content-height growth) and virtua does not auto-stick on append, so without
+  // this the list lands "almost" at the bottom and drifts up as late-measuring
+  // content settles. A ResizeObserver on the content wrapper catches exactly
+  // those size changes; we re-scroll only while shouldStickToBottom is set, so a
+  // user who scrolled up to read is never yanked back down.
+  const hasRows = rows.length > 0;
+  useEffect(() => {
+    if (scrollAnchor !== "bottom") return;
+    if (typeof ResizeObserver === "undefined") return;
+    const container = parentRef.current?.querySelector("[data-list-container]");
+    if (!container) return;
+    const observer = new ResizeObserver(() => {
+      if (!shouldStickToBottom.current) return;
+      if (programmaticScroll.current) return;
+      const v = virtualizerRef.current;
+      if (!v) return;
+      programmaticScroll.current = true;
+      // Absolute bottom (see the [rows] effect above) — robust to a still-
+      // measuring trailing item, which is exactly what the observer catches.
+      v.scrollTo(v.scrollSize);
+      requestAnimationFrame(() => {
+        programmaticScroll.current = false;
+      });
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [scrollAnchor, hasRows]);
 
   const isFetchingPrevPage = useRef(false);
   const tryToFetchPrevPage = useCallback(() => {
@@ -1010,19 +1047,35 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     }
   }, [rows.length, tryToFetchNextPage, tryToFetchPrevPage]);
 
+  const lastScrollOffset = useRef(0);
   const handleVirtuaScroll = useCallback(
     (offset) => {
       if (!virtualizerRef.current) return;
       // The sum may not be 0 because of sub-pixel value when browser's window.devicePixelRatio has decimal value
       const atEnd =
         offset - virtualizerRef.current.scrollSize + virtualizerRef.current.viewportSize >= -1.5;
+      const prevOffset = lastScrollOffset.current;
+      lastScrollOffset.current = offset;
+      const movedTowardTop = offset < prevOffset - 0.5;
+      const offsetChanged = Math.abs(offset - prevOffset) > 0.5;
       if (scrollAnchor === "bottom" && !programmaticScroll.current) {
-        shouldStickToBottom.current = atEnd;
+        // Stop following only on a genuine upward user scroll. When appended
+        // content grows below the fold, virtua fires onScroll with the SAME
+        // offset against a larger scrollSize, so atEnd is momentarily false —
+        // that must NOT be read as "the user scrolled up", or follow would die
+        // on every new item. In that case leave the flag unchanged; the
+        // re-stick effect/observer pins us back to the true bottom.
+        if (atEnd) {
+          shouldStickToBottom.current = true;
+        } else if (movedTowardTop) {
+          shouldStickToBottom.current = false;
+        }
       }
-      // Report scroll state to consumers, but only for user-driven scrolls —
-      // the List's own/auto scrolls are guarded by programmaticScroll so they
-      // don't emit spurious user-scroll events.
-      if (!programmaticScroll.current) {
+      // Report scroll state to consumers, but only for genuine user scrolls
+      // (the offset actually moved) and never during our own/auto programmatic
+      // scrolls — so a content-growth tick can't masquerade as the user
+      // leaving the bottom.
+      if (!programmaticScroll.current && offsetChanged) {
         onScroll?.({
           scrollTop: offset,
           scrollHeight: virtualizerRef.current.scrollSize,

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -263,6 +263,12 @@ type DynamicHeightListProps = {
   onPasteAction?: AsyncFunction;
   onDeleteAction?: AsyncFunction;
   rowDoubleClick?: (item: any) => void;
+  onScroll?: (event: {
+    scrollTop: number;
+    scrollHeight: number;
+    viewportSize: number;
+    atEnd: boolean;
+  }) => void;
   keyBindings?: Record<string, string>;
 };
 
@@ -691,6 +697,7 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     onPasteAction,
     onDeleteAction,
     rowDoubleClick,
+    onScroll,
     keyBindings = defaultProps.keyBindings,
     ...rest
   }: DynamicHeightListProps,
@@ -1003,18 +1010,30 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     }
   }, [rows.length, tryToFetchNextPage, tryToFetchPrevPage]);
 
-  const onScroll = useCallback(
+  const handleVirtuaScroll = useCallback(
     (offset) => {
       if (!virtualizerRef.current) return;
+      // The sum may not be 0 because of sub-pixel value when browser's window.devicePixelRatio has decimal value
+      const atEnd =
+        offset - virtualizerRef.current.scrollSize + virtualizerRef.current.viewportSize >= -1.5;
       if (scrollAnchor === "bottom" && !programmaticScroll.current) {
-        // The sum may not be 0 because of sub-pixel value when browser's window.devicePixelRatio has decimal value
-        shouldStickToBottom.current =
-          offset - virtualizerRef.current.scrollSize + virtualizerRef.current.viewportSize >= -1.5;
+        shouldStickToBottom.current = atEnd;
+      }
+      // Report scroll state to consumers, but only for user-driven scrolls —
+      // the List's own/auto scrolls are guarded by programmaticScroll so they
+      // don't emit spurious user-scroll events.
+      if (!programmaticScroll.current) {
+        onScroll?.({
+          scrollTop: offset,
+          scrollHeight: virtualizerRef.current.scrollSize,
+          viewportSize: virtualizerRef.current.viewportSize,
+          atEnd,
+        });
       }
       tryToFetchPrevPage();
       tryToFetchNextPage();
     },
-    [scrollAnchor, tryToFetchNextPage, tryToFetchPrevPage],
+    [scrollAnchor, onScroll, tryToFetchNextPage, tryToFetchPrevPage],
   );
 
   const scrollToBottom = useEvent(() => {
@@ -1107,7 +1126,7 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
                   ref={virtualizerRef}
                   scrollRef={scrollElementRef}
                   shift={shift}
-                  onScroll={onScroll}
+                  onScroll={handleVirtuaScroll}
                   startMargin={startMargin}
                   item={Item as CustomItemComponent}
                 >


### PR DESCRIPTION
Jon's Claude speaking — Jon asked me to open this PR on his behalf.

Builds on #3595 (merged). Three commits.

## 1. Add a public `scroll` event

Exposes the List's scroll state to consumers via a new `scroll` event, so
follow-newest and read-pause can be implemented without DOM access or
relying on the opaque `scrollAnchor` internals.

The handler receives `{ scrollTop, scrollHeight, viewportSize, atEnd }`,
where `atEnd` is true within ~1.5px of the bottom. The event reuses the
existing programmatic-scroll guard, so it fires only for user-driven
scrolls — the list's own and auto-follow scrolls do not emit it. Paired
with the existing `scrollToBottom()` method, a consumer can follow new
content only while the user is still at the end.

## 2. Harden `scrollAnchor="bottom"` follow through async content

Three fixes so a bottom-anchored list stays pinned to the true bottom as
content settles and streams:

- **Re-stick on content growth** via a ResizeObserver on the content
  wrapper, so async Markdown/images settling after the initial scroll no
  longer leave the list landing "almost" at the bottom.
- **Don't mistake content growth for a user scroll** — follow stops only
  on a genuine upward scroll (`scrollTop` actually decreases).
- **Land on the absolute bottom** with `scrollTo(scrollSize)` rather than
  `scrollToIndex(last, align:"end")`, so a still-measuring trailing item
  can't leave it a hair short.

## 3. Tests

A new `scroll event` describe in `List.spec.ts`:

- The event fires on a user scroll and reports a fully-typed
  `{ scrollTop, scrollHeight, viewportSize, atEnd }` payload, with `atEnd`
  true at the bottom and false after scrolling back up.
- The event does **not** fire for the list's own programmatic scroll: a
  `scrollAnchor="bottom"` auto-follow lands at the end on mount without
  emitting, while a subsequent genuine user scroll does emit. (The guard
  test asserts "fired" rather than an exact count, since virtua can emit
  more than one tick for a single jump.)

## Why

This is for a single bounded, self-following list — follow while the user
is at the bottom, pause the moment they scroll up to read. These give it
explicit, native control instead of DOM hacks.

## Files

- `xmlui/src/components/List/ListReact.tsx` — emit the public event; gate on the programmatic-scroll guard; re-stick on growth
- `xmlui/src/components/List/List.tsx` — register the `scroll` event in metadata
- `xmlui/src/components/List/List.md` — document it with an example
- `xmlui/src/components/List/List.spec.ts` — tests for the event + the guard
