### PR TITLE
Docs: add vertical-fill how-to and strengthen vertical centering (layout axis symmetry)

### DIFF
--- a/website/content/docs/pages/howto/center-content-on-the-page.md
+++ b/website/content/docs/pages/howto/center-content-on-the-page.md
@@ -20,6 +20,28 @@ A login page should display a single card perfectly centred horizontally and ver
 </App>
 ```
 
+## Center only vertically
+
+Vertical centering has one precondition that trips people up: it does nothing
+until the container **has a height to center within**. The block below is
+centered vertically only (left-aligned) inside a region that fills the height:
+
+```xmlui-pg copy display name="Centered vertically in a filled region" height="340px"
+---app display
+<App scrollWholePage="false">
+  <VStack height="100%" verticalAlignment="center" padding="$space-4" backgroundColor="$color-surface-100">
+    <H4>Vertically centered</H4>
+    <Text>This sits in the vertical middle because the VStack fills the height (height="100%" with scrollWholePage="false") and sets verticalAlignment="center".</Text>
+    <Text variant="secondary">Drop the height and it snaps to the top — vertical centering has nothing to center within.</Text>
+  </VStack>
+</App>
+```
+
+If content you expected to be vertically centered is stuck at the top, the
+container collapsed to content height. Give it `height="100vh"`, `height="100%"`
+with `scrollWholePage="false"`, or make it a `height="*"` child of a bounded
+parent — see [Make a child fill the remaining vertical space](/docs/howto/fill-remaining-vertical-space).
+
 ## Key points
 
 **`CVStack`**: Shorthand for a vertical `Stack` with `horizontalAlignment="center"` and `verticalAlignment="center"`. The most concise way to centre children in both axes:
@@ -39,7 +61,7 @@ A login page should display a single card perfectly centred horizontally and ver
 </CHStack>
 ```
 
-**Parent height determines vertical centring**: `verticalAlignment="center"` only takes effect when the parent has a defined height. Use `height="100vh"` to fill the viewport, or `height="100%"` with `scrollWholePage="false"` to fill the remaining content area between header and footer.
+**Vertical centering needs a filled container — this is the usual bug**: `verticalAlignment="center"` (and `CVStack`) do nothing until the parent has a real height to center within. If content sticks to the top, the container collapsed to content height. Give it `height="100vh"`, `height="100%"` with `scrollWholePage="false"`, or make it a `height="*"` child of a bounded parent — see [Make a child fill the remaining vertical space](/docs/howto/fill-remaining-vertical-space).
 
 **Fixed width on the card**: A fixed width works well for login forms and other centred dialogs:
 
@@ -64,6 +86,7 @@ A login page should display a single card perfectly centred horizontally and ver
 ---
 
 **See also**
+- [Make a child fill the remaining vertical space](/docs/howto/fill-remaining-vertical-space) — the `height="*"` precondition that vertical centering depends on
 - [Stack component](/docs/reference/components/Stack) — `horizontalAlignment`, `verticalAlignment`, and dock layout
 - [CVStack component](/docs/reference/components/CVStack) — centred vertical stack shorthand
 - [CHStack component](/docs/reference/components/CHStack) — centred horizontal stack shorthand

