### PR TITLE
Add xmlui-dnd-list extension package (DndItems)

### DIFF
--- a/.changeset/add-dnd-list-package.md
+++ b/.changeset/add-dnd-list-package.md
@@ -1,0 +1,8 @@
+---
+"xmlui-dnd-list": minor
+---
+
+Add `xmlui-dnd-list`: a drag-and-drop sortable list extension. `DndItems` is
+a drop-in replacement for `Items` that adds an `onReorder(newOrder, info)`
+event, plus an optional `dragHandle` mode that confines dragging to a rendered
+`⋮⋮` grip so input-heavy rows stay interactive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1484,6 +1484,59 @@
       "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
       "license": "MIT"
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -23515,6 +23568,10 @@
       "resolved": "packages/xmlui-devtools",
       "link": true
     },
+    "node_modules/xmlui-dnd-list": {
+      "resolved": "packages/xmlui-dnd-list",
+      "link": true
+    },
     "node_modules/xmlui-docs-blocks": {
       "resolved": "packages/xmlui-docs-blocks",
       "link": true
@@ -23865,8 +23922,22 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/xmlui-dnd-list": {
+      "version": "0.1.0",
+      "dependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2"
+      },
+      "devDependencies": {
+        "xmlui": "*"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/xmlui-docs-blocks": {
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@shikijs/langs": "3.4.2",
         "js-yaml": "4.1.1",
@@ -24120,7 +24191,7 @@
     },
     "tools/create-app": {
       "name": "create-xmlui-app",
-      "version": "0.12.30",
+      "version": "0.12.31",
       "bin": {
         "create-xmlui-app": "dist/index.js"
       },
@@ -24186,7 +24257,7 @@
     },
     "tools/vscode": {
       "name": "xmlui-vscode",
-      "version": "0.12.30",
+      "version": "0.12.31",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1",
@@ -24746,7 +24817,7 @@
       }
     },
     "xmlui": {
-      "version": "0.12.30",
+      "version": "0.12.31",
       "dependencies": {
         "@ark-ui/react": "5.36.2",
         "@babel/parser": "7.29.2",

--- a/packages/xmlui-dnd-list/.gitignore
+++ b/packages/xmlui-dnd-list/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+storybook-static
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+scripts/generate-docs/metadata.json
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/packages/xmlui-dnd-list/CHANGELOG.md
+++ b/packages/xmlui-dnd-list/CHANGELOG.md
@@ -1,0 +1,9 @@
+# xmlui-dnd-list
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release. `DndItems` — a drag-and-drop sortable list, drop-in for
+  `Items` with an `onReorder(newOrder, info)` event and an optional
+  `dragHandle` mode that confines dragging to a rendered `⋮⋮` grip.

--- a/packages/xmlui-dnd-list/demo/Main.xmlui
+++ b/packages/xmlui-dnd-list/demo/Main.xmlui
@@ -1,0 +1,59 @@
+<App
+  var.cities="{[
+    { id: 'berkeley', name: 'Berkeley', country: 'US' },
+    { id: 'albany', name: 'Albany', country: 'US' },
+    { id: 'tokyo', name: 'Tokyo', country: 'JP' },
+    { id: 'vancouver', name: 'Vancouver', country: 'CA' },
+    { id: 'lisbon', name: 'Lisbon', country: 'PT' }
+  ]}"
+  var.reorderCount="{0}">
+  <VStack padding="$space-4" gap="$space-4" maxWidth="480px">
+    <Text variant="title">DndItems</Text>
+    <Text>Drag rows to reorder. Reorder count: <Text>{reorderCount}</Text></Text>
+
+    <Card padding="$space-2">
+      <DndItems data="{cities}"
+        onReorder="(newOrder) => {
+          cities = newOrder;
+          reorderCount = reorderCount + 1;
+        }">
+        <HStack
+          padding="$space-3"
+          backgroundColor="$color-surface-50"
+          border="1px solid $color-surface-200"
+          borderRadius="$borderRadius"
+          marginBottom="$space-1">
+          <Text>⋮⋮</Text>
+          <Text fontWeight="bold">{$item.name}</Text>
+          <Text color="$color-surface-500">({$item.country})</Text>
+          <SpaceFiller />
+          <Text fontSize="0.8em" color="$color-surface-400">
+            {$isFirst ? 'first' : ($isLast ? 'last' : '')}
+          </Text>
+        </HStack>
+      </DndItems>
+    </Card>
+
+    <Text variant="subtitle">dragHandle mode</Text>
+    <Text>The row stays interactive; only the ⋮⋮ grip drags.</Text>
+    <Card padding="$space-2">
+      <DndItems data="{cities}" dragHandle="true"
+        onReorder="(newOrder) => { cities = newOrder; }">
+        <HStack
+          padding="$space-3"
+          backgroundColor="$color-surface-50"
+          border="1px solid $color-surface-200"
+          borderRadius="$borderRadius"
+          marginBottom="$space-1"
+          verticalAlignment="center">
+          <TextBox initialValue="{$item.name}" width="*" />
+          <Text color="$color-surface-500">({$item.country})</Text>
+        </HStack>
+      </DndItems>
+    </Card>
+
+    <Text variant="small" color="$color-surface-500">
+      Order: {cities.map(c => c.name).join(', ')}
+    </Text>
+  </VStack>
+</App>

