### PR TITLE
docs: how-to for passing arguments to a component method

### DIFF
--- a/website/content/docs/pages/howto/pass-arguments-to-a-component-method.md
+++ b/website/content/docs/pages/howto/pass-arguments-to-a-component-method.md
@@ -76,7 +76,7 @@ way the component's markup bindings do:
 | The component's own `var.X` | **Yes** — read *and* write | Component state lives in this scope |
 | `$props.X` | **Yes** — read-only | The caller-supplied attributes ([Create a reusable component](/docs/howto/create-a-reusable-component)) |
 | An `id` declared **inside** this component | **Yes** | Call its API, e.g. `internalDialog.open()` ([Expose a method from a component](/docs/howto/expose-a-method-from-a-component)) |
-| A parent / outer / App-level `var.X` | Treat as **No** | Variables stop at the user-defined-component boundary ([Scoping](/docs/scoping)) — pass them in as a prop, or emit an event |
+| A parent / outer / App-level `var.X` | Treat as **No** | Variables stop at the user-defined-component boundary ([Scoping](/docs/guides/scoping)) — pass them in as a prop, or emit an event |
 | An `id` in the caller's scope | **No** | Same boundary |
 
 ## To change parent state, emit an event
@@ -105,4 +105,4 @@ user-defined-component story follows.
 - [Delegate a method](/docs/howto/delegate-a-method) — forwarding a method straight to an internal built-in component
 - [Emit a custom event from a component](/docs/howto/emit-a-custom-event-from-a-component) — the way to change parent state from inside a component
 - [Create a reusable component](/docs/howto/create-a-reusable-component) — `$props`, `id`, and the component boundary
-- [Scoping](/docs/scoping) — which variables cross a user-defined-component boundary
+- [Scoping](/docs/guides/scoping) — which variables cross a user-defined-component boundary