--- a/website/content/docs/pages/howto/fill-remaining-vertical-space.md
+++ b/website/content/docs/pages/howto/fill-remaining-vertical-space.md
@@ -1,0 +1,121 @@
+# Make a child fill the remaining vertical space
+
+Give a `VStack` child `height="*"` and it takes the **remaining** vertical
+space — the parent's height minus the siblings that have a definite or natural
+height. It is the vertical mirror of `width="*"` in a row.
+
+> [!IMPORTANT]
+> `height="*"` only works if the height chain is **bounded at the top**. If no
+> ancestor has a real height, "available height" is just content height, nothing
+> is left over, and the starred child collapses to its content — the number-one
+> reason `height="*"` "does nothing." Bound the top with `App`
+> `scrollWholePage="false"` (fills the viewport), `height="100vh"`, or an
+> explicit container height.
+
+## The pattern
+
+A header and footer keep their natural height. Give the body `height="*"` and it
+fills everything they leave — flip it to `auto` or a fixed height with the
+buttons and watch the fill disappear:
+
+```xmlui-pg copy display name="Body height: * vs auto vs a fixed value" height="520px"
+---app display
+<App scrollWholePage="false" var.bh="*">
+  <VStack padding="$space-3" gap="$space-3">
+    <HStack verticalAlignment="center" gap="$space-2">
+      <Text variant="strong">Body height:</Text>
+      <Button label="*" variant="{bh === '*' ? 'solid' : 'outlined'}" onClick="bh = '*'" />
+      <Button label="auto" variant="{bh === 'auto' ? 'solid' : 'outlined'}" onClick="bh = 'auto'" />
+      <Button label="160px" variant="{bh === '160px' ? 'solid' : 'outlined'}" onClick="bh = '160px'" />
+    </HStack>
+    <VStack height="380px" gap="0" borderWidth="1px" borderColor="$color-surface-300">
+      <HStack padding="$space-3" backgroundColor="$color-primary-100">
+        <Text variant="strong">Header — natural height</Text>
+      </HStack>
+      <VStack
+        height="{bh}"
+        padding="$space-3"
+        gap="$space-2"
+        verticalAlignment="center"
+        backgroundColor="$color-surface-100"
+        borderVertical="2px dashed $color-primary-300">
+        <Text variant="strong">Body — height="{bh}"</Text>
+        <Text>Only "*" pushes the footer to the bottom. "auto" shrinks to this text and "160px" is a fixed slab — either way the rows bunch at the top and the leftover height falls below.</Text>
+      </VStack>
+      <HStack padding="$space-3" backgroundColor="$color-primary-100">
+        <Text variant="strong">Footer — natural height</Text>
+      </HStack>
+    </VStack>
+  </VStack>
+</App>
+```
+
+The inner `VStack` is a fixed-height bounded container (`height="380px"`). With
+the body at `height="*"` it consumes whatever the header and footer leave, so the
+footer sits on the bottom edge. Switch the body to `auto` (hug its text) or
+`160px` (a fixed slab) and it no longer fills — the three rows collapse to the top
+and the leftover height opens up below the footer. Only `*` expands to take the
+remainder. (Remove the container's `height` entirely and even `*` collapses —
+with no bounded parent there is nothing to divide.)
+
+## Key points
+
+**Bound the height chain at the top — this is the usual bug.** `height="*"`
+divides *available* height among star-sized children. "Available" is only real if
+some ancestor has a definite height: the `App` with `scrollWholePage="false"`, a
+`height="100vh"`/`height="100%"` container, or an explicit pixel/`rem` height.
+Without it there is nothing to divide and `height="*"` looks like it does
+nothing.
+
+**Siblings take their height first; the star gets the rest.** Exactly like
+`width="*"`: the starred child receives the parent's height minus the siblings
+with a definite or natural height. Give a fixed panel a real height (or let it
+size to content) so the starred region has a stable remainder.
+
+**Multiple `height="*"` children split the space.** Two starred siblings share
+the leftover height proportionally (`height="*"` each = 50/50), the same
+proportional rule as star widths. Change the top region's height to compare an
+even split, a weighted split, and a fixed value against the always-starred bottom:
+
+```xmlui-pg copy display name="Top region: equal star, weighted star, or fixed" height="440px"
+---app display
+<App scrollWholePage="false" var.top="*">
+  <VStack padding="$space-3" gap="$space-3">
+    <HStack verticalAlignment="center" gap="$space-2">
+      <Text variant="strong">Top region height:</Text>
+      <Button label="*" variant="{top === '*' ? 'solid' : 'outlined'}" onClick="top = '*'" />
+      <Button label="2*" variant="{top === '2*' ? 'solid' : 'outlined'}" onClick="top = '2*'" />
+      <Button label="120px" variant="{top === '120px' ? 'solid' : 'outlined'}" onClick="top = '120px'" />
+    </HStack>
+    <VStack height="320px" gap="0" borderWidth="1px" borderColor="$color-surface-300">
+      <HStack padding="$space-3" backgroundColor="$color-primary-100">
+        <Text variant="strong">Header — natural height</Text>
+      </HStack>
+      <VStack height="{top}" backgroundColor="$color-primary-50" verticalAlignment="center" horizontalAlignment="center">
+        <Text variant="strong">Top — height="{top}"</Text>
+      </VStack>
+      <VStack height="*" backgroundColor="$color-surface-200" verticalAlignment="center" horizontalAlignment="center">
+        <Text variant="strong">Bottom — height="*"</Text>
+      </VStack>
+    </VStack>
+  </VStack>
+</App>
+```
+
+`*` vs `*` splits evenly; `2*` makes the top twice the bottom (weights, like star
+widths); `120px` drops the top out of the star math entirely — it takes a fixed
+slab and the bottom `*` absorbs the rest.
+
+**It is the vertical mirror of `width="*"`.** The star rule is identical on both
+axes — remaining space after definite-size siblings, inside a bounded parent. If
+a `width="*"` how-to already solves your row, the same shape solves your column.
+
+---
+
+## See also
+
+- [Stop a `width="*"` element from collapsing next to a flexible sibling](/docs/howto/keep-a-star-sized-element-from-collapsing) — the horizontal mirror and the "starred child squeezed to a sliver" trap
+- [Fill the viewport with one internal scroll region](/docs/howto/build-a-full-height-scroll-layout) — when the filled region should scroll internally
+- [Center content on the page](/docs/howto/center-content-on-the-page) — centering *within* a container that fills the height
+- [Stack component](/docs/reference/components/Stack) — `height`, star sizing, and alignment
+- [Layout Properties](/docs/styles-and-themes/layout-props) — sizing units including `*`

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -911,6 +911,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Make a child fill the remaining vertical space"
+                            to="/docs/howto/fill-remaining-vertical-space"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Build a responsive card grid"
                             to="/docs/howto/build-a-responsive-card-grid"
                         />
