### PR TITLE
Docs: clarify dock vs StickyBox for bounded scroll regions, add Markdown highlight how-to

### DIFF
--- a/website/content/docs/pages/howto/highlight-inside-markdown.md
+++ b/website/content/docs/pages/howto/highlight-inside-markdown.md
@@ -1,0 +1,118 @@
+# Highlight matching text inside Markdown
+
+Wrap every occurrence of a search string in rendered Markdown with a `<mark>`,
+and step through the matches — using the `Markdown` component's `highlightText`,
+`highlightActive`, and `highlightActiveIndex` props.
+
+> [!NOTE]
+> Plain `Markdown` emits **no** `<mark>` for a substring on its own. There is no
+> hidden "find" behaviour to switch on — highlighting happens only when you set
+> `highlightText`. If you are hunting for why a `<mark>` never appears, this is
+> the answer: the prop is opt-in.
+
+## Highlight as you type
+
+Bind `highlightText` to a search box. Every case-insensitive occurrence in the
+rendered content — across prose, code, and links — is wrapped in a `<mark>`:
+
+```xmlui-pg copy display name="Highlight as you type" height="360px"
+<App var.query="scroll">
+  <VStack gap="$space-2">
+    <TextBox
+      placeholder="Highlight in the text below…"
+      width="260px"
+      value="{query}"
+      onDidChange="(v) => query = v" />
+    <Markdown highlightText="{query}"><![CDATA[
+## Scrolling in XMLUI
+
+The **scroll** position of a region is owned by one container. When a
+scroller nests inside another scroller, the inner one can defer its scroll to
+the outer one — give the inner region a firm height, set
+`scrollWholePage="false"`, and let one container own the scroll.
+
+See [Fill the viewport with one internal scroll region](/docs/howto/build-a-full-height-scroll-layout)
+for the whole-page scroll case.
+    ]]></Markdown>
+  </VStack>
+</App>
+```
+
+Type `scroll`: the word lights up in the heading, the prose, the inline
+`scrollWholePage` code, and the link text at once. Clear the box and the marks disappear. A search shorter
+than two characters is a no-op, so a single stray keystroke doesn't paint the
+whole document.
+
+## Step through the matches
+
+`highlightText` marks *every* occurrence. To make *one* of them the active match
+— emphasized with a distinct colour and scrolled into view — use
+`highlightActiveIndex` (a 0-based index across the whole block). `highlightActive`
+is the boolean shorthand for "the first one."
+
+Pair it with a find toolbar to get next/previous navigation and a match count:
+
+```xmlui-pg copy display name="Step through matches" height="360px"
+<App
+  var.doc="{`This region owns its scroll. A bounded region caps its own scroll, while an unbounded region defers to its parent. Give every scrolling region a firm height, and the region behaves. When one region contains another region, only the inner region should scroll.`}"
+  var.query="region"
+  var.active="{0}"
+  var.total="{query.length < 2 ? 0 : doc.toLowerCase().split(query.toLowerCase()).length - 1}">
+  <VStack gap="$space-2">
+    <HStack verticalAlignment="center" gap="$space-2">
+      <TextBox
+        placeholder="Find…"
+        width="180px"
+        value="{query}"
+        onDidChange="(v) => { query = v; active = 0; }" />
+      <Button
+        icon="chevronleft"
+        variant="outlined"
+        enabled="{total > 0}"
+        onClick="active = Math.max(0, active - 1)" />
+      <Button
+        icon="chevronright"
+        variant="outlined"
+        enabled="{total > 0}"
+        onClick="active = Math.min(active + 1, total - 1)" />
+      <Text
+        variant="secondary"
+        value="{query.length < 2 ? 'Type 2+ characters' : (total === 0 ? 'No matches' : (Math.min(active, total - 1) + 1) + ' of ' + total)}" />
+    </HStack>
+    <Markdown
+      content="{doc}"
+      highlightText="{query}"
+      highlightActiveIndex="{total === 0 ? -1 : Math.min(active, total - 1)}" />
+  </VStack>
+</App>
+```
+
+Next/previous move `highlightActiveIndex`; the active match takes the
+`markActive` colour while the rest keep the plain `mark` colour, and it scrolls
+into view when it is off-screen.
+
+## Key points
+
+**`highlightText` is opt-in and case-insensitive.** Every occurrence of the
+string in the rendered content is wrapped in a `<mark>` — prose, code, and link
+text alike. An empty string, or one shorter than two characters, highlights
+nothing.
+
+**`highlightActiveIndex` picks the active match.** It is 0-based and counts every
+occurrence in the block. `-1` or unset means no active match. `highlightActive="true"`
+is the shorthand for index `0`. The active match is both recoloured and scrolled
+into view.
+
+**Style the marks with theme variables.** The regular highlight uses
+`backgroundColor-mark-markdown` and `textColor-mark-markdown`; the active match
+uses `backgroundColor-markActive-markdown`. Override them to match your palette.
+
+**Counting and clamping is your job.** The component highlights and scrolls; it
+does not expose a match count or clamp the index. Derive the total from the
+source text (as `total` does above) and keep the index in `[0, total - 1]`.
+
+---
+
+**See also**
+- [Markdown component](/docs/reference/components/Markdown) — `highlightText`, `highlightActive`, `highlightActiveIndex` props
+- [Pin a toolbar above a bounded scroll region](/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region) — the find/filter toolbar layout this pairs with

