### PR TITLE
Docs: five how-to/reference additions from a memory sweep (theme-in-loops, sync callbacks, App.mark, id, xs restrictions)

### DIFF
--- a/website/content/docs/pages/components-intro.md
+++ b/website/content/docs/pages/components-intro.md
@@ -121,7 +121,7 @@ The `TubeStops` component:
 
 **Defines a dynamic data source**. When this page embeds `<TubeStops line="Bakerloo"/>`, the `TubeStops` component receives a `line` property used to form the URL that fetches data.
 
-**Transforms data**. When API responses are complex, the expressions needed to unpack them can clutter your XMLUI markup. In this case the  component offloads that work to the `transformStops` function so it can work with a simplified structure. The `transformStops` function is defined in a `<script>` tag in `index.html`. See [Scripting](/docs/scripting) for more on how to use JavaScript in XMLUI.
+**Transforms data**. When API responses are complex, the expressions needed to unpack them can clutter your XMLUI markup. In this case the  component offloads that work to the `transformStops` function so it can work with a simplified structure. The `transformStops` function is defined in a `<script>` tag in `index.html`. See [Scripting](/docs/guides/scripting) for more on how to use JavaScript in XMLUI.
 
 <details>
   <summary>view the transformStops function</summary>

--- a/website/content/docs/pages/howto/create-a-reusable-component.md
+++ b/website/content/docs/pages/howto/create-a-reusable-component.md
@@ -110,7 +110,7 @@ For tiny helpers used only by one app, you can start with an inline component in
 
 Prefer props when the same component is rendered with different data in different places. Prefer globals when every consumer reads the same singleton value and prop-threading would only create boilerplate. See [Scoping › Global variables](/docs/guides/scoping#global-variables) and [Scripting › Code-Behind files](/docs/guides/scripting#code-behind-files) for details on globals and `Globals.xs`.
 
-**`id` is reserved — never use it as a prop name**: The `id` attribute is special in XMLUI: it registers a named reference that parent built-in components can use to call the component's API. If you pass `id="{$item.id}"` to a user-defined component, XMLUI captures it as the component reference, not as `$props.id`. Use a descriptive name instead:
+**`id` is reserved — never use it as a prop name**: The `id` attribute is special in XMLUI: it registers a named reference that parent built-in components can use to call the component's API. If you pass `id="{$item.id}"` to a user-defined component, XMLUI captures it as the component reference, not as `$props.id` — which stays silently `undefined`. The tell is a guard like `when="{!!$props.id}"` (or a `DataSource` gated on it) that never fires, while other props on the same component work fine. Use a descriptive name instead:
 
 ```xmlui
 <!-- ❌ wrong: id is captured by the framework, $props.id is undefined -->

--- a/website/content/docs/pages/howto/keep-sync-callbacks-to-one-expression.md
+++ b/website/content/docs/pages/howto/keep-sync-callbacks-to-one-expression.md
@@ -61,7 +61,7 @@ itself a one-line expression.
 
 ## See also
 
-- [Scripting](/docs/scripting) — the `xs` language and its restrictions
+- [Scripting](/docs/guides/scripting) — the `xs` language and its restrictions
 - [Slider component](/docs/reference/components/Slider) — `valueFormat`
 - [List component](/docs/reference/components/List) — `groupBy`, `rowUnselectablePredicate`
 - [Table component](/docs/reference/components/Table) — `rowDisabledPredicate`, `rowUnselectablePredicate`

--- a/website/content/docs/pages/howto/keep-sync-callbacks-to-one-expression.md
+++ b/website/content/docs/pages/howto/keep-sync-callbacks-to-one-expression.md
@@ -1,0 +1,67 @@
+# Keep sync-callback attributes to one expression
+
+A few component attributes are **sync callbacks** — the engine runs them during
+evaluation/render, and they accept only a **single arrow expression**. A `{ }`
+statement block throws `Only arrow expression allowed in sync callback`. This is
+stricter than event handlers (`onClick` and friends), and the error doesn't name
+the offending attribute, so it helps to recognize the class.
+
+## A sync callback takes one arrow expression
+
+`Slider`'s `valueFormat` is a sync callback. Give it one arrow **expression**
+that returns the display string:
+
+```xmlui-pg copy display name="A sync callback takes one arrow expression" height="200px"
+---app display
+<App var.pct="{40}">
+  <VStack padding="$space-4" gap="$space-2">
+    <Text value="Selected: {pct}%" />
+    <Slider
+      initialValue="{pct}"
+      minValue="{0}"
+      maxValue="{100}"
+      step="{5}"
+      valueFormat="{(v) => v + '%'}"
+      onDidChange="(v) => pct = v" />
+  </VStack>
+</App>
+```
+
+Wrap that same body in braces and it fails:
+
+```xmlui
+<!-- ❌ throws: "Only arrow expression allowed in sync callback" -->
+<Slider valueFormat="{(v) => { return v + '%' }}" />
+
+<!-- ✅ single arrow expression -->
+<Slider valueFormat="{(v) => v + '%'}" />
+```
+
+## Key points
+
+**Sync callbacks accept a single arrow expression, not a statement block.** The
+engine evaluates them synchronously during render, so `(v) => { … }` with a body
+block throws `Only arrow expression allowed in sync callback`. Use
+`(v) => <expression>`.
+
+**The known sync-callback attributes** (as of the current engine): `Slider`
+`valueFormat`; `Table` `rowDisabledPredicate` and `rowUnselectablePredicate`;
+`List` `groupBy` and `rowUnselectablePredicate`. The error message doesn't say
+which attribute offended — if you see it, look for one of these.
+
+**Event handlers are different — they allow blocks.** `Button.onClick`,
+`onDidChange`, and other `on*` events run asynchronously and accept
+multi-statement blocks. Only the sync-callback attributes above are restricted.
+
+**Don't compute inside a sync callback.** If the value needs real work, derive it
+in a top-level binding or a named function and reference that — keep the callback
+itself a one-line expression.
+
+---
+
+## See also
+
+- [Scripting](/docs/scripting) — the `xs` language and its restrictions
+- [Slider component](/docs/reference/components/Slider) — `valueFormat`
+- [List component](/docs/reference/components/List) — `groupBy`, `rowUnselectablePredicate`
+- [Table component](/docs/reference/components/Table) — `rowDisabledPredicate`, `rowUnselectablePredicate`

--- a/website/content/docs/pages/howto/measure-performance-with-app-mark.md
+++ b/website/content/docs/pages/howto/measure-performance-with-app-mark.md
@@ -1,0 +1,64 @@
+# Measure performance with App.mark
+
+To time XMLUI hotspots, use `App.now()`, `App.mark()`, and `App.measure()`. They
+are the sandbox-safe replacements for the browser's `performance.*` API (which is
+banned in XMLUI scripts), and every mark and measure is pushed to the Inspector
+trace so you can read it in the timeline.
+
+## Mark and measure
+
+`App.mark(label)` records a named timing mark; `App.measure(label, fromMark)`
+returns the elapsed milliseconds since that mark. Click **Mark start**, wait a
+moment, then **Mark end + measure**:
+
+```xmlui-pg copy display name="Measure elapsed time with App marks" height="200px"
+---app display
+<App var.ms="{null}">
+  <VStack padding="$space-4" gap="$space-2">
+    <HStack gap="$space-2">
+      <Button label="Mark start" onClick="App.mark('start')" />
+      <Button label="Mark end + measure" onClick="ms = App.measure('span', 'start')" />
+    </HStack>
+    <Text value="{ms === null ? 'No measurement yet' : 'Elapsed: ' + ms.toFixed(1) + ' ms'}" />
+  </VStack>
+</App>
+```
+
+`App.measure` returns the number for use in markup (above); it *also* pushes an
+`app:measure` record to the Inspector trace, alongside the `app:mark` records
+each `App.mark` emits.
+
+## Read the marks in the Inspector
+
+Each `App.mark(label)` pushes an `app:mark` record carrying `label`, `ts` (a
+Unix-ms timestamp from `Date.now()`), and `perfTs` (a high-resolution
+`performance.now()` value). Because `ts` is on the same Unix-ms clock as a
+host-side log, you can merge the two streams; and counting how many times a label
+fired in a window ("this expression re-evaluated N times while typing") becomes a
+grep over the trace rather than guesswork.
+
+To find a hotspot: extract the suspected inline expression into a named function,
+add an `App.mark` at its top, and read the trace — don't infer downstream cost by
+eyeballing raw handler timings.
+
+## Key points
+
+**The `App` timing API replaces `performance.*`.** `App.now()` is a
+high-resolution timestamp; `App.mark(label)` records a named mark; `App.measure(label,
+fromMark, toMark?)` returns elapsed milliseconds. All three write to the Inspector
+trace.
+
+**Raw `performance.now/mark/measure` is banned.** Under `strictDomSandbox` the
+bundle blocks the `performance` global and points you at `App.now()` / `App.mark()`;
+reach for the `App` API instead.
+
+**Instrument named functions, don't eyeball traces.** Move the code you suspect
+into a named function and mark it. Marks give a hard record per region; inferring
+re-evaluation cost from handler timings alone is speculation.
+
+---
+
+## See also
+
+- [Scripting](/docs/guides/scripting) — the `xs` language and its restrictions
+- [App component](/docs/reference/components/App) — the `App` namespace

--- a/website/content/docs/pages/howto/scope-theme-outside-loops.md
+++ b/website/content/docs/pages/howto/scope-theme-outside-loops.md
@@ -1,0 +1,54 @@
+# Style looped rows without a per-row Theme
+
+To style every row of an `Items` or `List` loop, wrap the **whole loop** in one
+`<Theme>` — not each row. A `<Theme>` inside the row template creates a full
+theming context *per row*, and at a few hundred rows that cost is enough to
+freeze the UI.
+
+## Scope one Theme around the loop
+
+The `<Theme>` establishes a single theming context; every looped descendant
+inherits it. Here one `tone="dark"` themes all eight cards at once:
+
+```xmlui-pg copy display name="One Theme around the whole loop" height="360px"
+---app display
+<App var.rows="{Array.from({ length: 8 }).map((_, i) => ({ id: i, name: 'Row ' + (i + 1) }))}">
+  <Theme tone="dark">
+    <List data="{rows}">
+      <Card>
+        <Text value="{$item.name}" />
+      </Card>
+    </List>
+  </Theme>
+</App>
+```
+
+The Theme sits *outside* the `List`, so it is instantiated once and its theme
+variables cascade to all rows. Move that `<Theme>` inside the `<Card>` (into the
+row template) and you get one theming context per row instead — same visual
+result, very different cost.
+
+## Key points
+
+**One Theme around the loop is O(1); a Theme per row is O(rows × themes-per-row).**
+A `<Theme>` in the row template instantiates a full theming context for every
+rendered row. At scale this dominates render time — a couple hundred instances
+can stall the main thread for seconds, even when the same page renders in
+milliseconds server-side. Put the Theme above the loop.
+
+**For per-item styling that has a direct prop, set the prop.** If you only need
+a per-row `fontSize`, color, or variant that a component already exposes as a
+prop (`<Text fontSize="…">`, `themeColor`, `variant`), set that prop in the row
+template — don't wrap the row in a `<Theme>` to achieve it.
+
+**App-wide tokens belong in the project theme file.** Values that apply across
+the app go in the theme definition, not in markup `<Theme>` blocks — markup
+Theme is for scoping a *section* to a different look.
+
+---
+
+## See also
+
+- [Scope a theme to a card or section](/docs/howto/scope-a-theme-to-a-card-or-section) — the general pattern for restyling one subtree
+- [Theme component](/docs/reference/components/Theme) — theme variables and `tone`
+- [List component](/docs/reference/components/List) — the looped container used above

--- a/website/content/docs/pages/scripting.md
+++ b/website/content/docs/pages/scripting.md
@@ -367,6 +367,19 @@ The following JavaScript features are **not available** in the XMLUI scripting e
 | Destructuring assignment (`const { a, b } = obj`) | Not supported | Access properties directly: `obj.a`, `obj.b` |
 | Generator functions (`function*`) | Not supported | — |
 | `import` / `export` | Not available in inline code | Use code-behind files with top-level `function` declarations |
+| `var` inside a function body | Not supported | Use `let` or `const`. (Top-level `var` in a `.xmlui.xs` code-behind file is fine — see below.) It throws `'var' declarations are not allowed within functions`. |
+
+**Assigning through a non-script base fails silently.** An assignment whose target
+is reached through an identifier the engine doesn't track — for example
+`window.foo = x` — throws `Left value variable (foo) not found in the scope`. The
+engine resolves the assignment target as a bare name and can't find it. The
+failure is **silent at the call site**: the handler simply stops, and only a
+console error records it. Keep writable state in a component `var` or `global`,
+or perform the mutation in a real JavaScript function loaded from your
+`index.html` and call it from `xs`.
+
+For the same rule applied to *render-time* callbacks, see
+[Keep sync-callback attributes to one expression](/docs/howto/keep-sync-callbacks-to-one-expression).
 
 ### Unavailable globals
 

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -697,6 +697,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Measure performance with App.mark"
+                            to="/docs/howto/measure-performance-with-app-mark"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Handle action errors on a component"
                             to="/docs/howto/handle-action-errors-on-a-component"
                         />
@@ -2774,6 +2779,11 @@
             <Page url="/docs/howto/collect-global-errors-with-app-onerror">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/collect-global-errors-with-app-onerror.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/measure-performance-with-app-mark">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/measure-performance-with-app-mark.md']}"
                 />
             </Page>
             <Page url="/docs/howto/handle-action-errors-on-a-component">

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1108,6 +1108,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Style looped rows without a per-row Theme"
+                            to="/docs/howto/scope-theme-outside-loops"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Adjust spacing globally"
                             to="/docs/howto/adjust-spacing-globally"
                         />
@@ -2658,6 +2663,11 @@
             <Page url="/docs/howto/scope-a-theme-to-a-card-or-section">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/scope-a-theme-to-a-card-or-section.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/scope-theme-outside-loops">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/scope-theme-outside-loops.md']}"
                 />
             </Page>
             <Page url="/docs/howto/adjust-spacing-globally">

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1179,6 +1179,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Keep sync-callback attributes to one expression"
+                            to="/docs/howto/keep-sync-callbacks-to-one-expression"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Use accessors for complex expressions"
                             to="/docs/howto/use-accessors-to-simplify-complex-expressions"
                         />
@@ -2712,6 +2717,11 @@
             <Page url="/docs/howto/derive-a-value-from-multiple-sources">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/derive-a-value-from-multiple-sources.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/keep-sync-callbacks-to-one-expression">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/keep-sync-callbacks-to-one-expression.md']}"
                 />
             </Page>
             <Page url="/docs/howto/run-a-one-time-action-on-page-load">


### PR DESCRIPTION
## What

Five documentation additions from a Bram agent-memory sweep — findings that are XMLUI-framework-generic, so their home is the docs corpus. Three how-tos + two additions to existing pages, plus a link fix.

- **How-to: Style looped rows without a per-row `<Theme>`** — one `<Theme>` around an `Items`/`List` loop is O(1); a `<Theme>` in the row template is O(rows × themes) and can stall the UI at scale. Correct pattern shown; anti-pattern in Key points (no embedded freeze).
- **How-to: Keep sync-callback attributes to one expression** — the sync-callback class (evaluated during render, single arrow expression only; a `{ }` block throws `Only arrow expression allowed in sync callback`), anchored on the members that exist on `main`: `Slider.valueFormat`, `Table`/`List` row predicates, `List.groupBy`.
- **How-to: Measure performance with `App.mark`** — the sandbox-safe timing API (`App.now/mark/measure`) and the `app:mark` Inspector-trace workflow; raw `performance.*` is banned.
- **Addition — `create-a-reusable-component.md`:** the diagnostic symptom for passing `id` to a UDC (a `when="{!!$props.id}"` guard that silently never fires). The core fact was already documented; this adds the tell.
- **Addition — `scripting.md`:** `var` inside a function body, and assigning through a base the engine doesn't track (`window.foo = x` → `Left value variable not found in the scope`, silent at the call site).
- **Fix:** a dead `/docs/scripting` See-also link → `/docs/guides/scripting`.

## Verified against current `main` — which caught real drift

Every claim was re-checked before writing (the source handoff mandated it, and it paid off):

- Item 3's handoff cited `ChangeListener.onDidChange` as a sync callback; on `main` `didChange` is a regular event (multi-statement allowed), so that example was **dropped** rather than shipped as a false claim.
- Item 4's handoff claimed "top-level `window.X = …` works"; verified **false** (`window` is a gated member; `.xs` top-level rejects expression statements), so it was **not** documented.
- Item 2 turned out **already documented**; reduced to the diagnostic-symptom sentence.
- `var`-in-function confirmed by executing the engine's own `event-async-var.test.ts`.

Docs-only; no component or metadata changes. No filed issue — these came from agent memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
