### PR TITLE
Docs: reconcile the AppState deprecation (globals how-to, tutorial callout, reference reframe)

### DIFF
--- a/website/content/docs/pages/howto/manage-app-wide-state-with-reactive-globals.md
+++ b/website/content/docs/pages/howto/manage-app-wide-state-with-reactive-globals.md
@@ -1,0 +1,123 @@
+# Manage app-wide state with reactive globals
+
+Declare a `global` on the app root; any component — however deeply nested —
+reads and writes it by name, with no prop-drilling and no `AppState`.
+
+> [!NOTE]
+> This is the current pattern for app-wide shared state. The
+> [`AppState`](/docs/reference/components/AppState) component is **deprecated**;
+> the [Migrating from AppState](#migrating-from-appstate) section below shows the
+> one-to-one equivalent.
+
+## One global, read and written anywhere
+
+A `global` declared on the `App` root is visible everywhere in the app.
+`SessionBar` (a user-defined component) reads it; `ThemeToggle` writes it; the
+read updates automatically:
+
+```xmlui-pg copy display name="One global, read and written anywhere" height="220px"
+---app display
+<App global.session="{ { user: 'Ada', theme: 'light' } }">
+  <VStack gap="$space-3" padding="$space-3">
+    <SessionBar />
+    <ThemeToggle />
+  </VStack>
+</App>
+
+<Component name="SessionBar">
+  <HStack verticalAlignment="center" gap="$space-2">
+    <Text variant="strong">{session.user}</Text>
+    <Text variant="secondary">theme: {session.theme}</Text>
+  </HStack>
+</Component>
+
+<Component name="ThemeToggle">
+  <Button
+    label="Toggle theme"
+    onClick="session = { ...session, theme: session.theme === 'light' ? 'dark' : 'light' }" />
+</Component>
+```
+
+Neither component receives `session` as a prop. `ThemeToggle` reassigns it, and
+every reader — here `SessionBar`, in a real app any number of them — re-renders.
+Reassign the whole object (`{ ...session, theme }`) rather than mutating a field,
+so the change is a new value the reactive engine can see.
+
+Declare globals in one of two places only: the root element of `Main.xmlui`
+(with `global.` or a `<global>` tag), or as top-level declarations in a
+`Globals.xs` code-behind file. They **cannot** be declared inside a user-defined
+component file.
+
+## `var.` on an ancestor vs a `global`
+
+Reach for a `global` only when the state is genuinely app-wide. If the state
+belongs to *one view*, put a `var.` on the closest common ancestor instead — it
+is scoped, resets when that subtree unmounts, and won't collide with anything
+elsewhere.
+
+- **Subtree** (`var.` on a common ancestor) — a filter applied on this page, a
+  tab selected in this dialog. The right default. See
+  [Communicate between sibling components](/docs/howto/communicate-between-sibling-components).
+- **Global** (`global.` on the app root) — current user, theme, feature flags:
+  anything read from inside arbitrary user-defined components without
+  prop-threading, that should persist across navigation.
+
+The practical trigger to go global: at least one consumer is a user-defined
+component nested below the common ancestor. Subtree `var.`s don't cross
+user-defined-component boundaries; globals do. [Scoping](/docs/guides/scoping)
+has the full mechanics and the reasons not to reach for globals by default
+(instances couple, names collide, state goes stale across navigation).
+
+## Migrating from AppState
+
+`AppState` stored a bucket and mutated it through `update()`. A `global` holds
+the same object and is updated by plain assignment:
+
+```xmlui
+<!-- Legacy: AppState -->
+<App>
+  <AppState id="settings" bucket="settings" initialValue="{ { theme: 'light' } }" />
+  <Button label="Dark" onClick="settings.update({ theme: 'dark' })" />
+  <Text>{settings.value.theme}</Text>
+</App>
+```
+
+```xmlui
+<!-- Current: reactive global -->
+<App global.settings="{ { theme: 'light' } }">
+  <Button label="Dark" onClick="settings = { ...settings, theme: 'dark' }" />
+  <Text>{settings.theme}</Text>
+</App>
+```
+
+The mapping:
+
+| AppState | reactive global |
+| --- | --- |
+| `<AppState bucket="settings" initialValue="{…}" />` | `global.settings="{…}"` on the `App` root |
+| read `settings.value.theme` | read `settings.theme` |
+| write `settings.update({ theme: 'dark' })` | `settings = { ...settings, theme: 'dark' }` |
+| `settings.appendToList('ids', id)` | `settings = { ...settings, ids: [...settings.ids, id] }` |
+
+## Key points
+
+**Declare globals only on the app root or in `Globals.xs`.** A `global.` on a
+nested element or inside a user-defined component file is an error.
+
+**Reassign, don't mutate.** Write a new object (`{ ...state, field: value }`) so
+the reactive engine sees a new value. Mutating a field in place may not trigger
+readers.
+
+**Prefer the smallest scope that works.** A `var.` on a common ancestor is the
+default; go global only when a nested user-defined component must read or write
+the state, or it must outlive the view.
+
+---
+
+## See also
+
+- [Communicate between sibling components](/docs/howto/communicate-between-sibling-components) — subtree sharing with `var.` on a common ancestor
+- [Toggle multiple items with shared state](/docs/howto/toggle-multiple-items-with-shared-state) — a shared array as a multi-selection filter
+- [Keep per-item state in a loop](/docs/howto/keep-per-item-state-in-a-loop) — per-row state inside `Items`/`List`
+- [Scoping](/docs/guides/scoping) — the full rules for `var.`, `global.`, and `Globals.xs`
+- [AppState component](/docs/reference/components/AppState) — the deprecated component this pattern replaces

--- a/website/content/docs/pages/tutorial-12.md
+++ b/website/content/docs/pages/tutorial-12.md
@@ -2,6 +2,9 @@
 
 The `Settings` component demonstrates how to manage application state that persists between sessions using [AppState](/docs/reference/components/AppState), [DataSource](/docs/reference/components/DataSource), and [APICall](/docs/reference/components/APICall) working together.
 
+> [!WARNING]
+> This tutorial reflects the XMLUI Invoice app, which uses the [`AppState`](/docs/reference/components/AppState) component. **`AppState` is deprecated.** For new apps, manage app-wide state with reactive globals instead — see [Manage app-wide state with reactive globals](/docs/howto/manage-app-wide-state-with-reactive-globals), which includes a one-to-one AppState → globals migration. The pattern below still works and is kept here because it matches the existing app; read it as a walkthrough of that app, not as the recommended approach for new code.
+
 ## State management pattern
 
 XMLUI Invoice uses a three-component pattern for persistent settings:

--- a/website/content/docs/reference/components/AppState.md
+++ b/website/content/docs/reference/components/AppState.md
@@ -1,16 +1,15 @@
 # AppState [#appstate]
 
 >[!WARNING]
-> The AppState component is deprecated. We will remove it in a future release. Please use [global variables](/docs/guides/markup#global-variables) instead.
+> The AppState component is deprecated. We will remove it in a future release. Use [reactive globals](/docs/howto/manage-app-wide-state-with-reactive-globals) for app-wide state instead.
 
-`AppState` is an invisible component that provides global state management across your entire application. Unlike component variables that are scoped locally, AppState allows any component to access and update shared state without prop drilling.
+`AppState` is an invisible component that holds app-wide shared state any component can read and update without prop drilling. It is deprecated; new apps should use reactive globals instead.
 
-**Key advantages over variables:**
-- **Global accessibility**: Any component can access the state by referencing the same `bucket`
-- **Automatic reactivity**: UI updates automatically when state changes, no manual prop passing required
-- **Cross-component coordination**: Perfect for user sessions, UI preferences, loading states, and shared data
+The modern equivalent is a **reactive global**: declare `global.state="{...}"` on the app root, and any component reads or writes it by name — the same prop-drilling-free sharing, without an `AppState` instance per consumer. See [Manage app-wide state with reactive globals](/docs/howto/manage-app-wide-state-with-reactive-globals) for the pattern and a one-to-one `AppState` → globals migration.
 
-## Using AppState [#using-appstate]
+The rest of this page documents `AppState` as it works today, for apps that still use it.
+
+## Using AppState (legacy) [#using-appstate-legacy]
 
 Variables in xmlui are a straightforward tool for managing states. However, a variable's scope is the app's main file or the particular component file in which it is declared. To access the variable's value (the stored state), you must pass its value to components wanting to leverage it.
 
@@ -57,7 +56,7 @@ This situation is where `AppState` comes into the picture. With an `AppState` in
 
 Let's turn the previous example into one using `AppState`! The following code shows how we change the main app file:
 
-```xmlui-pg name="Storing State in AppState" 
+```xmlui-pg name="Storing State in AppState"
 ---app copy display filename="Main.xmlui"
 <App>
   <AppState id="appState" initialValue="{{ enhancedMode: false }}"/>

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1189,6 +1189,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Manage app-wide state with reactive globals"
+                            to="/docs/howto/manage-app-wide-state-with-reactive-globals"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Buffer a reactive edit"
                             to="/docs/howto/buffer-a-reactive-edit"
                         />
@@ -2687,6 +2692,11 @@
             <Page url="/docs/howto/communicate-between-sibling-components">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/communicate-between-sibling-components.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/manage-app-wide-state-with-reactive-globals">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/manage-app-wide-state-with-reactive-globals.md']}"
                 />
             </Page>
 

--- a/xmlui/src/components/AppState/AppState.md
+++ b/xmlui/src/components/AppState/AppState.md
@@ -1,11 +1,10 @@
 %-DESC-START
 
-**Key advantages over variables:**
-- **Global accessibility**: Any component can access the state by referencing the same `bucket`
-- **Automatic reactivity**: UI updates automatically when state changes, no manual prop passing required
-- **Cross-component coordination**: Perfect for user sessions, UI preferences, loading states, and shared data
+The modern equivalent is a **reactive global**: declare `global.state="{...}"` on the app root, and any component reads or writes it by name — the same prop-drilling-free sharing, without an `AppState` instance per consumer. See [Manage app-wide state with reactive globals](/docs/howto/manage-app-wide-state-with-reactive-globals) for the pattern and a one-to-one `AppState` → globals migration.
 
-## Using AppState
+The rest of this page documents `AppState` as it works today, for apps that still use it.
+
+## Using AppState (legacy)
 
 Variables in xmlui are a straightforward tool for managing states. However, a variable's scope is the app's main file or the particular component file in which it is declared. To access the variable's value (the stored state), you must pass its value to components wanting to leverage it.
 

--- a/xmlui/src/components/AppState/AppState.tsx
+++ b/xmlui/src/components/AppState/AppState.tsx
@@ -8,13 +8,13 @@ const COMP = "AppState";
 export const AppStateMd = createMetadata({
   status: "stable",
   description:
-    "`AppState` is an invisible component that provides global state management " +
-    "across your entire application. Unlike component variables that are scoped " +
-    "locally, AppState allows any component to access and update shared state " +
-    "without prop drilling.",
+    "`AppState` is an invisible component that holds app-wide shared state any " +
+    "component can read and update without prop drilling. It is deprecated; new " +
+    "apps should use reactive globals instead.",
   deprecationMessage:
     "The AppState component is deprecated. We will remove it in a future release. " +
-    "Please use [global variables](/docs/guides/markup#global-variables) instead.",
+    "Use [reactive globals](/docs/howto/manage-app-wide-state-with-reactive-globals) " +
+    "for app-wide state instead.",
   events: {
     didUpdate: {
       description:

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -2743,8 +2743,8 @@ export default {
   },
   "AppState": {
     "status": "stable",
-    "description": "`AppState` is an invisible component that provides global state management across your entire application. Unlike component variables that are scoped locally, AppState allows any component to access and update shared state without prop drilling.",
-    "deprecationMessage": "The AppState component is deprecated. We will remove it in a future release. Please use [global variables](/docs/guides/markup#global-variables) instead.",
+    "description": "`AppState` is an invisible component that holds app-wide shared state any component can read and update without prop drilling. It is deprecated; new apps should use reactive globals instead.",
+    "deprecationMessage": "The AppState component is deprecated. We will remove it in a future release. Use [reactive globals](/docs/howto/manage-app-wide-state-with-reactive-globals) for app-wide state instead.",
     "events": {
       "didUpdate": {
         "description": "This event is fired when the AppState value is updated. The event provides the new state value as its parameter.",


### PR DESCRIPTION
## What

Reconciles the docs' self-contradiction on `AppState` (#3670): the component reference marked it deprecated, but the two most discoverable state docs still taught it as the recommended pattern. Three commits:

- **New how-to: Manage app-wide state with reactive globals** — the orienting page that didn't exist. A runnable `global` read/written across user-defined components, when to use `var.` on an ancestor vs a `global`, and an explicit `AppState` → globals migration (`bucket`/`update()`/`appendToList` → `global` + reassignment). Registered in `Main.xmlui`, cross-links the narrow state how-tos.
- **Flag AppState as deprecated in the Settings tutorial** — `tutorial-12` taught AppState as the current pattern with no deprecation note. Added a warning callout linking the new how-to; the AppState-based body is left intact so it stays in sync with the real Invoice app it documents.
- **Reframe the AppState reference as legacy** — the deprecation now points at the new how-to, the description is softened, the "Key advantages over variables" pitch is replaced by the reactive-global equivalent + migration link, and the walkthrough is marked legacy. The `update()` API doc is kept for existing users.

## Acceptance (from #3670)

- ✅ Searching the how-to set for state management lands on a page recommending reactive globals and marking AppState legacy.
- ✅ `tutorial-12` no longer presents AppState as the current pattern without flagging it.
- ✅ The AppState reference body no longer reads as a recommendation.
- ✅ No remaining doc presents AppState as the preferred approach.

Refs #3670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