--- a/website/content/docs/pages/howto/make-a-sticky-header-in-a-scroll-area.md
+++ b/website/content/docs/pages/howto/make-a-sticky-header-in-a-scroll-area.md
@@ -1,6 +1,11 @@
 # Make a sticky header in a scroll area
 
-Use StickyBox or StickySection inside a scrollable container to keep a header visible while scrolling.
+Use `StickySection` inside a scrollable container to keep document-outline section headers visible while scrolling.
+
+> [!NOTE]
+> This how-to covers **stacking section headers** — a document outline where each `StickySection` yields the pinned slot to the next as you scroll one region. Two neighbouring cases are different patterns:
+> - A *single* toolbar or header pinned above a **bounded or nested** scrolling body (a search-result expander, a card, a dialog section) → [Pin a toolbar above a bounded scroll region](/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region).
+> - A persistent **app- or page-level** bar (a "Save changes" row over the whole page) → `StickyBox`, covered in the `StickySection` vs `StickyBox` note below.
 
 A project report has four long sections. As the user scrolls, the header for the current section should stay visible at the top so readers always know where they are. `StickySection` handles the stacking logic — when multiple sections compete for the sticky slot, only the most recently scrolled-to header wins.
 
@@ -72,7 +77,7 @@ A project report has four long sections. As the user scrolls, the header for the
 </App>
 ```
 
-**`StickySection` vs `StickyBox`**: Use `StickyBox` when you need a permanently visible element that should never yield its pinned position — for example a "Save changes" action bar:
+**`StickySection` vs `StickyBox`**: Use `StickyBox` for a persistent **app- or page-level** bar that should never yield its pinned position — for example a "Save changes" action bar over the whole page:
 
 ```xmlui
 <StickyBox to="top">
