### PR TITLE
Rename the External component to PushSource

### DIFF
--- a/website/content/docs/pages/howto/bridge-a-host-value-with-pushsource.md
+++ b/website/content/docs/pages/howto/bridge-a-host-value-with-pushsource.md
@@ -1,0 +1,48 @@
+# Bridge a host value into reactive state with PushSource
+
+`PushSource` is the push analogue of `DataSource`: where `DataSource` *pulls*
+(fetch / poll), `PushSource` *receives* values pushed to it. Use it to bring a
+host-provided value stream — `postMessage`, Tauri events, a WebSocket, a
+polling cache, a DOM observer — into XMLUI's reactive model, where it behaves
+like any other observable value.
+
+The `subscribe` prop is a function with the shape
+`(emit) => unsubscribe | void`. XMLUI calls it once on mount, handing it an
+`emit(value)` callback; every `emit` becomes an observable value change. The
+returned function (if any) runs on unmount. Give `initial` a seed value to
+render before the first `emit`.
+
+```xmlui-pg copy display name="Subscribe a host value stream"
+<App>
+  <!-- window.subscribeAgentStatus is provided by the host shell; it calls
+       emit(...) whenever the status changes and returns an unsubscribe fn. -->
+  <PushSource
+    id="agentStatus"
+    initial="{{ state: 'idle' }}"
+    subscribe="{window.subscribeAgentStatus}" />
+
+  <Text value="Agent is {agentStatus.value.state}" />
+</App>
+```
+
+`agentStatus.value` holds the latest emitted value and updates every binding
+that reads it. `agentStatus.loaded` is `true` once the source is mounted.
+
+**The `subscribe` contract:**
+
+```js
+// (emit) => unsubscribe | void
+function subscribeAgentStatus(emit) {
+  const handler = (e) => emit(e.detail);
+  window.addEventListener("agent-status", handler);
+  emit({ state: "idle" });            // optional synchronous seed
+  return () => window.removeEventListener("agent-status", handler);
+}
+```
+
+- Call `emit` synchronously inside `subscribe` to seed a first value (it wins
+  over `initial`), and asynchronously thereafter for every update.
+- Return an unsubscribe function so the source cleans up when the component
+  unmounts (or a `when` condition hides it).
+- `subscribe` lives in host/app JavaScript, not in XMLUI expressions — the
+  point of `PushSource` is to bridge things the markup can't express itself.

--- a/website/content/docs/pages/howto/react-to-pushed-values-with-changelistener.md
+++ b/website/content/docs/pages/howto/react-to-pushed-values-with-changelistener.md
@@ -1,0 +1,43 @@
+# Run a side effect when a PushSource value changes
+
+Binding to `PushSource.value` re-renders the UI automatically. When you need a
+*side effect* on each pushed value — refetch data, show a toast, advance a
+counter — pair `PushSource` with a `ChangeListener` that watches its value.
+This is the push counterpart to reacting to a `DataSource` result.
+
+```xmlui-pg copy display name="React to each pushed change"
+<App var.refreshes="{0}">
+  <!-- window.subscribeSessionsChanged emits a tick whenever the host sees the
+       session list change on disk. -->
+  <PushSource id="sessionsChanged" subscribe="{window.subscribeSessionsChanged}" />
+
+  <DataSource id="sessions" url="/api/sessions" />
+
+  <ChangeListener
+    listenTo="{sessionsChanged.value}"
+    onDidChange="() => { sessions.refetch(); refreshes++; }" />
+
+  <Text value="Refetched {refreshes} time(s)" />
+  <List data="{sessions.value}">
+    <Text value="{$item.name}" />
+  </List>
+</App>
+```
+
+This is the exact shape Bram uses to keep pull-based `DataSource`s fresh from
+push-based host events: a `PushSource` carries the "something changed" signal,
+and a `ChangeListener` turns each emit into a `refetch()`. Because
+`ChangeListener` reacts to the *value* regardless of who set it, the push
+source and the consumer stay decoupled.
+
+**Tips:**
+
+- Emit a monotonic tick (or a small changed-key) rather than a large payload
+  when the value is only a *signal* to act — cheaper to diff, and the
+  `ChangeListener` still fires on every emit.
+- Debounce bursts with `ChangeListener`'s `debounceWaitInMs` when the host can
+  push faster than you want to react (see
+  [Rate-limit value changes](/docs/howto/debounce-with-changelistener)).
+- Keep the `onDidChange` body to app-level calls (`refetch()`, `toast()`,
+  state assignments); the push machinery itself lives in the host `subscribe`
+  function.

