### PR TITLE
Fix Image blob-URL effect revoke/create loop (flicker on data prop)

### DIFF
--- a/xmlui/src/components/Image/ImageReact.tsx
+++ b/xmlui/src/components/Image/ImageReact.tsx
@@ -56,25 +56,20 @@ export const Image = memo(forwardRef(function Img(
     return imageData;
   }, [imageData]);
 
-  // Handle Blob data when src is empty
+  // Handle Blob data when src is empty. The cleanup owns revocation, so the
+  // effect must not depend on blobUrl — reacting to its own output revokes
+  // and recreates the URL in a loop, flickering the rendered image.
   useEffect(() => {
     if (!src && blobToRender) {
       const url = URL.createObjectURL(blobToRender);
       setBlobUrl(url);
 
-      // Cleanup function to revoke the blob URL
       return () => {
         URL.revokeObjectURL(url);
         setBlobUrl(null);
       };
-    } else {
-      // Clean up any existing blob URL if src is provided or imageData is not a Blob
-      if (blobUrl) {
-        URL.revokeObjectURL(blobUrl);
-        setBlobUrl(null);
-      }
     }
-  }, [src, blobToRender, blobUrl]);
+  }, [src, blobToRender]);
 
   src = safeConvertPropToString(src);
   alt = safeConvertPropToString(alt);


### PR DESCRIPTION
## Summary

`Image`'s blob-rendering effect listed its own `blobUrl` state in its dependency array. Each URL it created re-triggered the effect: the cleanup revoked the just-created URL and the body minted a new one, endlessly. Any `Image` rendered from binary data via the `data` prop flickered as its `src` cycled through discarded blob URLs.

The fix drops `blobUrl` from the deps so the effect depends only on `(src, blobToRender)`. The cleanup owns revocation — one object URL lives per input pair, created once and revoked exactly once when the inputs change or the component unmounts. The `else`-branch revoke this obsoletes is removed.

## How it was found

While validating the new paste-an-image-from-the-clipboard how-to (in the upcoming how-to batch PR), whose playground previews pasted `File` objects with `<Image data="{$item}" />` — the preview flickered continuously.

## Verification

- `npm run build:xmlui-standalone` type-checks and builds clean.
- With the fix live in the docs dev server, the how-to playground's pasted-image preview holds steady (previously it flickered on every render cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