@@ -83,6 +88,8 @@ A project report has four long sections. As the user scrolls, the header for the
   </HStack>
 </StickyBox>
 ```
+
+`StickyBox` finds its scroll container by walking the DOM at runtime, so its correctness is non-local — reserve it for the whole-page case. For a bar pinned over a *bounded* region, use the [dock pattern](/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region) instead, whose correctness depends only on the local subtree.
 
 **`stickTo="bottom"`**: Pins content to the bottom of the scroll container — useful for a sticky totals row at the bottom of a scrollable data section:
 
@@ -101,3 +108,4 @@ A project report has four long sections. As the user scrolls, the header for the
 - [StickyBox component](/docs/reference/components/StickyBox) — simpler always-on sticky positioning
 - [ScrollViewer component](/docs/reference/components/ScrollViewer) — scroll container required for sticky content
 - [App component](/docs/reference/components/App) — `scrollWholePage` prop
+- [Pin a toolbar above a bounded scroll region](/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region) — a single toolbar/header pinned over a bounded, nested scrolling body

--- a/website/content/docs/pages/howto/pin-a-toolbar-above-a-bounded-scroll-region.md
+++ b/website/content/docs/pages/howto/pin-a-toolbar-above-a-bounded-scroll-region.md
@@ -1,19 +1,36 @@
 # Pin a toolbar above a bounded scroll region
 
 Keep a find toolbar, filter bar, or header pinned above a scrolling body inside
-a bounded region — an expander, a panel, a detail view — using `dock`, not
-`StickyBox`, and without double-wrapping a component that already scrolls.
+a bounded region — an expander, a panel, a detail view — and stop it drifting
+off the top as the body scrolls.
 
-The whole-page case (a header that stays put while the page scrolls) is covered
-by [Fill the viewport with one internal scroll region](/docs/howto/build-a-full-height-scroll-layout).
-This how-to is about the *bounded* case: a toolbar that must stay fixed at the
-top of one region while only that region's content scrolls under it — the row
-you expand in a search-results list, a card, a dialog section.
+**Symptom → cause → fix.** A "pinned" toolbar drifts because the body is a
+scroller that *defers* its scroll instead of *capping* it. The usual culprit is
+a virtua `List` with no firm height: it hands its scroll to the nearest
+scrolling ancestor (internally, `hasOutsideScroll`), so the whole region —
+toolbar included — scrolls in that outer container. The fix is a body that
+**caps** its own scroll, with the toolbar as a **sibling** of it, never a child.
 
-The pattern is two siblings inside a height-bounded `Stack`: the toolbar docked
-to the top, the body a `ScrollViewer` (or bounded `VStack`) that fills the rest.
-The toolbar is a **sibling of** the scroller, never a child of it, so it cannot
-scroll.
+A capping scroller has two equally correct spellings:
+
+- a `ScrollViewer`, docked with `dock="stretch"` inside a height-bounded `Stack`, or
+- a bounded `VStack` with a firm height and `overflowY="auto"`.
+
+Both own their scroll locally; neither defers. Pick whichever reads better in the
+surrounding code — they are the same remedy, not a lightweight and a heavyweight
+option. This how-to shows both, then the traps that make a correct region drift
+anyway.
+
+The whole-page case (a header that stays put while the *page* scrolls) is a
+different layout — see [Fill the viewport with one internal scroll region](/docs/howto/build-a-full-height-scroll-layout).
+This how-to is the *bounded* case: one region scrolls under a fixed toolbar — the
+row you expand in a search-results list, a card, a dialog section.
+
+## The dock spelling
+
+The toolbar and the body are two siblings inside a height-bounded `Stack`: the
+toolbar `dock="top"`, the body a `ScrollViewer dock="stretch"` that fills the
+rest.
 
 ```xmlui-pg copy display name="Filter toolbar pinned above a scrolling body" height="360px"
 ---app display
@@ -56,6 +73,49 @@ the outer `Stack` — is the single scroll container in the region, and the
 toolbar sits outside it. The toolbar controls the body (the `query` variable
 drives the `Items` `data`); it never scrolls with it.
 
+## The bounded-VStack spelling
+
+The same region, spelled with a plain `VStack` body instead of a docked
+`ScrollViewer`. The toolbar is the first child; the body is a second `VStack`
+with `height="*"` (fill the leftover space) and `overflowY="auto"` (cap its own
+scroll). No `dock`, identical behaviour — this is what most existing code uses:
+
+```xmlui-pg copy display name="Same toolbar, bounded-VStack spelling" height="360px"
+---app display
+<App
+  scrollWholePage="false"
+  var.query=""
+  var.lines="{Array.from({ length: 40 }).map((_, i) => 'Matching line ' + (i + 1))}">
+  <VStack height="300px" gap="0" borderWidth="1px" borderColor="$color-surface-200">
+    <HStack
+      padding="$space-2 $space-3"
+      gap="$space-2"
+      verticalAlignment="center"
+      backgroundColor="$color-surface-100"
+      borderBottom="1px solid $color-surface-200">
+      <TextBox
+        placeholder="Filter these lines…"
+        width="220px"
+        value="{query}"
+        onDidChange="value => query = value" />
+      <SpaceFiller />
+      <Text
+        variant="secondary"
+        value="{lines.filter(l => query === '' || l.toLowerCase().includes(query.toLowerCase())).length + ' / ' + lines.length}" />
+    </HStack>
+    <VStack height="*" overflowY="auto" padding="$space-3" gap="$space-2">
+      <Items data="{lines.filter(l => query === '' || l.toLowerCase().includes(query.toLowerCase()))}">
+        <Text value="{$item}" />
+      </Items>
+    </VStack>
+  </VStack>
+</App>
+```
+
+Same result: the body caps its scroll, the toolbar is its sibling, nothing
+drifts. `dock="stretch"` and `height="*"` + `overflowY="auto"` are two ways to
+say "fill the leftover height and own the scroll there."
+
 Match-to-match *navigation and highlighting* — jumping between hits, drawing a
 `<mark>` on the matched text inside rendered content — is a separate concern
 from this layout; see the note under "Do not reach for `StickyBox`" and the