--- a/xmlui/src/components-core/loader/PushSourceLoader.tsx
+++ b/xmlui/src/components-core/loader/PushSourceLoader.tsx
@@ -19,7 +19,7 @@ import {
   xsConsoleLog,
 } from "../inspector/inspectorUtils";
 
-// --- ExternalLoader: wires an app-provided `subscribe` callback into the
+// --- PushSourceLoader: wires an app-provided `subscribe` callback into the
 // loader pipeline. The framework's role is narrow — call subscribe on
 // mount with an `emit(value)` function, dispatch every emit as a loader
 // "loaded" event so the value flows through the existing observability
@@ -30,21 +30,23 @@ import {
 // Producers may call it synchronously inside subscribe (to seed an
 // initial value) and asynchronously thereafter.
 //
-// Unlike `DataLoader` / `ApiLoader`, this loader does not own any fetch
-// or polling logic. It does not depend on React Query. Errors raised
-// inside subscribe are routed through `loaderError`; the loader stays
-// active and may continue receiving emits afterward.
+// PushSource is the push analogue of DataSource: DataSource pulls (fetch /
+// poll), PushSource receives pushed values. Unlike `DataLoader` / `ApiLoader`,
+// this loader does not own any fetch or polling logic. It does not depend on
+// React Query. Errors raised inside subscribe are routed through
+// `loaderError`; the loader stays active and may continue receiving emits
+// afterward.
 //
 // Inspector instrumentation mirrors DataLoader's xsLog plumbing:
-//  - external:mount        — component mounted (with initial value snapshot)
-//  - external:subscribe    — subscribe() called
-//  - external:emit         — producer pushed a value (payload included)
-//  - external:invalid      — subscribe prop is not a function
-//  - external:error        — subscribe() threw on registration
-//  - external:unsubscribe  — cleanup ran on unmount
+//  - pushsource:mount        — component mounted (with initial value snapshot)
+//  - pushsource:subscribe    — subscribe() called
+//  - pushsource:emit         — producer pushed a value (payload included)
+//  - pushsource:invalid      — subscribe prop is not a function
+//  - pushsource:error        — subscribe() threw on registration
+//  - pushsource:unsubscribe  — cleanup ran on unmount
 
-type ExternalLoaderProps = {
-  loader: ExternalLoaderDef;
+type PushSourceLoaderProps = {
+  loader: PushSourceLoaderDef;
   loaderInProgressChanged: LoaderInProgressChangedFn;
   loaderIsRefetchingChanged: LoaderInProgressChangedFn;
   loaderLoaded: LoaderLoadedFn;
@@ -52,24 +54,24 @@ type ExternalLoaderProps = {
   state: ContainerState;
 };
 
-function ExternalLoader({
+function PushSourceLoader({
   loader,
   loaderInProgressChanged,
   loaderLoaded,
   loaderError,
   state,
-}: ExternalLoaderProps) {
+}: PushSourceLoaderProps) {
   const appContext = useAppContext();
   const xsVerbose = appContext.xmluiConfig?.xsVerbose === true;
   const xsLogMax = Number(appContext.xmluiConfig?.xsVerboseLogMax ?? 200);
 
   const instanceIdRef = useRef<string>(
-    `ext-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`,
+    `push-${Math.random().toString(36).slice(2, 8)}-${Date.now().toString(36)}`,
   );
   const emitSeqRef = useRef<number>(0);
 
   // Inspector verbose logging — no-op when xsVerbose is off. Emits a
-  // structured entry to the xs log ring buffer with full External
+  // structured entry to the xs log ring buffer with full PushSource
   // context. Mirrors the shape DataLoader uses so the Inspector UI's
   // existing filters/columns light up the same way.
   const xsLog = useCallback(
@@ -83,7 +85,7 @@ function ExternalLoader({
           traceId: getCurrentTrace(),
           instanceId: instanceIdRef.current,
           // Reuse dataSourceId field name so existing Inspector columns
-          // surface the id for both DataSource and External rows.
+          // surface the id for both DataSource and PushSource rows.
           dataSourceId: (loader?.props as any)?.id,
           ownerUid: loader?.uid,
           ownerFileId: loader?.debug?.source?.fileId,
@@ -94,7 +96,7 @@ function ExternalLoader({
           kind,
           eventName: detail?.eventName,
           uid: detail?.uid ? String(detail.uid) : undefined,
-          componentType: "External",
+          componentType: "PushSource",
         },
         xsLogMax,
       );
@@ -125,14 +127,14 @@ function ExternalLoader({
   // that need a synchronous initial value can either rely on `initial`
   // or call `emit(seed)` synchronously inside their subscribe body.
   useEffect(() => {
-    xsLogRef.current("external:mount", {
+    xsLogRef.current("pushsource:mount", {
       hasInitial: initialValue !== undefined,
       initialValuePreview: initialValue !== undefined ? safeStringify(initialValue) : undefined,
     });
     if (initialValue !== undefined) {
       loaderLoadedRef.current(initialValue);
     }
-    // Mark not-in-progress: External is always "ready" once mounted.
+    // Mark not-in-progress: PushSource is always "ready" once mounted.
     loaderInProgressChangedRef.current(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -143,22 +145,22 @@ function ExternalLoader({
   useEffect(() => {
     if (typeof subscribeFn !== "function") {
       if (subscribeFn !== undefined && subscribeFn !== null) {
-        xsLogRef.current("external:invalid", {
+        xsLogRef.current("pushsource:invalid", {
           subscribeFnType: typeof subscribeFn,
         });
         console.warn(
-          "[XMLUI] External: `subscribe` prop must be a function; got " +
+          "[XMLUI] PushSource: `subscribe` prop must be a function; got " +
             typeof subscribeFn,
         );
       }
       return;
     }
 
-    xsLogRef.current("external:subscribe", {});
+    xsLogRef.current("pushsource:subscribe", {});
 
     const emit = (value: any) => {
       const seq = (emitSeqRef.current += 1);
-      xsLogRef.current("external:emit", {
+      xsLogRef.current("pushsource:emit", {
         seq,
         valuePreview: safeStringify(value),
       });
@@ -169,14 +171,14 @@ function ExternalLoader({
     try {
       unsubscribe = subscribeFn(emit);
     } catch (err) {
-      xsLogRef.current("external:error", {
+      xsLogRef.current("pushsource:error", {
         message: String((err as Error)?.message ?? err),
       });
       loaderErrorRef.current(AppError.from(err));
     }
 
     return () => {
-      xsLogRef.current("external:unsubscribe", {
+      xsLogRef.current("pushsource:unsubscribe", {
         hadUnsubscribeFn: typeof unsubscribe === "function",
       });
       if (typeof unsubscribe === "function") {
@@ -185,7 +187,7 @@ function ExternalLoader({
         } catch (err) {
           // Unsubscribe errors are reported but do not propagate; the
           // component is being torn down regardless.
-          console.error("[XMLUI] External: unsubscribe threw:", err);
+          console.error("[XMLUI] PushSource: unsubscribe threw:", err);
         }
       }
     };
@@ -197,15 +199,15 @@ function ExternalLoader({
 // ---------------------------------------------------------------------------
 // Renderer registration
 
-const ExternalLoaderMd = createMetadata({
+const PushSourceLoaderMd = createMetadata({
   status: "experimental",
   description:
-    "Bridges an app-defined external value source into XMLUI's reactive " +
-    "model. The `subscribe` prop is a function that receives an `emit` " +
-    "callback; every emit becomes an observable value change. Use for " +
-    "host-bridge values (postMessage, Tauri events, WebSocket pushes, " +
-    "polling caches, DOM observers) that cannot be expressed as a " +
-    "DataSource.",
+    "Bridges an app-defined push source into XMLUI's reactive model — the " +
+    "push analogue of DataSource. The `subscribe` prop is a function that " +
+    "receives an `emit` callback; every emit becomes an observable value " +
+    "change. Use for host-bridge values (postMessage, Tauri events, " +
+    "WebSocket pushes, polling caches, DOM observers) that cannot be " +
+    "expressed as a DataSource.",
   props: {
     subscribe: {
       description:
@@ -225,10 +227,10 @@ const ExternalLoaderMd = createMetadata({
   },
 });
 
-type ExternalLoaderDef = ComponentDef<typeof ExternalLoaderMd>;
+type PushSourceLoaderDef = ComponentDef<typeof PushSourceLoaderMd>;
 
-export const externalLoaderRenderer = createLoaderRenderer(
-  "External",
+export const pushSourceLoaderRenderer = createLoaderRenderer(
+  "PushSource",
   ({
     loader,
     state,
@@ -238,7 +240,7 @@ export const externalLoaderRenderer = createLoaderRenderer(
     loaderError,
   }) => {
     return (
-      <ExternalLoader
+      <PushSourceLoader
         loader={loader}
         state={state}
         loaderInProgressChanged={loaderInProgressChanged}
@@ -248,5 +250,5 @@ export const externalLoaderRenderer = createLoaderRenderer(
       />
     );
   },
-  ExternalLoaderMd,
+  PushSourceLoaderMd,
 );

--- a/xmlui/src/components-core/rendering/ComponentWrapper.tsx
+++ b/xmlui/src/components-core/rendering/ComponentWrapper.tsx
@@ -233,20 +233,20 @@ function transformNodeWithChildDatasource(node: ComponentDef) {
         when: child.when,
         debug: child.debug,
       });
-    } else if (child?.type === "External") {
+    } else if (child?.type === "PushSource") {
       didResolve = true;
       if (!loaders) {
         loaders = [];
       }
       loaders.push({
         uid: child.uid!,
-        type: "External",
+        type: "PushSource",
         props: child.props,
         events: child.events,
         when: child.when,
         debug: child.debug,
       });
-    } else if (node.scriptCollected && child?.type === "Fragment" && child.children?.some((c) => c?.type === "DataSource" || c?.type === "External")) {
+    } else if (node.scriptCollected && child?.type === "Fragment" && child.children?.some((c) => c?.type === "DataSource" || c?.type === "PushSource")) {
       // When a <script> tag and a <DataSource> are siblings, the parser wraps the non-helper
       // siblings in a synthetic Fragment (see transform.ts wrapWithFragment). The parent node
       // will have `scriptCollected` set in exactly this case. We must NOT apply this to
@@ -267,10 +267,10 @@ function transformNodeWithChildDatasource(node: ComponentDef) {
             when: fragmentChild.when,
             debug: fragmentChild.debug,
           });
-        } else if (fragmentChild?.type === "External") {
+        } else if (fragmentChild?.type === "PushSource") {
           loaders!.push({
             uid: fragmentChild.uid!,
-            type: "External",
+            type: "PushSource",
             props: fragmentChild.props,
             events: fragmentChild.events,
             when: fragmentChild.when,

--- a/xmlui/src/components/ComponentProvider.tsx
+++ b/xmlui/src/components/ComponentProvider.tsx
@@ -131,7 +131,7 @@ import type {
 } from "../components-core/abstractions/LoaderRenderer";
 import { apiLoaderRenderer } from "../components-core/loader/ApiLoader";
 import { dataLoaderRenderer } from "../components-core/loader/DataLoader";
-import { externalLoaderRenderer } from "../components-core/loader/ExternalLoader";
+import { pushSourceLoaderRenderer } from "../components-core/loader/PushSourceLoader";
 import { datePickerComponentRenderer } from "./DatePicker/DatePicker";
 import { dateInputComponentRenderer } from "./DateInput/DateInput";
 import { timeInputComponentRenderer } from "./TimeInput/TimeInput";
@@ -291,7 +291,7 @@ import { drawerComponentRenderer } from "./Drawer/Drawer";
  * values declare renderer functions for the built-in property holders.
  */
 const dataSourcePropHolder = createPropHolderComponent("DataSource");
-const externalPropHolder = createPropHolderComponent("External");
+const pushSourcePropHolder = createPropHolderComponent("PushSource");
 const textNodePropHolder = createPropHolderComponent("TextNode");
 const textNodeCDataPropHolder = createPropHolderComponent("TextNodeCData");
 const includeNavSectionPropHolder = createPropHolderComponent("IncludeNavSection");
@@ -407,7 +407,7 @@ export class ComponentRegistry {
 
     this.registerCoreComponent(SlotHolder);
     this.registerCoreComponent(dataSourcePropHolder);
-    this.registerCoreComponent(externalPropHolder);
+    this.registerCoreComponent(pushSourcePropHolder);
     this.registerCoreComponent(textNodePropHolder);
     this.registerCoreComponent(textNodeCDataPropHolder);
     this.registerCoreComponent(includeNavSectionPropHolder);
@@ -878,7 +878,7 @@ export class ComponentRegistry {
 
     this.registerLoaderRenderer(apiLoaderRenderer);
     this.registerLoaderRenderer(dataLoaderRenderer);
-    this.registerLoaderRenderer(externalLoaderRenderer);
+    this.registerLoaderRenderer(pushSourceLoaderRenderer);
 
     this.registerBehavior(labelBehavior);
     this.registerBehavior(animationBehavior);

--- a/xmlui/tests-e2e/push-source.spec.ts
+++ b/xmlui/tests-e2e/push-source.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 
 import { expect, test } from "../src/testing/fixtures";
 
-async function installExternalBridge(
+async function installPushSourceBridge(
   page: Page,
   options: { syncValue?: Record<string, any> | null } = {},
 ) {
@@ -13,8 +13,8 @@ async function installExternalBridge(
       unsubscribeCount: 0,
     };
 
-    (window as any).__externalBridge = bridge;
-    (window as any).__externalSubscribe = (emit: (value: any) => void) => {
+    (window as any).__pushSourceBridge = bridge;
+    (window as any).__pushSourceSubscribe = (emit: (value: any) => void) => {
       bridge.subscribeCount++;
       bridge.emitters.push(emit);
       if (syncValue !== null) {
@@ -24,10 +24,10 @@ async function installExternalBridge(
         bridge.unsubscribeCount++;
       };
     };
-    (window as any).__externalEmit = (value: any) => {
+    (window as any).__pushSourceEmit = (value: any) => {
       bridge.emitters.forEach((emit) => emit(value));
     };
-    (window as any).__externalStats = () => ({
+    (window as any).__pushSourceStats = () => ({
       subscribeCount: bridge.subscribeCount,
       unsubscribeCount: bridge.unsubscribeCount,
       emitterCount: bridge.emitters.length,
@@ -35,51 +35,51 @@ async function installExternalBridge(
   }, "syncValue" in options ? options.syncValue : { label: "sync", tick: 1 });
 }
 
-test.describe("External", () => {
+test.describe("PushSource", () => {
   test("exposes initial and emitted values through loader state", async ({ initTestBed, page }) => {
-    await installExternalBridge(page, { syncValue: null });
+    await installPushSourceBridge(page, { syncValue: null });
 
     await initTestBed(`
       <Fragment>
-        <External
-          id="externalSource"
+        <PushSource
+          id="pushSource"
           initial="{{ label: 'initial', tick: 0 }}"
-          subscribe="{window.__externalSubscribe}"
+          subscribe="{window.__pushSourceSubscribe}"
         />
         <Text
           testId="value"
-          value="{externalSource.value.label + ':' + externalSource.value.tick}"
+          value="{pushSource.value.label + ':' + pushSource.value.tick}"
         />
         <Text
           testId="loaded"
-          value="{externalSource.loaded ? 'loaded' : 'not-loaded'}"
+          value="{pushSource.loaded ? 'loaded' : 'not-loaded'}"
         />
       </Fragment>
     `);
 
     await expect(page.getByTestId("value")).toHaveText("initial:0");
     await expect(page.getByTestId("loaded")).toHaveText("loaded");
-    await expect.poll(() => page.evaluate(() => (window as any).__externalStats())).toMatchObject({
+    await expect.poll(() => page.evaluate(() => (window as any).__pushSourceStats())).toMatchObject({
       subscribeCount: 1,
       unsubscribeCount: 0,
       emitterCount: 1,
     });
 
     await page.evaluate(() => {
-      (window as any).__externalEmit({ label: "async", tick: 2 });
+      (window as any).__pushSourceEmit({ label: "async", tick: 2 });
     });
 
     await expect(page.getByTestId("value")).toHaveText("async:2");
   });
 
   test("emitted values are observable by ChangeListener", async ({ initTestBed, page }) => {
-    await installExternalBridge(page);
+    await installPushSourceBridge(page);
 
     await initTestBed(`
       <Fragment var.lastTick="{0}" var.changeCount="{0}">
-        <External id="externalSource" subscribe="{window.__externalSubscribe}" />
+        <PushSource id="pushSource" subscribe="{window.__pushSourceSubscribe}" />
         <ChangeListener
-          listenTo="{externalSource.value.tick}"
+          listenTo="{pushSource.value.tick}"
           onDidChange="(change) => { lastTick = change.newValue; changeCount++; }"
         />
         <Text testId="lastTick" value="{lastTick}" />
@@ -91,7 +91,7 @@ test.describe("External", () => {
     await expect(page.getByTestId("changeCount")).toHaveText("1");
 
     await page.evaluate(() => {
-      (window as any).__externalEmit({ label: "async", tick: 2 });
+      (window as any).__pushSourceEmit({ label: "async", tick: 2 });
     });
 
     await expect(page.getByTestId("lastTick")).toHaveText("2");
@@ -99,51 +99,51 @@ test.describe("External", () => {
   });
 
   test("calls unsubscribe when unmounted by a when condition", async ({ initTestBed, page }) => {
-    await installExternalBridge(page);
+    await installPushSourceBridge(page);
 
     await initTestBed(`
-      <Fragment var.showExternal="{true}">
-        <External
-          id="externalSource"
-          when="{showExternal}"
-          subscribe="{window.__externalSubscribe}"
+      <Fragment var.showPushSource="{true}">
+        <PushSource
+          id="pushSource"
+          when="{showPushSource}"
+          subscribe="{window.__pushSourceSubscribe}"
         />
-        <Button testId="toggle" label="Toggle" onClick="showExternal = !showExternal" />
+        <Button testId="toggle" label="Toggle" onClick="showPushSource = !showPushSource" />
         <Text
           testId="value"
-          value="{externalSource.value ? externalSource.value.label : 'none'}"
+          value="{pushSource.value ? pushSource.value.label : 'none'}"
         />
       </Fragment>
     `);
 
     await expect(page.getByTestId("value")).toHaveText("sync");
-    await expect.poll(() => page.evaluate(() => (window as any).__externalStats())).toMatchObject({
+    await expect.poll(() => page.evaluate(() => (window as any).__pushSourceStats())).toMatchObject({
       subscribeCount: 1,
       unsubscribeCount: 0,
     });
 
     await page.getByTestId("toggle").click();
 
-    await expect.poll(() => page.evaluate(() => (window as any).__externalStats())).toMatchObject({
+    await expect.poll(() => page.evaluate(() => (window as any).__pushSourceStats())).toMatchObject({
       subscribeCount: 1,
       unsubscribeCount: 1,
     });
   });
 
   test("works inside App when preceded by a script tag", async ({ initTestBed, page }) => {
-    await installExternalBridge(page);
+    await installPushSourceBridge(page);
 
     await initTestBed(`
       <App>
         <script>
           var greeting = "hello";
         </script>
-        <External id="externalSource" subscribe="{window.__externalSubscribe}" />
+        <PushSource id="pushSource" subscribe="{window.__pushSourceSubscribe}" />
         <Pages>
           <Page url="/">
             <Text
               testId="value"
-              value="{greeting + ':' + externalSource.value.label + ':' + externalSource.value.tick}"
+              value="{greeting + ':' + pushSource.value.label + ':' + pushSource.value.tick}"
             />
           </Page>
         </Pages>


### PR DESCRIPTION
## What

Rename the experimental `External` component to **`PushSource`**.

## Why

`External` is the push analogue of `DataSource`: `DataSource` *pulls* (fetch /
poll), while this component *receives* values pushed to it via a
`subscribe(emit) => unsubscribe` callback. `PushSource` conveys that pairing;
`External` did not. This was the intended name from the start.

## Changes

- `ExternalLoader.tsx` → `PushSourceLoader.tsx`: renderer registered as
  `"PushSource"`; symbols (`PushSourceLoader` / `PushSourceLoaderMd` /
  `pushSourceLoaderRenderer`), inspector log kinds (`pushsource:*`), error
  strings, and metadata renamed. Metadata now frames it as the push
  counterpart of `DataSource`.
- `ComponentProvider.tsx` / `ComponentWrapper.tsx`: register and wire the
  `"PushSource"` type (the `DataSource` / `PushSource` loader-collection
  sibling).
- `external.spec.ts` → `push-source.spec.ts` (fully renamed).
- Two new how-tos: *bridge a host value into reactive state with PushSource*,
  and *react to pushed values with ChangeListener* — drawn from real usage.

## Compatibility

Clean rename, **no `External` alias** — the component is experimental, so
consumers switch `<External>` → `<PushSource>`. Bram, the primary consumer, is
migrated in lockstep.

## Verification

- `tsc --noEmit` passes.
- The standalone bundle builds with `PushSource`, was vendored into Bram, and
  all push-driven surfaces (agent status, permission menu, conversation-state,
  PTY throughput, inflight, sessions/commits/issues refetch) were verified
  live after the rename.
