### PR TITLE
Add Markdown highlightText and highlightActive props for substring highlighting

### DIFF
--- a/xmlui/src/components/Markdown/Markdown.module.scss
+++ b/xmlui/src/components/Markdown/Markdown.module.scss
@@ -12,6 +12,9 @@ $themeVars: t.composeTextVars($themeVars, "Text") !global;
 $paddingTop-MarkDown: createThemeVar("paddingTop-Markdown");
 $paddingBottom-MarkDown: createThemeVar("paddingBottom-Markdown");
 $backgroundColor-MarkDown: createThemeVar("backgroundColor-Markdown");
+$backgroundColor-mark-markdown: createThemeVar("backgroundColor-mark-markdown");
+$textColor-mark-markdown: createThemeVar("textColor-mark-markdown");
+$backgroundColor-markActive-markdown: createThemeVar("backgroundColor-markActive-markdown");
 
 $themeVars: t.composePaddingVars($themeVars, "Blockquote-markdown");
 $themeVars: t.composeBorderVars($themeVars, "Blockquote-markdown");
@@ -213,6 +216,15 @@ $marginBottom-Details-markdown: createThemeVar("marginBottom-Details-markdown");
     :where(p, h1, h2, h3, h4, h5, h6, li, code, pre, blockquote, td, th, dt, dd, figcaption) {
       user-select: text;
       -webkit-user-select: text;
+    }
+
+    mark {
+      background-color: $backgroundColor-mark-markdown;
+      color: $textColor-mark-markdown;
+      border-radius: 2px;
+    }
+    mark[data-active="true"] {
+      background-color: $backgroundColor-markActive-markdown;
     }
 
     &.grayscale {

--- a/xmlui/src/components/Markdown/Markdown.tsx
+++ b/xmlui/src/components/Markdown/Markdown.tsx
@@ -101,6 +101,19 @@ export const MarkdownMd = createMetadata({
         "using the `| target=...` syntax will override this setting.",
       valueType: "boolean",
     },
+    highlightText: {
+      description:
+        "When set, every case-insensitive occurrence of this string in the rendered " +
+        "content is wrapped in a `<mark>` element (highlighted). Works across prose, " +
+        "code, and links. Empty or shorter than 2 characters is a no-op.",
+      valueType: "string",
+    },
+    highlightActive: {
+      description:
+        "When `true`, this Markdown block holds the active match: its first " +
+        "`highlightText` occurrence is emphasized and scrolled into view.",
+      valueType: "boolean",
+    },
     enablePlaygroundTracing: {
       description: "Automatically enables xsVerbose for xmlui-pg blocks rendered by this Markdown.",
       valueType: "boolean",
@@ -193,6 +206,10 @@ export const MarkdownMd = createMetadata({
     "width-accent-Blockquote-markdown": "3px",
     "color-accent-Blockquote-markdown": "$color-surface-500",
 
+    "backgroundColor-mark-markdown": "$color-warn-200",
+    "textColor-mark-markdown": "inherit",
+    "backgroundColor-markActive-markdown": "$color-warn-400",
+
     "borderRadius-Table-markdown": "$borderRadius",
     "textColor-Thead-markdown": "$color-surface-500",
     "backgroundColor-Thead-markdown": "$color-surface-100",
@@ -265,6 +282,8 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
     "breakMode",
     "anchorTemplate",
     "enablePlaygroundTracing",
+    "highlightText",
+    "highlightActive",
   ],
   customRender(_props, { node, extractValue, renderChild, classes }) {
     let renderedChildren = "";
@@ -303,6 +322,8 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
         overflowMode={extractValue(node.props.overflowMode) as OverflowMode | undefined}
         breakMode={extractValue(node.props.breakMode) as BreakMode | undefined}
         enablePlaygroundTracing={extractValue.asOptionalBoolean(node.props.enablePlaygroundTracing)}
+        highlightText={extractValue.asOptionalString(node.props.highlightText)}
+        highlightActive={extractValue.asOptionalBoolean(node.props.highlightActive)}
         anchorRenderer={
           node.props.anchorTemplate
             ? (anchorId: string, anchorHref: string) => (
@@ -337,6 +358,8 @@ type TransformedMarkdownProps = {
   breakMode?: BreakMode;
   enablePlaygroundTracing?: boolean;
   anchorRenderer?: (anchorId: string, anchorHref: string) => React.ReactNode;
+  highlightText?: string;
+  highlightActive?: boolean;
 };
 
 const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>(
@@ -357,6 +380,8 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
       breakMode,
       enablePlaygroundTracing,
       anchorRenderer,
+      highlightText,
+      highlightActive,
     }: TransformedMarkdownProps,
     ref,
   ) => {
@@ -409,6 +434,8 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
         overflowMode={overflowMode}
         breakMode={breakMode}
         anchorRenderer={anchorRenderer}
+        highlightText={highlightText}
+        highlightActive={highlightActive}
       >
         {markdownContent}
       </Markdown>

--- a/xmlui/src/components/Markdown/Markdown.tsx
+++ b/xmlui/src/components/Markdown/Markdown.tsx
@@ -114,6 +114,13 @@ export const MarkdownMd = createMetadata({
         "`highlightText` occurrence is emphasized and scrolled into view.",
       valueType: "boolean",
     },
+    highlightActiveIndex: {
+      description:
+        "Which occurrence (0-based, counted across the whole block) of `highlightText` is " +
+        "the active match: it is emphasized and scrolled into view. -1 or unset means none. " +
+        "Generalizes `highlightActive`.",
+      valueType: "number",
+    },
     enablePlaygroundTracing: {
       description: "Automatically enables xsVerbose for xmlui-pg blocks rendered by this Markdown.",
       valueType: "boolean",
@@ -284,6 +291,7 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
     "enablePlaygroundTracing",
     "highlightText",
     "highlightActive",
+    "highlightActiveIndex",
   ],
   customRender(_props, { node, extractValue, renderChild, classes }) {
     let renderedChildren = "";
@@ -324,6 +332,7 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
         enablePlaygroundTracing={extractValue.asOptionalBoolean(node.props.enablePlaygroundTracing)}
         highlightText={extractValue.asOptionalString(node.props.highlightText)}
         highlightActive={extractValue.asOptionalBoolean(node.props.highlightActive)}
+        highlightActiveIndex={extractValue.asOptionalNumber(node.props.highlightActiveIndex)}
         anchorRenderer={
           node.props.anchorTemplate
             ? (anchorId: string, anchorHref: string) => (
@@ -360,6 +369,7 @@ type TransformedMarkdownProps = {
   anchorRenderer?: (anchorId: string, anchorHref: string) => React.ReactNode;
   highlightText?: string;
   highlightActive?: boolean;
+  highlightActiveIndex?: number;
 };
 
 const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>(
@@ -382,6 +392,7 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
       anchorRenderer,
       highlightText,
       highlightActive,
+      highlightActiveIndex,
     }: TransformedMarkdownProps,
     ref,
   ) => {
@@ -436,6 +447,7 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
         anchorRenderer={anchorRenderer}
         highlightText={highlightText}
         highlightActive={highlightActive}
+        highlightActiveIndex={highlightActiveIndex}
       >
         {markdownContent}
       </Markdown>

--- a/xmlui/src/components/Markdown/MarkdownReact.tsx
+++ b/xmlui/src/components/Markdown/MarkdownReact.tsx
@@ -117,15 +117,16 @@ const preventPlaygroundParagraphWrap = () => {
 
 /** Rehype plugin factory: wrap case-insensitive occurrences of `needle` in
  *  <mark> nodes. Operates on the parsed hast tree, so matches inside code,
- *  inline code, and links are handled correctly with no escaping. The first
- *  match gets data-active="true" when `active` is set (the caller marks exactly
- *  one active block). */
-function makeHighlightPlugin(needle: string, active: boolean) {
+ *  inline code, and links are handled correctly with no escaping. The match
+ *  whose ordinal (0-based, counted across all text nodes in this block) equals
+ *  `activeIndex` gets data-active="true" (the caller marks exactly one active
+ *  block); -1 means no match in this block is active. */
+function makeHighlightPlugin(needle: string, activeIndex: number) {
   return function () {
     return function transformer(tree: Node) {
       const q = (needle || "").toLowerCase();
       if (q.length < 2) return;
-      let firstDone = false;
+      let matchOrdinal = 0;
       visit(tree, "text", (node: any, index: number | undefined, parent: any) => {
         if (!parent || typeof index !== "number") return;
         if (parent.tagName === "script" || parent.tagName === "style") return;
@@ -139,8 +140,8 @@ function makeHighlightPlugin(needle: string, active: boolean) {
         while (idx !== -1) {
           if (idx > last) out.push({ type: "text", value: value.slice(last, idx) });
           const matched = value.slice(idx, idx + q.length);
-          const isActive = active && !firstDone;
-          if (isActive) firstDone = true;
+          const isActive = matchOrdinal === activeIndex;
+          matchOrdinal++;
           out.push({
             type: "element",
             tagName: "mark",
@@ -226,6 +227,7 @@ type MarkdownProps = {
   anchorRenderer?: (anchorId: string, anchorHref: string) => ReactNode;
   highlightText?: string;
   highlightActive?: boolean;
+  highlightActiveIndex?: number;
 };
 
 function PreTagComponent({ id, children, codeHighlighter }) {
@@ -285,6 +287,7 @@ export const Markdown = memo(
       anchorRenderer,
       highlightText,
       highlightActive,
+      highlightActiveIndex,
       ...rest
     }: MarkdownProps,
     ref,
@@ -353,20 +356,31 @@ export const Markdown = memo(
       },
       [ref],
     );
+    const activeIndex =
+      typeof highlightActiveIndex === "number" && highlightActiveIndex >= 0
+        ? highlightActiveIndex
+        : highlightActive
+          ? 0
+          : -1;
     const rehypePlugins = useMemo(
       () =>
         highlightText && highlightText.trim().length >= 2
-          ? [...stableRehypePlugins, makeHighlightPlugin(highlightText.trim(), !!highlightActive)]
+          ? [...stableRehypePlugins, makeHighlightPlugin(highlightText.trim(), activeIndex)]
           : stableRehypePlugins,
-      [highlightText, highlightActive],
+      [highlightText, highlightActive, highlightActiveIndex],
     );
     useEffect(() => {
-      if (!highlightActive || !highlightText || highlightText.trim().length < 2) return;
+      if (
+        (!highlightActive && !(typeof highlightActiveIndex === "number" && highlightActiveIndex >= 0)) ||
+        !highlightText ||
+        highlightText.trim().length < 2
+      )
+        return;
       const el = containerRef.current?.querySelector(
         'mark[data-active="true"]',
       ) as HTMLElement | null;
       if (el) el.scrollIntoView({ block: "center", behavior: "auto" });
-    }, [highlightActive, highlightText]);
+    }, [highlightActive, highlightActiveIndex, highlightText]);
 
     const imageInfo = useRef(new Map<string, boolean>());
     if (typeof children !== "string") {

--- a/xmlui/src/components/Markdown/MarkdownReact.tsx
+++ b/xmlui/src/components/Markdown/MarkdownReact.tsx
@@ -30,7 +30,7 @@ import { markdownCodeBlockParser } from "../CodeBlock/CodeBlockReact";
 import classnames from "classnames";
 import { ThemedIcon } from "../Icon/Icon";
 import { ThemedTreeDisplay as TreeDisplay } from "../TreeDisplay/TreeDisplay";
-import { visit } from "unist-util-visit";
+import { visit, SKIP } from "unist-util-visit";
 import type { Node, Parent } from "unist";
 import { ThemedExpandableItem as ExpandableItem } from "../ExpandableItem/ExpandableItem";
 import NestedAppAndCodeViewReact, {
@@ -115,6 +115,49 @@ const preventPlaygroundParagraphWrap = () => {
   };
 };
 
+/** Rehype plugin factory: wrap case-insensitive occurrences of `needle` in
+ *  <mark> nodes. Operates on the parsed hast tree, so matches inside code,
+ *  inline code, and links are handled correctly with no escaping. The first
+ *  match gets data-active="true" when `active` is set (the caller marks exactly
+ *  one active block). */
+function makeHighlightPlugin(needle: string, active: boolean) {
+  return function () {
+    return function transformer(tree: Node) {
+      const q = (needle || "").toLowerCase();
+      if (q.length < 2) return;
+      let firstDone = false;
+      visit(tree, "text", (node: any, index: number | undefined, parent: any) => {
+        if (!parent || typeof index !== "number") return;
+        if (parent.tagName === "script" || parent.tagName === "style") return;
+        if (parent.tagName === "mark") return; // already highlighted
+        const value: string = node.value || "";
+        const hay = value.toLowerCase();
+        let idx = hay.indexOf(q);
+        if (idx === -1) return;
+        const out: any[] = [];
+        let last = 0;
+        while (idx !== -1) {
+          if (idx > last) out.push({ type: "text", value: value.slice(last, idx) });
+          const matched = value.slice(idx, idx + q.length);
+          const isActive = active && !firstDone;
+          if (isActive) firstDone = true;
+          out.push({
+            type: "element",
+            tagName: "mark",
+            properties: isActive ? { "data-active": "true" } : {},
+            children: [{ type: "text", value: matched }],
+          });
+          last = idx + q.length;
+          idx = hay.indexOf(q, last);
+        }
+        if (last < value.length) out.push({ type: "text", value: value.slice(last) });
+        parent.children.splice(index, 1, ...out);
+        return [SKIP, index + out.length]; // don't re-descend into the inserted <mark> nodes
+      });
+    };
+  };
+}
+
 /** Stable rehype plugin array — same reference across all Markdown renders. */
 const stableRehypePlugins = [rehypeRaw, replaceUnknownElements, preventPlaygroundParagraphWrap];
 
@@ -181,6 +224,8 @@ type MarkdownProps = {
   overflowMode?: OverflowMode;
   breakMode?: BreakMode;
   anchorRenderer?: (anchorId: string, anchorHref: string) => ReactNode;
+  highlightText?: string;
+  highlightActive?: boolean;
 };
 
 function PreTagComponent({ id, children, codeHighlighter }) {
@@ -238,6 +283,8 @@ export const Markdown = memo(
       overflowMode = defaultProps.overflowMode,
       breakMode = defaultProps.breakMode,
       anchorRenderer,
+      highlightText,
+      highlightActive,
       ...rest
     }: MarkdownProps,
     ref,
@@ -297,6 +344,30 @@ export const Markdown = memo(
       return classes;
     }, [breakMode]);
 
+    const containerRef = useRef<HTMLDivElement>(null);
+    const setRefs = useCallback(
+      (el: HTMLDivElement | null) => {
+        containerRef.current = el;
+        if (typeof ref === "function") ref(el);
+        else if (ref) (ref as any).current = el;
+      },
+      [ref],
+    );
+    const rehypePlugins = useMemo(
+      () =>
+        highlightText && highlightText.trim().length >= 2
+          ? [...stableRehypePlugins, makeHighlightPlugin(highlightText.trim(), !!highlightActive)]
+          : stableRehypePlugins,
+      [highlightText, highlightActive],
+    );
+    useEffect(() => {
+      if (!highlightActive || !highlightText || highlightText.trim().length < 2) return;
+      const el = containerRef.current?.querySelector(
+        'mark[data-active="true"]',
+      ) as HTMLElement | null;
+      if (el) el.scrollIntoView({ block: "center", behavior: "auto" });
+    }, [highlightActive, highlightText]);
+
     const imageInfo = useRef(new Map<string, boolean>());
     if (typeof children !== "string") {
       return null;
@@ -328,7 +399,7 @@ export const Markdown = memo(
     return (
       <div
         {...rest}
-        ref={ref}
+        ref={setRefs}
         className={classnames(
           styles.markdownContent,
           { [styles.grayscale]: grayscale },
@@ -342,7 +413,7 @@ export const Markdown = memo(
       >
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
-          rehypePlugins={stableRehypePlugins}
+          rehypePlugins={rehypePlugins}
           components={{
             details({ children, node, ...props }) {
               return (

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -12387,6 +12387,9 @@ export default {
       "paddingTop-Markdown": "var(--xmlui-paddingTop-Markdown)",
       "paddingBottom-Markdown": "var(--xmlui-paddingBottom-Markdown)",
       "backgroundColor-Markdown": "var(--xmlui-backgroundColor-Markdown)",
+      "backgroundColor-mark-markdown": "var(--xmlui-backgroundColor-mark-markdown)",
+      "textColor-mark-markdown": "var(--xmlui-textColor-mark-markdown)",
+      "backgroundColor-markActive-markdown": "var(--xmlui-backgroundColor-markActive-markdown)",
       "padding-Blockquote-markdown": "var(--xmlui-padding-Blockquote-markdown)",
       "paddingHorizontal-Blockquote-markdown": "var(--xmlui-paddingHorizontal-Blockquote-markdown, var(--xmlui-padding-Blockquote-markdown))",
       "paddingVertical-Blockquote-markdown": "var(--xmlui-paddingVertical-Blockquote-markdown, var(--xmlui-padding-Blockquote-markdown))",
@@ -12981,6 +12984,18 @@ export default {
         "description": "This boolean property specifies whether links should open in a new tab. If set to `true`, all links within the markdown will open in a new tab with `target=\"_blank\"`. Links that explicitly specify their own target using the `| target=...` syntax will override this setting.",
         "valueType": "boolean"
       },
+      "highlightText": {
+        "description": "When set, every case-insensitive occurrence of this string in the rendered content is wrapped in a `<mark>` element (highlighted). Works across prose, code, and links. Empty or shorter than 2 characters is a no-op.",
+        "valueType": "string"
+      },
+      "highlightActive": {
+        "description": "When `true`, this Markdown block holds the active match: its first `highlightText` occurrence is emphasized and scrolled into view.",
+        "valueType": "boolean"
+      },
+      "highlightActiveIndex": {
+        "description": "Which occurrence (0-based, counted across the whole block) of `highlightText` is the active match: it is emphasized and scrolled into view. -1 or unset means none. Generalizes `highlightActive`.",
+        "valueType": "number"
+      },
       "enablePlaygroundTracing": {
         "description": "Automatically enables xsVerbose for xmlui-pg blocks rendered by this Markdown.",
         "valueType": "boolean",
@@ -13078,6 +13093,9 @@ export default {
       "backgroundColor-Blockquote-markdown": "$color-surface-100",
       "width-accent-Blockquote-markdown": "3px",
       "color-accent-Blockquote-markdown": "$color-surface-500",
+      "backgroundColor-mark-markdown": "$color-warn-200",
+      "textColor-mark-markdown": "inherit",
+      "backgroundColor-markActive-markdown": "$color-warn-400",
       "borderRadius-Table-markdown": "$borderRadius",
       "textColor-Thead-markdown": "$color-surface-500",
       "backgroundColor-Thead-markdown": "$color-surface-100",


### PR DESCRIPTION
## What

Two new props on `Markdown`:

- **`highlightText`** (string) — highlight every case-insensitive occurrence of this string in the rendered content.
- **`highlightActive`** (boolean) — this block holds the active match: its first occurrence is emphasized and scrolled into view.

## How

- A **rehype plugin** walks the parsed hast tree and splits matching `text` nodes, wrapping matches in `<mark>` element nodes. Because it operates on the tree (not the source string), matches inside **code, inline code, and links** are highlighted correctly, with no escaping hacks — the same substring-decoration idea `CodeBlock` already uses, generalized to prose.
- **`highlightActive`** tags the first match with `data-active="true"` and the component `scrollIntoView({block: 'center'})`s it from an internal ref, so consumers stay declarative (no DOM access, no CSS Custom Highlight API).
- Themed via `backgroundColor-mark-markdown` / `textColor-mark-markdown` / `backgroundColor-markActive-markdown` (`$color-warn-*` defaults).

## Motivation

Powering an in-view "find" over a virtualized Markdown transcript: highlight all matches (including inside code) and center the active one. There was previously no way to highlight a substring inside rendered Markdown prose — only `CodeBlock`'s code-fence substring decorations.

## Notes

- Additive and backward-compatible: with `highlightText` unset, `Markdown` renders exactly as before (the stable rehype-plugins array is reused, so no extra allocation on the common path).
- Possible follow-ups: unit tests for the rehype plugin and a how-to doc entry.