@@ -2544,6 +2549,11 @@
             <Page url="/docs/howto/keep-a-star-sized-element-from-collapsing">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/keep-a-star-sized-element-from-collapsing.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/fill-remaining-vertical-space">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/fill-remaining-vertical-space.md']}"
                 />
             </Page>
             <Page url="/docs/howto/build-a-responsive-card-grid">


### PR DESCRIPTION
## What

Fixes the horizontal/vertical asymmetry in the layout how-tos (#3671): the horizontal axis is well covered, but there was no how-to for filling remaining vertical height, and the vertical-centering case was thin.

- **New how-to: Make a child fill the remaining vertical space** — the `height="*"` vertical mirror of the `width="*"` how-tos. Leads with the bounded-height precondition (the #1 reason `height="*"` "does nothing"), and has two **interactive** playgrounds: one flips the body between `*` / `auto` / `160px`, the other flips a starred sibling between `*` / `2*` / `120px` — so the reader sees `*` next to non-`*` values. Registered in `Main.xmlui`.
- **Strengthen the vertical case in Center content on the page** — a vertical-only runnable example, the "vertical centering needs a filled container" precondition promoted to a named key point, and cross-links to the new how-to both ways.

## Acceptance (from #3671)

- ✅ Searching "fill remaining vertical space" / "height star sizing" / "vertical center" now lands on a page that answers it directly, with runnable examples.
- ✅ The examples make the bounded-height precondition explicit (the usual "`height="*"` does nothing" cause).
- ✅ Horizontal/vertical how-to coverage is symmetric.

Refs #3671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