--- a/packages/xmlui-dnd-list/index.html
+++ b/packages/xmlui-dnd-list/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/resources/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/index.ts"></script>
+</body>
+</html>

--- a/packages/xmlui-dnd-list/index.ts
+++ b/packages/xmlui-dnd-list/index.ts
@@ -1,0 +1,13 @@
+import { startApp } from "xmlui";
+import dndList from "./src";
+
+export const runtime = import.meta.glob(`/demo/**`, { eager: true });
+startApp(runtime, [dndList]);
+
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    startApp(newModule?.runtime, [dndList]);
+  });
+}
+
+export default dndList;

--- a/packages/xmlui-dnd-list/meta/componentsMetadata.ts
+++ b/packages/xmlui-dnd-list/meta/componentsMetadata.ts
@@ -1,0 +1,13 @@
+import { DndItemsMd } from "../src/DndList";
+
+export const componentMetadata = {
+  name: "DndList",
+  state: "experimental",
+  description:
+    "This package provides a drag-and-drop sortable list. `DndItems` is a " +
+    "drop-in replacement for `Items` that adds an `onReorder` event firing " +
+    "with the new array order after a drag completes.",
+  metadata: {
+    DndItems: DndItemsMd,
+  },
+};

--- a/packages/xmlui-dnd-list/package.json
+++ b/packages/xmlui-dnd-list/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "xmlui-dnd-list",
+  "version": "0.1.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": "./src/index.tsx",
+  "scripts": {
+    "start": "xmlui start",
+    "preview": "xmlui preview",
+    "build:extension": "xmlui build-lib",
+    "build-watch": "xmlui build-lib --watch",
+    "build:demo": "xmlui build",
+    "build:meta": "xmlui build-lib --mode=metadata",
+    "prepublishOnly": "clean-package",
+    "postpublish": "clean-package restore"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2"
+  },
+  "devDependencies": {
+    "xmlui": "*"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "clean-package": {
+    "replace": {
+      "exports": {
+        ".": {
+          "import": "./dist/xmlui-dnd-list.mjs",
+          "require": "./dist/xmlui-dnd-list.js"
+        }
+      }
+    }
+  }
+}