@@ -63,6 +123,15 @@ Markdown highlight how-to. This example keeps the toolbar honest with live
 filtering, which is enough to prove the layout.
 
 ## Key points
+
+**Use a scroller that caps, not one that defers.** The body must own its scroll.
+A `ScrollViewer` and a bounded `VStack` with `overflowY="auto"` both *cap* — the
+scroll stops at the region. A virtua `List` with no firm height does the
+opposite: it *defers*, handing its scroll to the nearest scrolling ancestor
+(`hasOutsideScroll`), so the toolbar rides that outer scroll and drifts. If your
+body is a `List`, give it a firm height (or move the toolbar outside the `List`'s
+own scroll) — the point is a local, capping scroll, whichever component provides
+it.
 
 **The bounded parent must own a height.** `dock="stretch"` fills the space left
 over after the docked toolbar, but only if the parent `Stack` has an explicit
@@ -117,10 +186,11 @@ That works when the scroll container is unambiguous — app-level or page-level
 chrome, where the page itself is the one scroller. In a bounded, nested region
 the container it discovers is ambiguous, and its runtime pinning ends up
 fighting exactly the kind of wrapper described above. For a toolbar over a
-bounded body, the `dock` pattern is self-contained: its correctness depends only
-on this `Stack` and its two children, not on what encloses them. Reserve
+bounded body, a capping scroller is self-contained: its correctness depends only
+on this region and its two children, not on what encloses them. Reserve
 `StickyBox` for a persistent app-level bar (a "Save changes" action row that
-stays visible over the whole page) and use `dock` for everything bounded.
+stays visible over the whole page) and use a capping scroller for everything
+bounded.
 
 ---
 

--- a/website/content/docs/reference/components/StickyBox.md
+++ b/website/content/docs/reference/components/StickyBox.md
@@ -2,6 +2,24 @@
 
 `StickyBox` remains fixed at the top or bottom of the screen as the user scrolls.
 
