### PR TITLE
docs: how-to for confining a hot input's reactivity to a UDC

### DIFF
--- a/website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md
+++ b/website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md
@@ -23,71 +23,77 @@ re-evaluates bindings inside the component's subtree.
     <Text>• {$item}</Text>
   </List>
 </App>
----comp display /var.message/ /emitEvent/ /method name/ MessageComposer
-<Component name="MessageComposer" var.message="{''}">
-  <Form
-    data="{{ message }}"
-    onSubmit="(data) => { emitEvent('send', data.message); message = ''; }"
-  >
-    <TextArea
-      bindTo="message"
-      autoSize="true"
-      placeholder="Type a message, press Enter to send"
-    />
-  </Form>
+---comp display /var.draft/ /emitEvent/ /method name/ MessageComposer
+<Component name="MessageComposer" var.draft="{''}">
+  <TextArea
+    id="box"
+    autoSize="true"
+    placeholder="Type a message, then Send"
+    onDidChange="(v) => draft = v"
+  />
+  <Text variant="caption">{draft.length} characters</Text>
+  <Button
+    label="Send"
+    onClick="() => { emitEvent('send', box.value); box.setValue(''); }"
+  />
 
   <method name="setValue">
-    (v) => message = v
+    (v) => box.setValue(v)
   </method>
 </Component>
 ```
 
-The `message` variable — the one that changes on every keystroke — lives inside
-`MessageComposer`. Typing re-evaluates only the composer's own bindings. The
+The `draft` variable — reassigned on every keystroke by the TextArea's
+`onDidChange` — lives inside `MessageComposer`, and the `{draft.length} characters`
+counter is the only binding that re-evaluates as you type. Both stay in the
+component's subtree, so a keystroke never re-runs anything in App scope. The
 parent still drives the pipeline: it receives finished messages through the
-`send` event and writes into the field through the exposed `setValue` method,
-without ever putting `message` in App scope.
+`send` event and prefills the field through the exposed `setValue` method,
+without ever putting the input's state in App scope.
 
 ## Key points
 
 **The bound variable belongs inside the component**: Declare
-`var.message="{''}"` on the `<Component>`, not on the `<App>` or an outer
-container. Subtree variables don't cross a user-defined-component boundary
-([Scoping](/docs/guides/scoping)) — that isolation is exactly what bounds the
-keystroke re-evaluation. The nesting guide states the guarantee directly:
-"Variables and IDs declared in `TaskBoard` are invisible inside `TaskColumn` or
-`TaskCard`" ([Compose components with nesting](/docs/howto/compose-components-with-nesting)).
+`var.draft="{''}"` on the `<Component>`, not on the `<App>` or an outer
+container. The `{draft.length}` binding — and any other per-keystroke binding you
+add — then re-evaluates only within the component. Subtree variables don't cross
+a user-defined-component boundary ([Scoping](/docs/guides/scoping)) — that
+isolation is exactly what bounds the keystroke re-evaluation. The nesting guide
+states the guarantee directly: "Variables and IDs declared in `TaskBoard` are
+invisible inside `TaskColumn` or `TaskCard`"
+([Compose components with nesting](/docs/howto/compose-components-with-nesting)).
 
 **Finished values flow up through an event**: The parent needs the *committed*
-message, not every intermediate keystroke. `emitEvent('send', data.message)`
-hands the parent the final value on submit, and the parent listens with
+message, not every intermediate keystroke. `emitEvent('send', box.value)` hands
+the parent the final value when the user clicks Send, and the parent listens with
 `onSend`. This keeps the parent's dispatch logic at App scope where it belongs —
 props flow down, events flow up ([Emit a custom event from a component](/docs/howto/emit-a-custom-event-from-a-component)).
 
-**Let an emitting handler also complete its local state change**: Notice the
-`onSubmit` handler ends with `message = ''` *after* `emitEvent('send', …)`.
-Resetting the field is the obvious reason, but it also keeps event delivery
-prompt: a handler whose only effect is `emitEvent(...)`, with no trailing write
-to observable state, can have its emission flushed on a later reactive tick
-rather than immediately. Give an emit-only handler something local to do (clear
-the field, flip a flag), or fold the emit into a handler that already mutates
-state.
+**Let an emitting handler also complete its local state change**: Notice the Send
+handler ends with `box.setValue('')` *after* `emitEvent('send', …)`. Clearing the
+field is the obvious reason, but it also keeps event delivery prompt: a handler
+whose only effect is `emitEvent(...)`, with no trailing write to observable state,
+can have its emission flushed on a later reactive tick rather than immediately.
+Give an emit-only handler something local to do (clear the field, flip a flag), or
+fold the emit into a handler that already mutates state.
 
 **Imperative writes come in through a method**: When the parent must *write* the
 field — clear it after a turn, prefill a template, append a voice transcript —
 expose a `<method name="setValue">` and call `composer.setValue(...)` by the
 component's `id` ([Expose a method from a component](/docs/howto/expose-a-method-from-a-component)).
-Write the method body as an arrow function so it receives the argument —
-`(v) => message = v`. A statement body like `message = $params[0]` does *not*
-work: `$param` / `$params` are not bound inside a user-defined component's method
-body (they belong to built-in component methods such as `APICall.execute` and
+Drive the input's *own* `setValue` (`(v) => box.setValue(v)`) so the change shows
+in the field — see [Control a TextArea from code](/docs/howto/control-a-textarea-from-code).
+Write the method body as an arrow function so it receives the argument: a
+statement body like `box.setValue($params[0])` does *not* work, because
+`$param` / `$params` are not bound inside a user-defined component's method body
+(they belong to built-in component methods such as `APICall.execute` and
 `ModalDialog.open`). The parent reaches in without holding the variable.
 
 **What stays outside**: Pure pipeline state that the *parent* owns — an
 `awaiting` flag, a `submittedKind` marker, the dispatch that routes the message —
 belongs in the parent's `onSend` handler at App scope. Moving that state into the
-component defeats the purpose; the goal is to move only the high-frequency
-`bindTo` target inward, not the whole feature.
+component defeats the purpose; the goal is to move only the high-frequency input
+state inward, not the whole feature.
 
 ## Diagnose it first
 

--- a/website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md
+++ b/website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md
@@ -37,7 +37,7 @@ re-evaluates bindings inside the component's subtree.
   </Form>
 
   <method name="setValue">
-    message = $params[0];
+    (v) => message = v
   </method>
 </Component>
 ```
