### PR TITLE
Markdown highlightText: accept multiple terms (string | string[]) with document-order active index

### DIFF
--- a/website/content/docs/reference/components/Markdown.md
+++ b/website/content/docs/reference/components/Markdown.md
@@ -246,6 +246,18 @@ Use this property when the text you provide is not static but a result of calcul
 
 This boolean property specifies whether images should be displayed in grayscale. If set to `true`, all images within the markdown will be rendered in grayscale.
 
+### `highlightActive` [#highlightactive]
+
+When `true`, this Markdown block holds the active match: its first `highlightText` occurrence is emphasized and scrolled into view.
+
+### `highlightActiveIndex` [#highlightactiveindex]
+
+Which occurrence (0-based) of `highlightText` is the active match: it is emphasized and scrolled into view. Occurrences are counted **across all terms in document order**, so stepping the index walks every `<mark>` top-to-bottom regardless of which term produced it. -1 or unset means none. Generalizes `highlightActive`.
+
+### `highlightText` [#highlighttext]
+
+When set, wraps every case-insensitive occurrence in the rendered content in a `<mark>` element (highlighted). Accepts a **string** (a single phrase) or a **string array** (each term highlighted independently). Works across prose, code, and links. A term shorter than 2 characters, an empty string, or an empty array is a no-op.
+
 ### `openLinkInNewTab` [#openlinkinnewtab]
 
 This boolean property specifies whether links should open in a new tab. If set to `true`, all links within the markdown will open in a new tab with `target="_blank"`. Links that explicitly specify their own target using the `| target=...` syntax will override this setting.