--- a/packages/xmlui-dnd-list/src/DndList.tsx
+++ b/packages/xmlui-dnd-list/src/DndList.tsx
@@ -1,0 +1,87 @@
+// XMLUI adapter for DndListNative.
+//
+// Mirrors xmlui/src/components/Items/Items.tsx — wrapComponent + customRender
+// is the modern primitive for components that drive their own iteration.
+// customRender's context exposes the same node/renderChild/extractValue/
+// layoutContext/lookupEventHandler helpers, plus everything wrapComponent
+// adds (auto prop forwarding, automatic event registration, future hooks).
+//
+// xmlui externalizes 'xmlui' at build time, so these imports resolve to the
+// host app's standalone runtime when the extension UMD is loaded.
+import {
+  wrapComponent,
+  createMetadata,
+  MemoizedItem,
+  dComponent,
+  dInternal,
+} from "xmlui";
+import { DndListNative } from "./DndListNative";
+
+const COMP = "DndItems";
+
+export const DndItemsMd = createMetadata({
+  status: "experimental",
+  description:
+    "`DndItems` renders a sortable list of data items with drag-and-drop " +
+    "reordering. Drop-in replacement for `Items` plus an `onReorder` event " +
+    "that fires with the new array order.",
+  props: {
+    items: dInternal(`This property contains the list of data items this component renders.`),
+    data: {
+      description:
+        `This property contains the list of data items (obtained from a data source) this component renders.`,
+    },
+    reverse: {
+      description:
+        "This property reverses the order in which data is mapped to template components.",
+      valueType: "boolean",
+      defaultValue: false,
+    },
+    dragHandle: {
+      description:
+        "When true, only a rendered `⋮⋮` grip carries the drag listeners, " +
+        "leaving the rest of each row fully interactive (inputs, buttons, " +
+        "selectable text). When false (default) the whole row is draggable.",
+      valueType: "boolean",
+      defaultValue: false,
+    },
+    itemTemplate: dComponent("The component template to display a single item"),
+  },
+  events: {
+    reorder: {
+      description:
+        "Fires after a drag completes. Receives the new array of items in their reordered positions.",
+    },
+  },
+  childrenAsTemplate: "itemTemplate",
+  contextVars: {
+    $item: dComponent("Current data item being rendered"),
+    $itemIndex: dComponent("Zero-based index of current item"),
+    $isFirst: dComponent("Boolean indicating if this is the first item"),
+    $isLast: dComponent("Boolean indicating if this is the last item"),
+  },
+  opaque: true,
+});
+
+export const dndItemsComponentRenderer = wrapComponent(COMP, DndListNative, DndItemsMd, {
+  customRender: (_props, context) => {
+    const { node, renderChild, extractValue, layoutContext, lookupEventHandler } = context;
+    return (
+      <DndListNative
+        items={extractValue(node.props.items) || extractValue(node.props.data)}
+        reverse={extractValue(node.props.reverse)}
+        dragHandle={extractValue(node.props.dragHandle)}
+        onReorder={lookupEventHandler("reorder")}
+        renderItem={(contextVars, key) => (
+          <MemoizedItem
+            key={key}
+            contextVars={contextVars}
+            node={node.props.itemTemplate}
+            renderChild={renderChild}
+            layoutContext={layoutContext}
+          />
+        )}
+      />
+    );
+  },
+});