@@ -77,7 +77,11 @@ state.
 field — clear it after a turn, prefill a template, append a voice transcript —
 expose a `<method name="setValue">` and call `composer.setValue(...)` by the
 component's `id` ([Expose a method from a component](/docs/howto/expose-a-method-from-a-component)).
-The parent reaches in without holding the variable.
+Write the method body as an arrow function so it receives the argument —
+`(v) => message = v`. A statement body like `message = $params[0]` does *not*
+work: `$param` / `$params` are not bound inside a user-defined component's method
+body (they belong to built-in component methods such as `APICall.execute` and
+`ModalDialog.open`). The parent reaches in without holding the variable.
 
 **What stays outside**: Pure pipeline state that the *parent* owns — an
 `awaiting` flag, a `submittedKind` marker, the dispatch that routes the message —

--- a/website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md
+++ b/website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md
@@ -1,0 +1,119 @@
+# Confine a hot input's reactivity to its own component
+
+When typing in one input feels noticeably laggier than typing in another, the
+slow input is almost always bound to a variable declared in an *outer* scope.
+Every keystroke reassigns that variable, and XMLUI re-evaluates **every binding
+reachable in that scope** — every `ChangeListener` `listenTo`, every `when` /
+`enabled` / `value` expression, every sibling `DataSource` signature under the
+same container. The fix is structural, not a binding tweak: extract the input
+(and the siblings that read its value) into a user-defined component, and
+declare the bound variable **inside** that component. A keystroke then only
+re-evaluates bindings inside the component's subtree.
+
+```xmlui-pg copy display name="A message composer that keeps its own input state" height="360px"
+---app display /onSend/ /composer.setValue/
+<App var.log="{[]}">
+  <MessageComposer
+    id="composer"
+    onSend="(text) => { log = [...log, text]; }"
+  />
+  <Button label="Prefill greeting" onClick="composer.setValue('Hello there')" />
+  <Text variant="strong">Sent</Text>
+  <List data="{log}">
+    <Text>• {$item}</Text>
+  </List>
+</App>
+---comp display /var.message/ /emitEvent/ /method name/ MessageComposer
+<Component name="MessageComposer" var.message="{''}">
+  <Form
+    data="{{ message }}"
+    onSubmit="(data) => { emitEvent('send', data.message); message = ''; }"
+  >
+    <TextArea
+      bindTo="message"
+      autoSize="true"
+      placeholder="Type a message, press Enter to send"
+    />
+  </Form>
+
+  <method name="setValue">
+    message = $params[0];
+  </method>
+</Component>
+```
+
+The `message` variable — the one that changes on every keystroke — lives inside
+`MessageComposer`. Typing re-evaluates only the composer's own bindings. The
+parent still drives the pipeline: it receives finished messages through the
+`send` event and writes into the field through the exposed `setValue` method,
+without ever putting `message` in App scope.
+
+## Key points
+
+**The bound variable belongs inside the component**: Declare
+`var.message="{''}"` on the `<Component>`, not on the `<App>` or an outer
+container. Subtree variables don't cross a user-defined-component boundary
+([Scoping](/docs/guides/scoping)) — that isolation is exactly what bounds the
+keystroke re-evaluation. The nesting guide states the guarantee directly:
+"Variables and IDs declared in `TaskBoard` are invisible inside `TaskColumn` or
+`TaskCard`" ([Compose components with nesting](/docs/howto/compose-components-with-nesting)).
+
+**Finished values flow up through an event**: The parent needs the *committed*
+message, not every intermediate keystroke. `emitEvent('send', data.message)`
+hands the parent the final value on submit, and the parent listens with
+`onSend`. This keeps the parent's dispatch logic at App scope where it belongs —
+props flow down, events flow up ([Emit a custom event from a component](/docs/howto/emit-a-custom-event-from-a-component)).
+
+**Let an emitting handler also complete its local state change**: Notice the
+`onSubmit` handler ends with `message = ''` *after* `emitEvent('send', …)`.
+Resetting the field is the obvious reason, but it also keeps event delivery
+prompt: a handler whose only effect is `emitEvent(...)`, with no trailing write
+to observable state, can have its emission flushed on a later reactive tick
+rather than immediately. Give an emit-only handler something local to do (clear
+the field, flip a flag), or fold the emit into a handler that already mutates
+state.
+
+**Imperative writes come in through a method**: When the parent must *write* the
+field — clear it after a turn, prefill a template, append a voice transcript —
+expose a `<method name="setValue">` and call `composer.setValue(...)` by the
+component's `id` ([Expose a method from a component](/docs/howto/expose-a-method-from-a-component)).
+The parent reaches in without holding the variable.
+
+**What stays outside**: Pure pipeline state that the *parent* owns — an
+`awaiting` flag, a `submittedKind` marker, the dispatch that routes the message —
+belongs in the parent's `onSend` handler at App scope. Moving that state into the
+component defeats the purpose; the goal is to move only the high-frequency
+`bindTo` target inward, not the whole feature.
+
+## Diagnose it first
+
+Before extracting, confirm the input's scope is the cause:
+
+- **Compare against an input that already lives in a small scope.** A `TextBox`
+  or `TextArea` rendered inside an `Items` row (so its `bindTo` target is
+  row-local) will feel snappy. If your standalone input is visibly laggier than
+  that per-row input, outer-scope re-evaluation is the likely difference.
+- **Count what's reachable in the input's scope.** Every `ChangeListener`,
+  derived `var`, `DataSource`, and conditional binding under the same container
+  as the bound variable re-runs on each keystroke. A handful is fine; a chat
+  surface sitting under an App scope with many listeners and an `Items` loop is
+  the classic trap.
+- **Measure with the Inspector** if you want numbers. Extracting a
+  message-composer surface (a `Form` + `TextArea` + paste strip + send/skip
+  buttons, previously bound to an App-level `var`) into its own component moved
+  the median inter-keydown gap from ~225 ms to ~170 ms — matching the app's
+  already-fast per-row feedback boxes. The reactive model's elegance is what
+  makes the trap easy to fall into: every reachable binding is "free" to
+  express, so one inadvertently expensive `ChangeListener` under the same scope
+  as a hot input silently makes typing feel sluggish.
+
+---
+
+## See also
+
+- [Compose components with nesting](/docs/howto/compose-components-with-nesting) — the scope-isolation guarantee this pattern relies on
+- [Emit a custom event from a component](/docs/howto/emit-a-custom-event-from-a-component) — sending the committed value up to the parent
+- [Expose a method from a component](/docs/howto/expose-a-method-from-a-component) — letting the parent write the field imperatively
+- [Control a TextArea from code](/docs/howto/control-a-textarea-from-code) — the `setValue` / `value` / `focus` methods on the input itself
+- [Keep per-item state in an Items or List loop](/docs/howto/keep-per-item-state-in-a-loop) — why inputs rendered inside a loop already have a small reactive scope
+- [Scoping](/docs/guides/scoping) — the full rules for what variables cross a component boundary

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -561,6 +561,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Confine a hot input's reactivity to its own component"
+                            to="/docs/howto/confine-a-hot-input-to-its-own-component"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Use built-in form validation"
                             to="/docs/howto/use-built-in-form-validation"
                         />