+**When to use.** `StickyBox` fits app- and page-level chrome whose scroll
+container is the page itself — a persistent navigation bar, or a "Save changes"
+bar pinned to the bottom of the viewport.
+
+For a header or toolbar that stays visible over a **bounded or nested** scroll
+region (an expander, a card, a dialog body), use the `dock` layout pattern
+instead — see
+[Pin a toolbar above a bounded scroll region](/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region).
+`StickyBox` discovers its scroll container at runtime and writes a
+document-global scroll offset, so its effect is non-local and it does not
+compose reliably inside a nested scroll area.
+
+> [!NOTE]
+> `StickyBox` is built on
+> [`react-sticky-el`](https://github.com/gm0t/react-sticky-el), which has a
+> known defect under React `StrictMode`
+> ([react-sticky-el #82](https://github.com/gm0t/react-sticky-el/issues/82)).
+
 ## Behaviors [#behaviors]
 
 This component supports the following behaviors:

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -896,6 +896,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Highlight matching text inside Markdown"
+                            to="/docs/howto/highlight-inside-markdown"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Fill the viewport with one internal scroll region"
                             to="/docs/howto/build-a-full-height-scroll-layout"
                         />
@@ -2529,6 +2534,11 @@
             <Page url="/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/pin-a-toolbar-above-a-bounded-scroll-region.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/highlight-inside-markdown">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/highlight-inside-markdown.md']}"
                 />
             </Page>
             <Page url="/docs/howto/build-a-full-height-scroll-layout">

--- a/xmlui/src/components/StickyBox/StickyBox.md
+++ b/xmlui/src/components/StickyBox/StickyBox.md
@@ -1,3 +1,25 @@
+%-desc-START
+
+**When to use.** `StickyBox` fits app- and page-level chrome whose scroll
+container is the page itself — a persistent navigation bar, or a "Save changes"
+bar pinned to the bottom of the viewport.
+
+For a header or toolbar that stays visible over a **bounded or nested** scroll
+region (an expander, a card, a dialog body), use the `dock` layout pattern
+instead — see
+[Pin a toolbar above a bounded scroll region](/docs/howto/pin-a-toolbar-above-a-bounded-scroll-region).
+`StickyBox` discovers its scroll container at runtime and writes a
+document-global scroll offset, so its effect is non-local and it does not
+compose reliably inside a nested scroll area.
+
+> [!NOTE]
+> `StickyBox` is built on
+> [`react-sticky-el`](https://github.com/gm0t/react-sticky-el), which has a
+> known defect under React `StrictMode`
+> ([react-sticky-el #82](https://github.com/gm0t/react-sticky-el/issues/82)).
+
+%-DESC-END
+
 %-PROP-START to
 
 ```xmlui-pg copy display name="Example: to" height="200px"


### PR DESCRIPTION
## What

Four documentation changes that sort out the sticky / scroll how-to family and add the missing Markdown-highlight how-to:

- **StickyBox reference** — a "When to use" note: StickyBox fits app/page-level chrome; it discovers its scroll container at runtime (`react-sticky-el`) so its effect is non-local, and it carries a `StrictMode` caveat ([react-sticky-el #82](https://github.com/gm0t/react-sticky-el/issues/82)). Bounded cases are pointed at the dock pattern.
- **New how-to: Highlight matching text inside Markdown** — documents `highlightText` / `highlightActive` / `highlightActiveIndex` (from #3664) with two runnable examples (highlight-as-you-type, and a find toolbar that steps through matches). States plainly that plain `Markdown` emits no `<mark>` without `highlightText`.
- **Reframe the #3666 pin-a-toolbar how-to** — lead with the structural principle instead of `dock`: a pinned toolbar drifts because the body is a scroller that *defers* (a virtua `List` with no firm height, via `hasOutsideScroll`) rather than *caps*. Present `ScrollViewer dock="stretch"` and a bounded `VStack` + `overflowY="auto"` as **co-equal spellings** of one remedy, each as a runnable example. Traps (double-wrap, diagnose-by-differencing, StickyBox-non-local) unchanged.
- **Scope the make-a-sticky-header how-to** to `StickySection` document-outline headers, routing the bounded single-toolbar case to the pin-a-toolbar how-to and the app-level bar case to StickyBox.

Refs #3664, #3666.

## Why

@dotneteer — after #3666 I felt we were left unclear about **`dock` vs the #3666 pattern**: whether they were two different things, and when to reach for which. Digging into an actual toolbar-drift case (verified in xmlui source) turned up a sharper framing than "use dock":

- The real cause of drift is a **scroller that defers** — a virtua `List` with no firm height hands its scroll to the nearest scrolling ancestor (`ListReact.tsx` `hasOutsideScroll`). `ScrollViewer` is plain CSS overflow and does **not** defer (`ScrollViewerReact.tsx`).
- So `dock="stretch"` (a `ScrollViewer`) and a bounded `VStack` + `overflowY:auto` are **two spellings of one principle** — a scroller that caps + a toolbar that is its sibling — not a heavyweight and a lightweight option. #3666 wasn't wrong, it just over-indexed on `dock` and hid the principle.

This PR reframes #3666 around that principle and lines up the neighbouring docs so the family stops pointing at the wrong tool.

**Two questions for you:**

1. Does this reframing make the **`dock` vs #3666 pattern** relationship clear — or is there still an ambiguity you'd want resolved differently?
2. Do you agree with the **StickyBox caveats** — non-local runtime scroll-container discovery, the `StrictMode` issue, "reserve it for app-level chrome"? I stopped short of an actual `status` change or hard deprecation; the note is guidance only. Say the word if you want it stronger (or softer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
