### PR TITLE
List: scrollToBottom() scrolls to the absolute bottom

### DIFF
--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -1090,11 +1090,15 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
   );
 
   const scrollToBottom = useEvent(() => {
-    if (rows.length) {
-      virtualizerRef.current?.scrollToIndex(rows.length + 1, {
-        align: "end",
-        offset: startMargin,
-      });
+    const v = virtualizerRef.current;
+    if (v && rows.length) {
+      // Absolute bottom, not align-end of the last item: aligning to the last
+      // item's currently measured end lands short while late-measuring content
+      // (async Markdown, images) is still growing, and repeated calls keep
+      // landing short of the settled bottom. scrollTo(scrollSize) clamps to
+      // the true bottom regardless of item boundaries — the same call the
+      // scrollAnchor="bottom" internals use for exactly this reason.
+      v.scrollTo(v.scrollSize + startMargin);
     }
   });
 


### PR DESCRIPTION
## What

Makes the `List` component's exposed `scrollToBottom()` method scroll to the **absolute** bottom — `scrollTo(scrollSize + startMargin)` — instead of `scrollToIndex(rows.length + 1, { align: "end" })`.

## Why

Align-to-last-item-end lands on the last item's *currently measured* end. While late-measuring content is still growing (async Markdown, images, content that streams in), that's a hair short of the true bottom — and repeated calls keep landing short of the settled bottom. A consumer implementing explicit follow-newest (track `atEnd` from the `scroll` event, call `scrollToBottom()` on append) leaves the user perpetually a few pixels above the end, forced to nudge the last bit manually on every new item.

The `scrollAnchor="bottom"` internals already use `scrollTo(scrollSize)` for exactly this reason (the code comments there call out the same failure). This brings the public method in line with what its name promises. `+ startMargin` preserves outside-scroll container behavior, mirroring `scrollToTop`'s `-startMargin` offset.

## Motivating use case (Bram)

Bram's transcript pane uses explicit follow (deliberately, instead of `scrollAnchor="bottom"`): `atBottom` tracked via the `scroll` event, repin via `scrollToBottom()` on new events. Field report from today's dogfooding: "when a new thing is added, I always have to nudge my way to the absolute bottom. It's really annoying." The short landing compounds as tool rows, Markdown, and async-spliced description lines settle after each repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