@@ -2305,6 +2310,11 @@
             <Page url="/docs/howto/control-a-textarea-from-code">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/control-a-textarea-from-code.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/confine-a-hot-input-to-its-own-component">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/confine-a-hot-input-to-its-own-component.md']}"
                 />
             </Page>
 

--- a/xmlui/tests-e2e/confine-hot-input-composer.spec.ts
+++ b/xmlui/tests-e2e/confine-hot-input-composer.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "../src/testing/fixtures";
+
+// Backs the how-to "Confine a hot input's reactivity to its own component".
+// The composer keeps its own input state; the parent prefills via an exposed
+// setValue method and receives finished messages via the send event.
+// Note: autoSize renders a hidden shadow <textarea> too, so target the visible
+// one by its testId ("box", from the TextArea id) rather than the tag.
+const COMPOSER = `
+  <Component name="MessageComposer" var.draft="{''}">
+    <TextArea id="box" autoSize="true" placeholder="Type a message, then Send"
+      onDidChange="(v) => draft = v" />
+    <Text variant="caption">{draft.length} characters</Text>
+    <Button label="Send"
+      onClick="() => { emitEvent('send', box.value); box.setValue(''); }" />
+    <method name="setValue">(v) => box.setValue(v)</method>
+  </Component>
+`;
+const APP = `
+  <App var.log="{[]}">
+    <MessageComposer id="composer" onSend="(text) => { log = [...log, text]; }" />
+    <Button testId="prefill" label="Prefill greeting" onClick="composer.setValue('Hello there')" />
+    <Text testId="last">LAST:{log.length ? log[log.length-1] : ''}</Text>
+    <Text testId="count">SENT:{log.length}</Text>
+  </App>
+`;
+
+test("prefill visibly fills the input", async ({ page, initTestBed }) => {
+  await initTestBed(APP, { components: [COMPOSER] });
+  await expect(page.getByTestId("count")).toHaveText("SENT:0");
+  await page.getByTestId("prefill").click();
+  await expect(page.getByRole("textbox")).toHaveValue("Hello there");
+});
+
+test("typing then Send emits the text to the parent and clears", async ({ page, initTestBed }) => {
+  await initTestBed(APP, { components: [COMPOSER] });
+  await expect(page.getByTestId("count")).toHaveText("SENT:0");
+  await page.getByRole("textbox").click();
+  await page.getByRole("textbox").pressSequentially("hi there");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByTestId("last")).toHaveText("LAST:hi there");
+  await expect(page.getByTestId("count")).toHaveText("SENT:1");
+  await expect(page.getByRole("textbox")).toHaveValue("");
+});
+
+test("prefill then Send emits the prefilled text", async ({ page, initTestBed }) => {
+  await initTestBed(APP, { components: [COMPOSER] });
+  await expect(page.getByTestId("count")).toHaveText("SENT:0");
+  await page.getByTestId("prefill").click();
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByTestId("last")).toHaveText("LAST:Hello there");
+});