--- a/packages/xmlui-dnd-list/src/DndListNative.tsx
+++ b/packages/xmlui-dnd-list/src/DndListNative.tsx
@@ -1,0 +1,255 @@
+import {
+  Fragment,
+  type ReactNode,
+  useCallback,
+  useMemo,
+} from "react";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+// =====================================================================================================================
+// Pure React drag-and-drop sortable list. No XMLUI imports.
+//
+// API mirrors XMLUI's <Items>: takes `items` + `renderItem(contextVars, key)`,
+// where contextVars exposes `$item`, `$itemIndex`, `$isFirst`, `$isLast`.
+// One additional event: `onReorder(newItems)` — fires after a drag completes.
+//
+// Stable IDs: dnd-kit needs each item to have a stable id so it can track
+// positions during a drag. We accept an optional `getItemId(item, index)` prop;
+// the default tries `item.id`, then `item.name`, then falls back to a JSON
+// digest of the item. For typical lists of objects with id/name this is fine;
+// if it's not, callers pass `getItemId`.
+
+export type ContextVars = {
+  $item: any;
+  $itemIndex: number;
+  $isFirst: boolean;
+  $isLast: boolean;
+};
+
+export type ReorderInfo = {
+  /** The item that was dragged. */
+  item: any;
+  /** 0-based index in the canonical (un-reversed) array, before the move. */
+  fromIndex: number;
+  /** 0-based index in the canonical (un-reversed) array, after the move. */
+  toIndex: number;
+  /** Human-readable summary, e.g. "Toronto moved from position 1 to position 3".
+   *  Best-effort: derived from item.name/label/title/id or the item itself
+   *  when stringifiable. Trace consumers (Inspector, xs-trace tooling) can
+   *  surface this directly. */
+  description: string;
+};
+
+export type DndListNativeProps = {
+  items: any[];
+  renderItem: (contextVars: ContextVars, key: number) => ReactNode;
+  onReorder?: (newItems: any[], info: ReorderInfo) => void;
+  getItemId?: (item: any, index: number) => string | number;
+  reverse?: boolean;
+  /** When true, only a rendered ⋮⋮ grip carries the drag listeners; the rest
+   *  of the row stays fully interactive (inputs, buttons, text selection).
+   *  Default false keeps the v0 behavior where the whole row is the handle. */
+  dragHandle?: boolean;
+};
+
+function defaultItemLabel(item: any): string {
+  if (item == null) return "(empty)";
+  if (typeof item === "string" || typeof item === "number") return String(item);
+  if (typeof item === "object") {
+    if (item.name !== undefined) return String(item.name);
+    if (item.label !== undefined) return String(item.label);
+    if (item.title !== undefined) return String(item.title);
+    if (item.id !== undefined) return `#${String(item.id)}`;
+  }
+  return String(item);
+}
+
+const defaultGetItemId = (item: any, index: number): string | number => {
+  if (item == null) return index;
+  if (typeof item === "object") {
+    if (item.id !== undefined) return String(item.id);
+    if (item.name !== undefined) return String(item.name);
+    try {
+      return JSON.stringify(item);
+    } catch {
+      return index;
+    }
+  }
+  return String(item);
+};
+
+export function DndListNative({
+  items,
+  renderItem,
+  onReorder,
+  getItemId = defaultGetItemId,
+  reverse = false,
+  dragHandle = false,
+}: DndListNativeProps) {
+  const normalized = useMemo(() => {
+    if (!Array.isArray(items)) return [];
+    return reverse ? [...items].reverse() : items;
+  }, [items, reverse]);
+
+  // Tag each item with a stable id once per render, so the DragEndEvent
+  // active.id / over.id round-trip lands us back on the right item.
+  const idForIndex = useMemo(
+    () => normalized.map((item, idx) => String(getItemId(item, idx))),
+    [normalized, getItemId],
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      // Require a small drag distance so plain clicks don't trigger drag —
+      // important when row content has its own buttons.
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const oldLocal = idForIndex.indexOf(String(active.id));
+      const newLocal = idForIndex.indexOf(String(over.id));
+      if (oldLocal < 0 || newLocal < 0) return;
+      const newLocalOrder = arrayMove(normalized, oldLocal, newLocal);
+      // If we rendered reversed, un-reverse the reported array so the caller
+      // sees the canonical source-of-truth order.
+      const newOrder = reverse ? [...newLocalOrder].reverse() : newLocalOrder;
+
+      // Build the structured info payload. Map local indices into the canonical
+      // array space so `fromIndex`/`toIndex` describe the move in terms of the
+      // array the caller stores, not the rendered order.
+      const last = normalized.length - 1;
+      const fromIndex = reverse ? last - oldLocal : oldLocal;
+      const toIndex = reverse ? last - newLocal : newLocal;
+      const item = normalized[oldLocal];
+      const description = `${defaultItemLabel(item)} moved from position ${fromIndex + 1} to position ${toIndex + 1}`;
+
+      onReorder?.(newOrder, { item, fromIndex, toIndex, description });
+    },
+    [idForIndex, normalized, onReorder, reverse],
+  );
+
+  if (normalized.length === 0) return null;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={idForIndex} strategy={verticalListSortingStrategy}>
+        {normalized.map((item, index) => (
+          <SortableRow key={idForIndex[index]} id={idForIndex[index]} dragHandle={dragHandle}>
+            {renderItem(
+              {
+                $item: item,
+                $itemIndex: index,
+                $isFirst: index === 0,
+                $isLast: index === normalized.length - 1,
+              },
+              index,
+            )}
+          </SortableRow>
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+// SortableRow wraps each rendered child in the dnd-kit sortable hook, applying
+// transform styles. Two modes:
+//   - default: the whole row carries the drag listeners (simple lists).
+//   - dragHandle: only a rendered ⋮⋮ grip carries the listeners, so the row's
+//     own content (inputs, buttons, selectable text) stays fully interactive.
+//     The grip lives inside the extension because XMLUI markup can't spread
+//     raw pointer/keyboard listeners onto components.
+function SortableRow({
+  id,
+  dragHandle,
+  children,
+}: {
+  id: string;
+  dragHandle: boolean;
+  children: ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const baseStyle: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  if (dragHandle) {
+    return (
+      <div
+        ref={setNodeRef}
+        style={{ ...baseStyle, display: "flex", alignItems: "stretch", gap: 8 }}
+      >
+        <div
+          {...attributes}
+          {...listeners}
+          aria-label="Drag to reorder"
+          style={{
+            cursor: isDragging ? "grabbing" : "grab",
+            touchAction: "none",
+            userSelect: "none",
+            display: "flex",
+            alignItems: "center",
+            padding: "0 4px",
+            opacity: 0.5,
+            fontSize: "1.1em",
+            lineHeight: 1,
+          }}
+        >
+          ⋮⋮
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>{children}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        ...baseStyle,
+        cursor: isDragging ? "grabbing" : "grab",
+        touchAction: "none",
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      <Fragment>{children}</Fragment>
+    </div>
+  );
+}

--- a/packages/xmlui-dnd-list/src/index.tsx
+++ b/packages/xmlui-dnd-list/src/index.tsx
@@ -1,0 +1,9 @@
+import { dndItemsComponentRenderer } from "./DndList";
+
+// Namespace matches the other wrapped extension packages. Bare `<DndItems>`
+// resolves too; users can disambiguate a name collision with
+// `xmlns:Ext="component-ns:XMLUIExtensions"` on <App>.
+export default {
+  namespace: "XMLUIExtensions",
+  components: [dndItemsComponentRenderer],
+};


### PR DESCRIPTION
## Summary

Adds `xmlui-dnd-list` as a new extension package under `packages/` — a
drag-and-drop sortable list.

**`DndItems`** is a drop-in replacement for `Items`: same `data` / `reverse`
/ `itemTemplate` and the same `$item` / `$itemIndex` / `$isFirst` / `$isLast`
context vars. It adds one event, `onReorder(newOrder, info)`, which fires
after a drag completes with the new array plus
`info = { item, fromIndex, toIndex, description }` in canonical
(un-reversed) index space.

An optional **`dragHandle`** prop confines dragging to a rendered `⋮⋮` grip,
so input-heavy rows (text boxes, selects, buttons) stay fully interactive —
the whole row is the handle only when `dragHandle` is omitted.

Built on [`@dnd-kit/sortable`](https://docs.dndkit.com/) (keyboard sensors,
accessibility built in). The React core (`DndListNative`) has zero XMLUI
imports; `DndList` wraps it via `wrapComponent` + `customRender`, mirroring
core `Items` line-for-line.

## Shoutout

The original extension is [@rdhyee](https://github.com/rdhyee)'s work at
[github.com/rdhyee/xmlui-dnd-list](https://github.com/rdhyee/xmlui-dnd-list) —
including a thorough `BUILD_LOG.md` narrative of building an XMLUI extension
from scratch. This PR brings it under the xmlui-org umbrella as (I believe)
the first community-contributed extension package, with a light enhancement:
the `dragHandle` mode above. Full credit to Raymond for the foundation.

## What's here

- `packages/xmlui-dnd-list/` — package following the current wrapped-extension
  convention (`xmlui build-lib`, `index.ts` dev harness, `demo/Main.xmlui`,
  `meta/componentsMetadata.ts`, `src/{index.tsx,DndList.tsx,DndListNative.tsx}`).
- `@dnd-kit/*` in `dependencies` (bundled into the UMD; ~49 kB minified).
- Namespace `XMLUIExtensions`, matching the other wrapped packages.
- A changeset for the new package.

## Verified

- `npm run build:extension` and `npm run build:meta` both pass.
- `npm run start` demo renders both whole-row and `dragHandle` lists; drag
  reorders correctly and the grip-only mode leaves inputs interactive.
- Vendored into a downstream standalone app (Bram), where it drives a
  drag-reorderable queue — confirming the UMD self-registers against a
  standalone runtime.

@dotneteer — tagging you for review as maintainer. Happy to adjust namespace,
version, or packaging conventions to match your preferences.