--- a/website/content/docs/pages/howto/pass-arguments-to-a-component-method.md
+++ b/website/content/docs/pages/howto/pass-arguments-to-a-component-method.md
@@ -1,0 +1,108 @@
+# Pass arguments to a component method
+
+[Expose a method from a component](/docs/howto/expose-a-method-from-a-component)
+shows how to *declare* a method. The moment a method needs to take an argument,
+one detail trips people up: **arguments bind to a named arrow parameter, not to
+`$param` / `$params`.** Write the body as an arrow function and name the
+parameter you want:
+
+```xmlui-pg copy display name="Passing arguments to a component's methods" height="360px"
+---app display /counter\./
+<App var.readout="(nothing read yet)">
+  <Counter id="counter" />
+  <FlowLayout>
+    <Button label="add 5 (attribute form)" onClick="counter.addAttr(5)" />
+    <Button label="add 3 (element form)"   onClick="counter.addElem(3)" />
+    <Button label="reset"                  onClick="counter.reset()" />
+    <Button label="read"                   onClick="readout = 'count = ' + counter.getCount()" />
+  </FlowLayout>
+  <Text>{readout}</Text>
+</App>
+---comp display /method\./ /method name/ /\(n\) =>/ Counter
+<Component name="Counter" var.count="{0}"
+  method.addAttr="(n) => count = count + n">
+  <Text variant="strong">Count: {count}</Text>
+
+  <method name="addElem">(n) => count = count + n</method>
+  <method name="reset">count = 0</method>
+  <method name="getCount">return count</method>
+</Component>
+```
+
+`addAttr` and `addElem` are the **same** method written two ways — an arrow
+function whose parameter `n` receives the call argument. `reset` and `getCount`
+take no argument, so a plain statement body is enough.
+
+## Key points
+
+**Arguments come in through a named arrow parameter**: To receive an argument,
+the method body must be an arrow function. The parameters bind positionally to
+the call arguments, so `counter.addAttr(5)` makes `n` equal `5`:
+
+```xmlui
+<!-- attribute form -->
+method.setLabel="(text) => label = text"
+
+<!-- element form — identical behavior -->
+<method name="setLabel">(text) => label = text</method>
+
+<!-- multiple arguments bind left to right -->
+<method name="move">(dx, dy) => { x = x + dx; y = y + dy; }</method>
+```
+
+**`$param` / `$params` are NOT bound in a component method body**: This is the
+usual surprise. `$param` and `$params` are context values for *built-in*
+component methods — `APICall.execute(...)`, `ModalDialog.open(...)`, and the like
+([context variables](/docs/context-variables2#`$param`)). Inside a user-defined
+component's `<method>` body they are `undefined`, so `message = $params[0]`
+silently assigns `undefined`. Name an arrow parameter instead.
+
+**A statement body is fine when there is no argument**: `<method name="reset">count = 0</method>`
+runs its body as statements and can call internal component APIs and `return` a
+value (`<method name="getCount">return count</method>`). You only need the arrow
+form to *receive* arguments. The element form and the `method.` attribute form
+have the same semantics — pick the attribute form for one-liners, the element
+form for multi-line bodies.
+
+## What else the body can reach
+
+A method body resolves identifiers through the component's own scope, the same
+way the component's markup bindings do:
+
+| Inside a `<method>` body | Resolves? | How / why |
+| --- | --- | --- |
+| Call arguments | **Yes** | Name them as arrow parameters: `(a, b) => …` |
+| `$param` / `$params` | **No** | Reserved for built-in component methods (`APICall.execute`, `ModalDialog.open`) |
+| The component's own `var.X` | **Yes** — read *and* write | Component state lives in this scope |
+| `$props.X` | **Yes** — read-only | The caller-supplied attributes ([Create a reusable component](/docs/howto/create-a-reusable-component)) |
+| An `id` declared **inside** this component | **Yes** | Call its API, e.g. `internalDialog.open()` ([Expose a method from a component](/docs/howto/expose-a-method-from-a-component)) |
+| A parent / outer / App-level `var.X` | Treat as **No** | Variables stop at the user-defined-component boundary ([Scoping](/docs/scoping)) — pass them in as a prop, or emit an event |
+| An `id` in the caller's scope | **No** | Same boundary |
+
+## To change parent state, emit an event
+
+Because outer variables stop at the component boundary, a method **cannot** write
+the parent's state directly — pass a value up with
+[`emitEvent`](/docs/howto/emit-a-custom-event-from-a-component) and let the
+parent's handler do the write:
+
+```xmlui
+<!-- inside the component: the method reports upward -->
+<method name="commit">(text) => emitEvent('committed', text)</method>
+
+<!-- the parent owns the write -->
+<Editor onCommitted="(text) => savedValue = text" />
+```
+
+Props flow down, events flow up — the same data-flow rule the rest of the
+user-defined-component story follows.
+
+---
+
+## See also
+
+- [Expose a method from a component](/docs/howto/expose-a-method-from-a-component) — declaring `<method>` and the `method.` attribute form
+- [Delegate a method](/docs/howto/delegate-a-method) — forwarding a method straight to an internal built-in component
+- [Emit a custom event from a component](/docs/howto/emit-a-custom-event-from-a-component) — the way to change parent state from inside a component
+- [Create a reusable component](/docs/howto/create-a-reusable-component) — `$props`, `id`, and the component boundary
+- [Scoping](/docs/scoping) — which variables cross a user-defined-component boundary

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1121,6 +1121,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Pass arguments to a component method"
+                            to="/docs/howto/pass-arguments-to-a-component-method"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Delegate a method"
                             to="/docs/howto/delegate-a-method"
                         />
@@ -1899,6 +1904,13 @@
             >
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/expose-a-method-from-a-component.md']}"
+                />
+            </Page>
+            <Page
+                url="/docs/howto/pass-arguments-to-a-component-method"
+            >
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/pass-arguments-to-a-component-method.md']}"
                 />
             </Page>
             <Page

--- a/xmlui/tests-e2e/udc-method-arguments.spec.ts
+++ b/xmlui/tests-e2e/udc-method-arguments.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "../src/testing/fixtures";
+
+// Companion tests for the how-to "Pass arguments to a component method".
+// A UDC <method> receives call arguments through a NAMED ARROW PARAMETER, in
+// both the element and attribute forms. $param / $params are NOT bound in a
+// UDC method body (they belong to built-in component methods).
+
+const COUNTER = `
+  <Component name="Counter" var.count="{0}"
+    method.addAttr="(n) => count = count + n">
+    <Text testId="innerCount">{count}</Text>
+    <method name="addElem">(n) => count = count + n</method>
+    <method name="reset">count = 0</method>
+    <method name="getCount">return count</method>
+    <method name="echoParam">return typeof $param + ':' + $param</method>
+  </Component>
+`;
+
+test("attribute form arrow parameter receives the argument", async ({ page, initTestBed }) => {
+  await initTestBed(
+    `<Fragment var.r="">
+       <Counter id="c" />
+       <Button testId="go" onClick="() => { c.addAttr(5); r = 'count=' + c.getCount(); }">go</Button>
+       <H2 testId="out">{r}</H2>
+     </Fragment>`,
+    { components: [COUNTER] },
+  );
+  await page.getByTestId("go").click();
+  await expect(page.getByTestId("out")).toHaveText("count=5");
+});
+
+test("element form arrow parameter receives the argument", async ({ page, initTestBed }) => {
+  await initTestBed(
+    `<Fragment var.r="">
+       <Counter id="c" />
+       <Button testId="go" onClick="() => { c.addElem(3); r = 'count=' + c.getCount(); }">go</Button>
+       <H2 testId="out">{r}</H2>
+     </Fragment>`,
+    { components: [COUNTER] },
+  );
+  await page.getByTestId("go").click();
+  await expect(page.getByTestId("out")).toHaveText("count=3");
+});
+
+test("no-arg statement body runs and getter returns a value", async ({ page, initTestBed }) => {
+  await initTestBed(
+    `<Fragment var.r="">
+       <Counter id="c" />
+       <Button testId="go" onClick="() => { c.addAttr(9); c.reset(); r = 'count=' + c.getCount(); }">go</Button>
+       <H2 testId="out">{r}</H2>
+     </Fragment>`,
+    { components: [COUNTER] },
+  );
+  await page.getByTestId("go").click();
+  await expect(page.getByTestId("out")).toHaveText("count=0");
+});
+
+test("$params is NOT bound in a UDC method body", async ({ page, initTestBed }) => {
+  await initTestBed(
+    `<Fragment var.r="unset">
+       <Counter id="c" />
+       <Button testId="go" onClick="() => r = c.echoParam('X')">go</Button>
+       <H2 testId="out">{r}</H2>
+     </Fragment>`,
+    { components: [COUNTER] },
+  );
+  await page.getByTestId("go").click();
+  // $param is undefined inside a UDC method body — the argument 'X' does not land there.
+  await expect(page.getByTestId("out")).toHaveText("undefined:undefined");
+});


### PR DESCRIPTION
Fills the how-to gap requested in #3591. [Expose a method from a component](https://docs.xmlui.org/howto/expose-a-method-from-a-component) shows how to *declare* a method, but its examples take no arguments — so the first question every implementer hits ("how does my method receive an argument?") is unanswered, and the natural guess (`$param` / `$params`, which are real for *built-in* component methods) silently fails.

## Verified against the runtime, not just read from source

I added e2e tests (`xmlui/tests-e2e/udc-method-arguments.spec.ts`, 4 passing) that pin down the actual behavior:

- **Arguments bind to a named arrow parameter**, in **both** forms, which are equivalent:
  - element: `<method name="add">(n) => count = count + n</method>`
  - attribute: `method.add="(n) => count = count + n"`
- **`$param` / `$params` are NOT bound** inside a user-defined-component method body (a probe returned `undefined` / no params array). They belong to built-in component methods (`APICall.execute`, `ModalDialog.open`). So `x = $params[0]` silently assigns `undefined` — exactly the trap #3591 describes.
- A **no-arg statement body** runs fine and can `return` a value.

## What the article adds

- A runnable `xmlui-pg` playground (a `Counter` exposing `addAttr` / `addElem` / `reset` / `getCount`) showing both argument-passing forms side by side.
- A **scope table** for what a method body can reach: own `var.X` (read+write), `$props.X` (read-only), internal `id`s — yes; outer/App-level `var.X` and caller-scope ids — treat as no (they stop at the [component boundary](https://docs.xmlui.org/scoping); pass a prop or emit an event).
- A short "to change parent state, emit an event" section tying back to [Emit a custom event from a component](https://docs.xmlui.org/howto/emit-a-custom-event-from-a-component).

## Wiring

- New `website/content/docs/pages/howto/pass-arguments-to-a-component-method.md`
- `NavLink` (Components group, next to *Expose a method*) + `Page` route in `website/src/Main.xmlui`
- `docsContent` picks the markdown up automatically via the content glob.

## Note for maintainers (separate from this docs change)

While verifying the scope table I found a **discrepancy between the documented contract and the runtime**: [scoping.md](https://docs.xmlui.org/scoping) says variables "stop at the boundary of a user-defined component file," but a probe (App-level `var.parentVar` read from inside a UDC method body) returned the parent's value (`string|PARENT`) rather than `undefined` — i.e. outer vars currently *leak* into the UDC. The how-to deliberately teaches the **documented** contract (treat outer vars as unavailable; pass props / emit events) and does **not** advertise the leak. Whether the fix is in the docs or the runtime is a separate call — happy to file a dedicated issue if useful.

Closes #3591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
