### PR TITLE
Docs: how-to Wrap long text in a Link (corrects the wraps-by-default premise)

### DIFF
--- a/website/content/docs/pages/howto/wrap-long-text-in-a-link.md
+++ b/website/content/docs/pages/howto/wrap-long-text-in-a-link.md
@@ -1,0 +1,92 @@
+# Wrap long text in a Link
+
+A `Link`'s own text **wraps by default** in a width-constrained container — you
+usually don't need to do anything. Two situations break that: a long **unbroken
+token** (like a URL) with no place to wrap, and a **nested `Text` child**. This
+how-to covers both.
+
+## Prose wraps; long URLs need `breakMode`
+
+Plain wrapping happens at spaces and hyphens, so ordinary prose wraps on its own.
+A long URL breaks only at its hyphens by default — not at `/` or `.` — so a long
+slash-delimited segment still overflows its container. Set `breakMode="anywhere"`
+(or `"word"`) to break mid-segment:
+
+```xmlui-pg copy display name="Prose wraps; a URL needs breakMode" height="420px"
+---app display
+<App>
+  <VStack width="260px" gap="$space-4" padding="$space-3" borderWidth="1px" borderColor="$color-surface-300">
+    <VStack gap="$space-1">
+      <Text variant="strong">Prose — wraps on its own</Text>
+      <Link to="/">Read the full incident report and postmortem for last night's outage</Link>
+    </VStack>
+    <VStack gap="$space-1">
+      <Text variant="strong">Long URL — overflows (breaks only at hyphens)</Text>
+      <Link to="/">https://status.example.com/incidents/2026-07-28-database-failover-postmortem</Link>
+    </VStack>
+    <VStack gap="$space-1">
+      <Text variant="strong">Long URL — breakMode="anywhere"</Text>
+      <Link to="/" breakMode="anywhere">https://status.example.com/incidents/2026-07-28-database-failover-postmortem</Link>
+    </VStack>
+  </VStack>
+</App>
+```
+
+`breakMode` values: `normal` (default, break at word boundaries only), `word`
+(break long words when needed), `anywhere` (break at any character), `keep` (never
+break within words), `hyphenate` (add hyphens). Use `word` or `anywhere` for URLs
+and other long unbroken strings.
+
+## The nested-`Text` trap
+
+The wrapping above applies to the Link's **own** text. A nested `<Text>`
+*component* child does not inherit it — the Link is an inline-flex row and the
+nested `Text` keeps `min-width: auto`, so it can't shrink and silently overflows
+instead of wrapping. Put the copy directly in the Link instead:
+
+```xmlui-pg copy display name="Nested Text vs the Link's own text" height="380px"
+---app display
+<App>
+  <VStack width="260px" gap="$space-4" padding="$space-3" borderWidth="1px" borderColor="$color-surface-300">
+    <VStack gap="$space-1">
+      <Text variant="strong">Nested Text child</Text>
+      <Link to="/">
+        <Text>This copy is a nested Text component inside the Link, so it does not share the Link's wrapping</Text>
+      </Link>
+    </VStack>
+    <VStack gap="$space-1">
+      <Text variant="strong">Link's own text</Text>
+      <Link to="/">This copy is the Link's own content, so it wraps like ordinary link text</Link>
+    </VStack>
+  </VStack>
+</App>
+```
+
+If you need a nested component for styling, don't put the wrapping copy inside the
+Link. Render the paragraph as a plain `Text` and use a separate, compact `Link`
+(or `Button`) as the click target beside or below it.
+
+## Key points
+
+**Link prose wraps by default.** A width-constrained `Link` wraps its own text at
+word boundaries with no extra props — `overflowMode="flow"` is not required for
+ordinary wrapping.
+
+**Long slugs need `breakMode`.** URLs and paths break only at hyphens by default,
+not within a long slash-delimited segment; pair them with `breakMode="anywhere"`
+(or `"word"`) so they break to fit.
+
+**A nested `<Text>` child bypasses the Link's wrapping.** Put the copy directly in
+the Link, or separate the wrapping text from a compact click target.
+
+**If you explicitly set a non-wrapping `overflowMode`, wrapping stops.**
+`overflowMode="ellipsis"`, `"none"`, and `"scroll"` all force a single line; switch
+to `overflowMode="flow"` to restore multi-line wrapping.
+
+---
+
+## See also
+
+- [Customize link focus and decoration](/docs/howto/customize-link-focus-and-decoration) — style Link states without affecting layout
+- [Wrap items across multiple rows](/docs/howto/wrap-items-across-multiple-rows) — flow *items* (not text) onto multiple lines in an `HStack`
+- [Link component](/docs/reference/components/Link) — `overflowMode`, `breakMode`, `maxLines`, `preserveLinebreaks`

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1341,6 +1341,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Wrap long text in a Link"
+                            to="/docs/howto/wrap-long-text-in-a-link"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Theme DatePicker calendar items"
                             to="/docs/howto/theme-datepicker-calendar-items"
                         />
@@ -2851,6 +2856,11 @@
             <Page url="/docs/howto/customize-link-focus-and-decoration">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/customize-link-focus-and-decoration.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/wrap-long-text-in-a-link">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/wrap-long-text-in-a-link.md']}"
                 />
             </Page>
             <Page url="/docs/howto/theme-datepicker-calendar-items">


### PR DESCRIPTION
## What

New how-to: **Wrap long text in a Link** (`website/content/docs/pages/howto/wrap-long-text-in-a-link.md`), registered in `website/src/Main.xmlui`.

## A correction to the issue's premise

#3696 proposed the recipe as `overflowMode="flow"` and stated that a long line inside `<Link>` "refuses to wrap." Verifying against live renders showed that's not what happens: a `Link`'s own text **wraps by default** in a width-constrained container (`Link.module.scss`: the anchor is `width: fit-content; max-width: 100%`, and the default text span has no `white-space: nowrap`). `overflowMode="flow"` is redundant for ordinary prose.

So the how-to teaches what's actually true, which is more useful:

- **Prose wraps on its own** — no props needed.
- **Long URLs/paths** break only at hyphens by default (not at `/` or `.`), so a long slash-delimited segment overflows — `breakMode="anywhere"` (or `"word"`) breaks mid-segment.
- **The nested-`Text` trap** (the issue's titled concern, and confirmed real): a nested `<Text>` component child does not share the Link's wrapping and runs off one line; put the copy directly in the Link, or split a wrapping `Text` from a compact click target.
- A closing note: if you *explicitly* set `overflowMode="ellipsis"/"none"/"scroll"`, wrapping stops — `flow` restores it.

## Verification

Both runnable examples were checked against the doc server render (not just a route 200): prose wraps; the default URL overflows the column while `breakMode="anywhere"` fits; and the nested-`Text` child visibly fails to wrap while the Link's own text wraps.

Docs-only; no component or metadata changes.

Refs #3696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