@@ -410,6 +422,8 @@ The component itself cannot be styled, but the components that render the final 
 | [backgroundColor](/docs/styles-and-themes/common-units/#color)-Admonition-markdown-warning | $color-warn-100 | $color-warn-100 |
 | [backgroundColor](/docs/styles-and-themes/common-units/#color)-Blockquote-markdown | $color-surface-100 | $color-surface-50 |
 | [backgroundColor](/docs/styles-and-themes/common-units/#color)-even-Tr-markdown | *none* | *none* |
+| [backgroundColor](/docs/styles-and-themes/common-units/#color)-mark-markdown | $color-warn-200 | $color-warn-200 |
+| [backgroundColor](/docs/styles-and-themes/common-units/#color)-markActive-markdown | $color-warn-400 | $color-warn-400 |
 | [backgroundColor](/docs/styles-and-themes/common-units/#color)-Markdown | *none* | *none* |
 | [backgroundColor](/docs/styles-and-themes/common-units/#color)-Table-markdown | *none* | *none* |
 | [backgroundColor](/docs/styles-and-themes/common-units/#color)-Tbody-markdown | *none* | *none* |
@@ -955,6 +969,7 @@ The component itself cannot be styled, but the components that render the final 
 | [textAlign](/docs/styles-and-themes/common-units/#text-align)-Td-markdown | *none* | *none* |
 | [textAlign](/docs/styles-and-themes/common-units/#text-align)-Text | *none* | *none* |
 | [textAlignLast](/docs/styles-and-themes/common-units/#text-align)-Text | *none* | *none* |
+| [textColor](/docs/styles-and-themes/common-units/#color)-mark-markdown | inherit | inherit |
 | [textColor](/docs/styles-and-themes/common-units/#color)-Table-markdown | *none* | *none* |
 | [textColor](/docs/styles-and-themes/common-units/#color)-Tbody-markdown | *none* | *none* |
 | [textColor](/docs/styles-and-themes/common-units/#color)-Text | *none* | *none* |

--- a/xmlui/src/components/Markdown/Markdown.spec.ts
+++ b/xmlui/src/components/Markdown/Markdown.spec.ts
@@ -1004,3 +1004,64 @@ test.describe("xmlui-pg inline components", () => {
     await expect(page.getByText("A reusable component must have a non-empty name.")).toBeVisible();
   });
 });
+
+test.describe("highlightText", () => {
+  // Text ordering of terms: pty(0) ticker(1) pty(2) ticker(3)
+  const MULTI = `The pty layer and the ticker both matter. Another pty here, and a ticker there.`;
+
+  test("string highlights only the literal phrase", async ({ initTestBed, page }) => {
+    await initTestBed(
+      `<Markdown highlightText="pty ticker"><![CDATA[The pty layer, the ticker, and the phrase pty ticker once.]]></Markdown>`,
+    );
+    await expect(page.locator("mark")).toHaveCount(1);
+    await expect(page.locator("mark")).toHaveText("pty ticker");
+  });
+
+  test("array marks every occurrence of each term", async ({ initTestBed, page }) => {
+    await initTestBed(`<Markdown highlightText="{['pty', 'ticker']}"><![CDATA[${MULTI}]]></Markdown>`);
+    await expect(page.locator("mark")).toHaveCount(4);
+    await expect(page.locator("mark").filter({ hasText: "pty" })).toHaveCount(2);
+    await expect(page.locator("mark").filter({ hasText: "ticker" })).toHaveCount(2);
+  });
+
+  test("highlightActiveIndex walks marks in document order across terms", async ({
+    initTestBed,
+    page,
+  }) => {
+    // Index 1 is the first ticker (document order), NOT the second pty (per-term order).
+    await initTestBed(
+      `<Markdown highlightText="{['pty', 'ticker']}" highlightActiveIndex="{1}"><![CDATA[${MULTI}]]></Markdown>`,
+    );
+    await expect(page.locator('mark[data-active="true"]')).toHaveCount(1);
+    await expect(page.locator('mark[data-active="true"]')).toHaveText("ticker");
+  });
+
+  test("active index 2 selects a pty, not a ticker — counting is interleaved, not per-term", async ({
+    initTestBed,
+    page,
+  }) => {
+    // Per-term counting would put both ptys at indexes 0,1 and ticker at 2;
+    // interleaved document order puts pty at 0, ticker at 1, pty at 2.
+    await initTestBed(
+      `<Markdown highlightText="{['pty', 'ticker']}" highlightActiveIndex="{2}"><![CDATA[${MULTI}]]></Markdown>`,
+    );
+    await expect(page.locator('mark[data-active="true"]')).toHaveText("pty");
+  });
+
+  test("longest overlapping term wins (no nested marks)", async ({ initTestBed, page }) => {
+    await initTestBed(
+      `<Markdown highlightText="{['cat', 'category']}"><![CDATA[Pick a category for the cat.]]></Markdown>`,
+    );
+    // "category" matched as one mark (longest-first), plus the standalone "cat" = 2 marks, none nested.
+    await expect(page.locator("mark")).toHaveCount(2);
+    await expect(page.locator("mark mark")).toHaveCount(0);
+    await expect(page.locator("mark").filter({ hasText: "category" })).toHaveCount(1);
+  });
+
+  test("terms shorter than 2 chars and empty array are no-ops", async ({ initTestBed, page }) => {
+    await initTestBed(
+      `<Markdown highlightText="{['a', '']}"><![CDATA[a apple banana]]></Markdown>`,
+    );
+    await expect(page.locator("mark")).toHaveCount(0);
+  });
+});

--- a/xmlui/src/components/Markdown/Markdown.tsx
+++ b/xmlui/src/components/Markdown/Markdown.tsx
@@ -103,9 +103,11 @@ export const MarkdownMd = createMetadata({
     },
     highlightText: {
       description:
-        "When set, every case-insensitive occurrence of this string in the rendered " +
-        "content is wrapped in a `<mark>` element (highlighted). Works across prose, " +
-        "code, and links. Empty or shorter than 2 characters is a no-op.",
+        "When set, wraps every case-insensitive occurrence in the rendered content in a " +
+        "`<mark>` element (highlighted). Accepts a **string** (a single phrase) or a " +
+        "**string array** (each term highlighted independently). Works across prose, " +
+        "code, and links. A term shorter than 2 characters, an empty string, or an empty " +
+        "array is a no-op.",
       valueType: "string",
     },
     highlightActive: {
@@ -116,9 +118,10 @@ export const MarkdownMd = createMetadata({
     },
     highlightActiveIndex: {
       description:
-        "Which occurrence (0-based, counted across the whole block) of `highlightText` is " +
-        "the active match: it is emphasized and scrolled into view. -1 or unset means none. " +
-        "Generalizes `highlightActive`.",
+        "Which occurrence (0-based) of `highlightText` is the active match: it is emphasized " +
+        "and scrolled into view. Occurrences are counted **across all terms in document " +
+        "order**, so stepping the index walks every `<mark>` top-to-bottom regardless of " +
+        "which term produced it. -1 or unset means none. Generalizes `highlightActive`.",
       valueType: "number",
     },
     enablePlaygroundTracing: {
@@ -330,7 +333,7 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
         overflowMode={extractValue(node.props.overflowMode) as OverflowMode | undefined}
         breakMode={extractValue(node.props.breakMode) as BreakMode | undefined}
         enablePlaygroundTracing={extractValue.asOptionalBoolean(node.props.enablePlaygroundTracing)}
-        highlightText={extractValue.asOptionalString(node.props.highlightText)}
+        highlightText={extractValue(node.props.highlightText) as string | string[] | undefined}
         highlightActive={extractValue.asOptionalBoolean(node.props.highlightActive)}
         highlightActiveIndex={extractValue.asOptionalNumber(node.props.highlightActiveIndex)}
         anchorRenderer={
@@ -367,7 +370,7 @@ type TransformedMarkdownProps = {
   breakMode?: BreakMode;
   enablePlaygroundTracing?: boolean;
   anchorRenderer?: (anchorId: string, anchorHref: string) => React.ReactNode;
-  highlightText?: string;
+  highlightText?: string | string[];
   highlightActive?: boolean;
   highlightActiveIndex?: number;
 };

--- a/xmlui/src/components/Markdown/MarkdownReact.tsx
+++ b/xmlui/src/components/Markdown/MarkdownReact.tsx
@@ -115,17 +115,45 @@ const preventPlaygroundParagraphWrap = () => {
   };
 };
 
-/** Rehype plugin factory: wrap case-insensitive occurrences of `needle` in
- *  <mark> nodes. Operates on the parsed hast tree, so matches inside code,
- *  inline code, and links are handled correctly with no escaping. The match
- *  whose ordinal (0-based, counted across all text nodes in this block) equals
- *  `activeIndex` gets data-active="true" (the caller marks exactly one active
- *  block); -1 means no match in this block is active. */
-function makeHighlightPlugin(needle: string, activeIndex: number) {
+/** Normalize the `highlightText` prop (`string | string[]`) to a list of needles.
+ *  A string stays a single phrase (never whitespace-split — that would break an
+ *  intentional `"foo bar"` phrase highlight); an array is treated as independent
+ *  terms. Each needle is trimmed; those shorter than 2 characters are dropped, and
+ *  case-insensitive duplicates are removed. */
+function normalizeNeedles(highlightText?: string | string[]): string[] {
+  if (highlightText == null) return [];
+  const raw = Array.isArray(highlightText) ? highlightText : [highlightText];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const term of raw) {
+    const s = (term ?? "").trim();
+    const key = s.toLowerCase();
+    if (s.length >= 2 && !seen.has(key)) {
+      seen.add(key);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+/** Rehype plugin factory: wrap case-insensitive occurrences of any of `needles`
+ *  in <mark> nodes. Operates on the parsed hast tree, so matches inside code,
+ *  inline code, and links are handled correctly with no escaping. Matches are
+ *  numbered in a single 0-based ordinal sequence in **document order** across all
+ *  terms (text nodes are visited in document order, and each node is scanned
+ *  left-to-right); the match whose ordinal equals `activeIndex` gets
+ *  data-active="true" (-1 means no match in this block is active). At any position
+ *  the longest matching needle wins, so terms that overlap (`cat` vs `category`)
+ *  never produce nested or overlapping marks. */
+function makeHighlightPlugin(needles: string[], activeIndex: number) {
+  // Longest-first so an overlapping longer term is preferred at a given position.
+  const qs = needles
+    .map((n) => (n || "").toLowerCase())
+    .filter((q) => q.length >= 2)
+    .sort((a, b) => b.length - a.length);
   return function () {
     return function transformer(tree: Node) {
-      const q = (needle || "").toLowerCase();
-      if (q.length < 2) return;
+      if (qs.length === 0) return;
       let matchOrdinal = 0;
       visit(tree, "text", (node: any, index: number | undefined, parent: any) => {
         if (!parent || typeof index !== "number") return;
@@ -133,24 +161,37 @@ function makeHighlightPlugin(needle: string, activeIndex: number) {
         if (parent.tagName === "mark") return; // already highlighted
         const value: string = node.value || "";
         const hay = value.toLowerCase();
-        let idx = hay.indexOf(q);
-        if (idx === -1) return;
         const out: any[] = [];
-        let last = 0;
-        while (idx !== -1) {
-          if (idx > last) out.push({ type: "text", value: value.slice(last, idx) });
-          const matched = value.slice(idx, idx + q.length);
-          const isActive = matchOrdinal === activeIndex;
-          matchOrdinal++;
-          out.push({
-            type: "element",
-            tagName: "mark",
-            properties: isActive ? { "data-active": "true" } : {},
-            children: [{ type: "text", value: matched }],
-          });
-          last = idx + q.length;
-          idx = hay.indexOf(q, last);
+        let i = 0; // scan cursor
+        let last = 0; // start of pending unmarked text
+        let anyMatch = false;
+        while (i < value.length) {
+          let matchLen = 0;
+          for (const q of qs) {
+            if (hay.startsWith(q, i)) {
+              matchLen = q.length;
+              break;
+            }
+          }
+          if (matchLen > 0) {
+            anyMatch = true;
+            if (i > last) out.push({ type: "text", value: value.slice(last, i) });
+            const matched = value.slice(i, i + matchLen);
+            const isActive = matchOrdinal === activeIndex;
+            matchOrdinal++;
+            out.push({
+              type: "element",
+              tagName: "mark",
+              properties: isActive ? { "data-active": "true" } : {},
+              children: [{ type: "text", value: matched }],
+            });
+            i += matchLen;
+            last = i;
+          } else {
+            i++;
+          }
         }
+        if (!anyMatch) return;
         if (last < value.length) out.push({ type: "text", value: value.slice(last) });
         parent.children.splice(index, 1, ...out);
         return [SKIP, index + out.length]; // don't re-descend into the inserted <mark> nodes
@@ -225,7 +266,7 @@ type MarkdownProps = {
   overflowMode?: OverflowMode;
   breakMode?: BreakMode;
   anchorRenderer?: (anchorId: string, anchorHref: string) => ReactNode;
-  highlightText?: string;
+  highlightText?: string | string[];
   highlightActive?: boolean;
   highlightActiveIndex?: number;
 };
@@ -362,25 +403,30 @@ export const Markdown = memo(
         : highlightActive
           ? 0
           : -1;
+    // Stable dependency key: an inline array prop is a new reference every render,
+    // so memoize on the joined needle text rather than the array identity.
+    const needleKey = Array.isArray(highlightText)
+      ? highlightText.join(" ")
+      : highlightText ?? "";
+    const needles = useMemo(() => normalizeNeedles(highlightText), [needleKey]);
     const rehypePlugins = useMemo(
       () =>
-        highlightText && highlightText.trim().length >= 2
-          ? [...stableRehypePlugins, makeHighlightPlugin(highlightText.trim(), activeIndex)]
+        needles.length > 0
+          ? [...stableRehypePlugins, makeHighlightPlugin(needles, activeIndex)]
           : stableRehypePlugins,
-      [highlightText, highlightActive, highlightActiveIndex],
+      [needleKey, activeIndex],
     );
     useEffect(() => {
       if (
         (!highlightActive && !(typeof highlightActiveIndex === "number" && highlightActiveIndex >= 0)) ||
-        !highlightText ||
-        highlightText.trim().length < 2
+        needles.length === 0
       )
         return;
       const el = containerRef.current?.querySelector(
         'mark[data-active="true"]',
       ) as HTMLElement | null;
       if (el) el.scrollIntoView({ block: "center", behavior: "auto" });
-    }, [highlightActive, highlightActiveIndex, highlightText]);
+    }, [highlightActive, highlightActiveIndex, needleKey]);
 
     const imageInfo = useRef(new Map<string, boolean>());
     if (typeof children !== "string") {

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -12985,7 +12985,7 @@ export default {
         "valueType": "boolean"
       },
       "highlightText": {
-        "description": "When set, every case-insensitive occurrence of this string in the rendered content is wrapped in a `<mark>` element (highlighted). Works across prose, code, and links. Empty or shorter than 2 characters is a no-op.",
+        "description": "When set, wraps every case-insensitive occurrence in the rendered content in a `<mark>` element (highlighted). Accepts a **string** (a single phrase) or a **string array** (each term highlighted independently). Works across prose, code, and links. A term shorter than 2 characters, an empty string, or an empty array is a no-op.",
         "valueType": "string"
       },
       "highlightActive": {
@@ -12993,7 +12993,7 @@ export default {
         "valueType": "boolean"
       },
       "highlightActiveIndex": {
-        "description": "Which occurrence (0-based, counted across the whole block) of `highlightText` is the active match: it is emphasized and scrolled into view. -1 or unset means none. Generalizes `highlightActive`.",
+        "description": "Which occurrence (0-based) of `highlightText` is the active match: it is emphasized and scrolled into view. Occurrences are counted **across all terms in document order**, so stepping the index walks every `<mark>` top-to-bottom regardless of which term produced it. -1 or unset means none. Generalizes `highlightActive`.",
         "valueType": "number"
       },
       "enablePlaygroundTracing": {


### PR DESCRIPTION
## What

Extends `Markdown`'s `highlightText` to accept **`string | string[]`**, the follow-on to #3664.

- **`string`** — unchanged. A single literal phrase, never whitespace-split (so an intentional `"foo bar"` phrase highlight is preserved). Backward compatible.
- **`string[]`** — each term highlighted independently; every case-insensitive occurrence of any term is wrapped in `<mark>`.
- **`highlightActiveIndex`** now counts across all terms in **document order** — a find-next control walks every `<mark>` top-to-bottom regardless of which term produced it (not all of term A, then all of term B).
- **Overlaps**: at each position the longest matching term wins (`category` before `cat`), so overlapping terms never produce nested marks.
- Terms under 2 chars and empty arrays are no-ops.

## Why

The downstream consumer is a keyword/AND search whose in-view find must highlight the same terms the search matched on. Before this, a doc that matched on *both* `pty` and `ticker` (non-adjacent) drove the find with `highlightText="pty ticker"`, found zero occurrences of the literal phrase, and reported "No matches" despite the clear match. String = phrase, array = terms keeps the two intents separate and the change non-breaking.

## Implementation

- `MarkdownReact.tsx` — `normalizeNeedles()` (string → one phrase; array → deduped terms ≥ 2 chars) and a rewritten `makeHighlightPlugin(needles[], activeIndex)` that scans each text node left-to-right, longest-term-first, with one shared document-order ordinal. Call site memoized on a stable needle key so an inline array prop doesn't re-run every render.
- `Markdown.tsx` — `string | string[]` type, raw pass-through extraction, updated prop descriptions.
- Regenerated `xmlui-metadata-generated.js` and the Markdown reference (which previously didn't list the highlight props at all — now documented, with the `mark`/`markActive` theme vars).

## Tests

Six new `Markdown.spec.ts` cases, all passing locally, mirroring the acceptance:

- `["pty","ticker"]` marks every `pty` and every `ticker`
- `highlightActiveIndex` walks marks in document order (index 1 = first ticker; index 2 = second pty — interleaved, not per-term)
- `"pty ticker"` (string) still marks only the literal phrase
- longest overlapping term wins, no nested marks
- terms < 2 chars and empty array are no-ops

## Acceptance

All four bullets in #3675 are covered by the tests above.

Closes #3675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