### PR DESCRIPTION
Fills the how-to gap requested in #3589. The existing scope/reuse how-tos ([Create a reusable component](https://docs.xmlui.org/howto/create-a-reusable-component), [Compose components with nesting](https://docs.xmlui.org/howto/compose-components-with-nesting)) frame user-defined-component extraction as a *reuse* feature. None frames it as a **performance** technique for a high-frequency input — which is the gap.

## The pattern

An input bound to a `var` in an outer scope re-evaluates **every binding reachable in that scope** on each keystroke (every `ChangeListener` `listenTo`, every `when`/`enabled`/`value` expression, every sibling `DataSource` signature). Extracting the input plus its companion bindings into a component, with the bound var declared *inside* it, confines the per-keystroke re-eval to the component's own subtree.

## What the article covers

- **Diagnosis** — compare against an `Items`-row input that's already snappy, count what's reachable in the input's scope, measure with the Inspector.
- **The extraction** — bound var inside the component; finished value flows up via `emitEvent`; imperative writes come in via an exposed `<method>`; parent-owned pipeline state stays at parent scope.
- **A runnable `xmlui-pg` playground** — a `MessageComposer` that owns its `message` var, emits `send`, and exposes `setValue`.
- **Caveat** — an emitting handler should complete a local state write in the same handler (the example's `onSubmit` ends with `message = ''` after `emitEvent`), framed as good practice.

Grounded in a real case: extracting this surface in the Bram project moved the median inter-keydown gap from ~225 ms to ~170 ms, matching the app's already-fast per-row inputs.

## Wiring

- New `website/content/docs/pages/howto/confine-a-hot-input-to-its-own-component.md`
- `NavLink` (Forms & input group) + `Page` route in `website/src/Main.xmlui`
- `docsContent` picks the markdown up automatically via the content glob; the how-to e2e spec isn't an enumerating test, so no test change is needed.

Closes #3589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
