### PR TITLE
Docs: three how-tos from MCP demand analysis (range slider, clipboard paste, infinite scroll) plus link fixes

### DIFF
--- a/website/content/docs/pages/howto/create-a-two-handle-range-slider.md
+++ b/website/content/docs/pages/howto/create-a-two-handle-range-slider.md
@@ -51,6 +51,6 @@ A range slider is the natural control for "between X and Y" filters: price bands
 
 ## See also
 
-- [Slider component reference](/components/Slider) - all Slider properties, events, and theme variables
+- [Slider component reference](/docs/reference/components/Slider) - all Slider properties, events, and theme variables
 - [Filter and transform data from an API](/docs/howto/filter-and-transform-data-from-an-api) - apply the selected range to fetched data
 - [Debounce with ChangeListener](/docs/howto/debounce-with-changelistener) - avoid reacting to every intermediate drag value

--- a/website/content/docs/pages/howto/create-a-two-handle-range-slider.md
+++ b/website/content/docs/pages/howto/create-a-two-handle-range-slider.md
@@ -1,0 +1,56 @@
+# Create a two-handle range slider
+
+Give a `Slider` two handles (dual thumbs) by initializing it with an array of two values; it then reports a `[low, high]` range instead of a single number.
+
+A range slider is the natural control for "between X and Y" filters: price bands, date windows, size limits. `Slider` switches to two handles when its `initialValue` is a two-element array, and `minStepsBetweenThumbs` keeps the handles from crossing or crowding each other.
+
+```xmlui-pg copy display name="Two-handle range slider" height="380px"
+<App
+  var.priceRange="{[20, 80]}"
+  var.products="{[
+    { name: 'Notebook', price: 12 },
+    { name: 'Backpack', price: 45 },
+    { name: 'Headphones', price: 65 },
+    { name: 'Keyboard', price: 85 },
+    { name: 'Monitor', price: 95 }
+  ]}">
+  <VStack gap="$space-4" padding="$space-4">
+    <Slider
+      label="Price range"
+      minValue="{0}"
+      maxValue="{100}"
+      step="{5}"
+      minStepsBetweenThumbs="{2}"
+      initialValue="{priceRange}"
+      onDidChange="(val) => { priceRange = val }"
+      valueFormat="{(value) => '$' + value}"
+    />
+    <Text>Showing products from ${priceRange[0]} to ${priceRange[1]}</Text>
+    <Items data="{products.filter(p =>
+        p.price >= priceRange[0] && p.price <= priceRange[1])}">
+      <HStack gap="$space-2">
+        <Text width="120px">{$item.name}</Text>
+        <Text variant="strong">${$item.price}</Text>
+      </HStack>
+    </Items>
+  </VStack>
+</App>
+```
+
+## Key points
+
+**A two-element array creates the second handle**: `initialValue="{[20, 80]}"` is what makes this a range slider rather than a single-value one. From then on the component's value — in `onDidChange`, in `slider.value`, and in form submission — is the array `[low, high]`.
+
+**React to the array value**: the `didChange` handler receives the full array on every drag of either handle. Read the ends with `val[0]` and `val[1]`, or store the whole array in a component variable as this example does with `priceRange`.
+
+**`minStepsBetweenThumbs` is measured in steps, not units**: with `step="{5}"` and `minStepsBetweenThumbs="{2}"`, the handles stay at least 10 units apart. The default of 1 already prevents the two thumbs from occupying the same value.
+
+**`valueFormat` labels both thumbs**: the formatting function is applied to each handle's value independently, so one function covers both ends of the range.
+
+---
+
+## See also
+
+- [Slider component reference](/components/Slider) - all Slider properties, events, and theme variables
+- [Filter and transform data from an API](/docs/howto/filter-and-transform-data-from-an-api) - apply the selected range to fetched data
+- [Debounce with ChangeListener](/docs/howto/debounce-with-changelistener) - avoid reacting to every intermediate drag value

--- a/website/content/docs/pages/howto/implement-infinite-scroll-pagination.md
+++ b/website/content/docs/pages/howto/implement-infinite-scroll-pagination.md
@@ -1,0 +1,69 @@
+# Implement infinite scroll pagination
+
+Combine a paged `DataSource` (`nextPageSelector`) with `List`'s `pageInfo` and `onRequestFetchNextPage` so scrolling near the end of the list fetches and appends the next page automatically.
+
+Infinite scroll replaces visible page controls with "load more as you go": the list grows as the user approaches its end, until the data runs out. In XMLUI this is a composition of two documented pieces — `DataSource` becomes pageable when `nextPageSelector` is set, and `List` requests the next page when the user scrolls close to the last row.
+
+```xmlui-pg copy display name="Infinite scroll pagination" height="480px"
+---app display
+<App>
+  <DataSource
+    id="feed"
+    url="/api/feed"
+    queryParams="{{ after: $pageParams ? $pageParams.nextPageParam : 0, limit: 15 }}"
+    nextPageSelector="{$response.length === 15 ? $response[$response.length - 1].id : null}"
+  />
+  <VStack gap="$space-2" padding="$space-4">
+    <H3>Message feed</H3>
+    <List
+      data="{feed}"
+      pageInfo="{feed.pageInfo}"
+      onRequestFetchNextPage="feed.fetchNextPage()"
+      height="300px">
+      <Card>
+        <Text variant="strong">{$item.author}</Text>
+        <Text>{$item.text}</Text>
+      </Card>
+    </List>
+    <Text when="{feed.pageInfo && feed.pageInfo.isFetchingNextPage}">
+      Loading more…
+    </Text>
+    <Text when="{feed.pageInfo && !feed.pageInfo.hasNextPage}">
+      You're all caught up — 57 of 57 messages loaded.
+    </Text>
+  </VStack>
+</App>
+---api
+{
+  "apiUrl": "/api",
+  "initialize": "$state.messages = Array.from({length: 57}, (_, i) => ({ id: i + 1, author: 'User ' + ((i % 7) + 1), text: 'Message #' + (i + 1) }))",
+  "operations": {
+    "get-feed": {
+      "url": "/feed",
+      "method": "get",
+      "queryParams": { "after": "integer", "limit": "integer" },
+      "handler": "const after = Number($queryParams.after || 0); const limit = Number($queryParams.limit || 15); return $state.messages.filter(m => m.id > after).slice(0, limit);"
+    }
+  }
+}
+```
+
+## Key points
+
+**`nextPageSelector` makes the `DataSource` pageable**: it runs against each response (`$response`) and extracts the cursor for the next page — here the last item's `id`, or `null` when a short page signals the end. A `null`/`undefined` cursor is what turns `pageInfo.hasNextPage` off. The selector can be a simple property path (`nextCursor`) or a full binding expression as in this example.
+
+**`$pageParams` carries the cursor into the next request**: the first request runs with `$pageParams` undefined; each subsequent page request re-evaluates `url`/`queryParams` with `$pageParams.nextPageParam` set to what `nextPageSelector` extracted. Adapt the arithmetic to your API's shape — cursor, offset, or page number all work.
+
+**`List` drives the fetching**: setting `pageInfo` switches `List` into paged mode. When the user scrolls to within a few rows of the end, `List` fires `requestFetchNextPage` — guarded internally by `pageInfo.hasNextPage` and `pageInfo.isFetchingNextPage`, so it never double-fetches or requests past the end. The handler just calls the DataSource's `fetchNextPage()` method; fetched pages append to the existing rows.
+
+**`pageInfo` also powers the status line**: `isFetchingNextPage` shows a loading indicator during a fetch, and `!hasNextPage` shows the end-of-data message. No manual bookkeeping variables are needed.
+
+**Infinite scroll vs. `Pagination`**: the [Paginate a list](/docs/howto/paginate-a-list) pattern replaces the visible rows page by page under explicit user control; this pattern appends pages invisibly as a side effect of scrolling. Prefer visible pagination when users need to jump around or cite "page N"; prefer infinite scroll for feeds consumed linearly.
+
+---
+
+## See also
+
+- [Paginate a list](/docs/howto/paginate-a-list) - visible page controls with `Pagination`
+- [DataSource component reference](/docs/reference/components/DataSource) - `nextPageSelector`, `prevPageSelector`, and `$pageParams`
+- [List component reference](/docs/reference/components/List) - `pageInfo` and scrolling behavior

--- a/website/content/docs/pages/howto/paste-an-image-from-the-clipboard.md
+++ b/website/content/docs/pages/howto/paste-an-image-from-the-clipboard.md
@@ -1,0 +1,52 @@
+# Paste an image from the clipboard
+
+Let users paste an image from the clipboard with `FileUploadDropZone allowPaste="true"`; the pasted image arrives in the `upload` event as a `File` object.
+
+Screenshots are the common case: a user captures one, and instead of saving it to disk and browsing for it, they paste it straight into the app. `FileUploadDropZone` handles the clipboard wiring — your app receives the same `File` objects a drag-and-drop would produce — and `Image`'s `data` prop displays a `File` directly.
+
+```xmlui-pg copy display name="Paste an image from the clipboard" height="420px"
+<App var.images="{[]}">
+  <VStack gap="$space-4" padding="$space-4">
+    <FileUploadDropZone
+      height="120px"
+      allowPaste="true"
+      acceptedFileTypes="image/*"
+      text="Click here, then paste an image from the clipboard"
+      onUpload="(files) => {
+        images = [...images, ...files];
+        toast('Pasted ' + files.length + ' image(s)');
+      }"
+    />
+    <Text when="{images.length === 0}">
+      Copy an image (or take a screenshot), click the drop zone,
+      then press Ctrl+V (Cmd+V on Mac).
+    </Text>
+    <Items data="{images}">
+      <VStack gap="$space-1">
+        <Image data="{$item}" maxHeight="160px" fit="contain" />
+        <Text>{$item.name} · {$item.type} · {Math.round($item.size / 1024)} KB</Text>
+      </VStack>
+    </Items>
+  </VStack>
+</App>
+```
+
+## Key points
+
+**`allowPaste="true"` turns pasting on**: pasting is disabled by default so that pasting text into inputs inside the drop zone doesn't trigger unexpected uploads. Even with it enabled, paste events that originate from text inputs and editable elements are still ignored — only pasting into the zone itself counts.
+
+**Focus the drop zone first**: the paste target is the zone, so the user clicks it (or tabs to it) and then presses the OS paste shortcut. A screenshot pasted from the clipboard typically arrives as a file named `image.png`.
+
+**`acceptedFileTypes` restricts input to images**: it takes MIME types separated by commas, so `image/*` accepts any image format while rejecting other clipboard or dropped content.
+
+**`Image data` displays the pasted file**: `Image`'s `data` prop takes the binary data of an image — the `File` object from the `upload` event works as-is, with no object URL or base64 conversion. The script engine has no access to browser APIs like `FileReader`, so `data` is the way to preview a pasted or dropped image.
+
+**Your app performs the actual upload**: the component accepts the pasted file but does not transmit it anywhere. The `upload` event passes the `File` objects, and the handler is where you send them to your backend — for example with an `APICall` — according to whatever protocol your API expects. This example keeps them in a component variable and previews them.
+
+---
+
+## See also
+
+- [FileUploadDropZone component reference](/docs/reference/components/FileUploadDropZone) - `allowPaste`, `acceptedFileTypes`, `maxFiles`, and the `upload` event
+- [Image component reference](/docs/reference/components/Image) - the `data` prop for binary image data
+- [Submit a form with file uploads](/docs/howto/submit-a-form-with-file-uploads) - file pickers as form fields with `FileInput`

--- a/website/content/docs/pages/scoping.md
+++ b/website/content/docs/pages/scoping.md
@@ -59,7 +59,7 @@ The variable can be passed into a user-defined component.
 ```
 
 
-Or the variable can be transposed into the user-defined component by means of the [Slot](/components/Slot) mechanism. The `Slot` content evaluates in the parent's scope, so it can see parent vars and IDs, but renders inside the child’s layout.
+Or the variable can be transposed into the user-defined component by means of the [Slot](/docs/reference/components/Slot) mechanism. The `Slot` content evaluates in the parent's scope, so it can see parent vars and IDs, but renders inside the child’s layout.
 
 ```xmlui-pg name="Variables 4"
 ---app display filename="Main.xmlui"
@@ -263,7 +263,7 @@ The id can be passed into a user-defined component.
 </Component>
 ```
 
-Or the component ID can be transposed into the user-defined component by means of the [Slot](/components/Slot) mechanism.
+Or the component ID can be transposed into the user-defined component by means of the [Slot](/docs/reference/components/Slot) mechanism.
 
 ```xmlui-pg name="Component IDs 4"
 ---app display filename="Main.xmlui"

--- a/website/content/docs/pages/tutorial-06.md
+++ b/website/content/docs/pages/tutorial-06.md
@@ -1,6 +1,6 @@
 # Slider
 
-The `Dashboard` page continues with a chart of daily revenue that uses a [Slider](/components/Slider) to control both ends of a date range.
+The `Dashboard` page continues with a chart of daily revenue that uses a [Slider](/docs/reference/components/Slider) to control both ends of a date range.
 
 Here is a simplified version of that mechanism. Try using both slider handles to adjust the date range and corresponding total revenue.
 

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -589,6 +589,11 @@
                             label="Set the initial value of a Select from fetched data"
                             to="/docs/howto/set-the-initial-value-of-a-select-from-fetched-data"
                         />
+                        <NavLink
+                            icon="article"
+                            label="Create a two-handle range slider"
+                            to="/docs/howto/create-a-two-handle-range-slider"
+                        />
                     </NavGroup>
 
                     <NavGroup label="Data Loading & APIs">
@@ -2188,6 +2193,11 @@
             >
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/set-the-initial-value-of-a-select-from-fetched-data.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/create-a-two-handle-range-slider">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/create-a-two-handle-range-slider.md']}"
                 />
             </Page>
             <Page

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -551,6 +551,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Paste an image from the clipboard"
+                            to="/docs/howto/paste-an-image-from-the-clipboard"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Submit a form from a custom button or the Enter key"
                             to="/docs/howto/submit-a-form-from-a-custom-button"
                         />
@@ -2377,6 +2382,11 @@
             <Page url="/docs/howto/submit-a-form-with-file-uploads">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/submit-a-form-with-file-uploads.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/paste-an-image-from-the-clipboard">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/paste-an-image-from-the-clipboard.md']}"
                 />
             </Page>
             <Page url="/docs/howto/submit-a-form-from-a-custom-button">

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -818,6 +818,11 @@
                             label="Paginate a list"
                             to="/docs/howto/paginate-a-list"
                         />
+                        <NavLink
+                            icon="article"
+                            label="Implement infinite scroll pagination"
+                            to="/docs/howto/implement-infinite-scroll-pagination"
+                        />
                     </NavGroup>
 
                     <NavGroup label="Navigation & Routing">
@@ -2229,6 +2234,11 @@
             <Page url="/docs/howto/paginate-a-list">
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/paginate-a-list.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/implement-infinite-scroll-pagination">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/implement-infinite-scroll-pagination.md']}"
                 />
             </Page>
             <Page url="/docs/howto/chain-a-refetch">


### PR DESCRIPTION
## Summary

Three new how-to pages plus a link-form cleanup, each closing a gap surfaced by MCP search analytics — task-oriented queries that the how-to corpus couldn't answer. Every page is a runnable `xmlui-pg` example, registered in `Main.xmlui` nav and routes, and worded so the originally-missed query retrieves it.

- **Create a two-handle range slider** — `Slider` switches to dual thumbs with an array `initialValue`; covers the `[low, high]` value shape and `minStepsBetweenThumbs` (measured in steps, not units).
- **Paste an image from the clipboard** — `FileUploadDropZone allowPaste="true"` with `acceptedFileTypes="image/*"`; pasted `File` objects preview directly via `Image`'s `data` prop. Validating this page end-to-end surfaced the `Image` blob-URL flicker bug fixed separately in #3711.
- **Implement infinite scroll pagination** — the supported composition: `DataSource` becomes pageable via `nextPageSelector`/`$pageParams`, and `List` in `pageInfo` mode calls `fetchNextPage()` near the end of the scroll. Validated live in-browser: a 57-item mock feed loads in four cursor pages with working loading and end-of-data guards.
- **Fix component reference links** — four links in three pages used the routeless `/components/<Name>` form (no such route or redirect exists in `Main.xmlui`); rewritten to the canonical `/docs/reference/components/<Name>`.

## Validation

Each page was exercised in the local docs dev server: the slider playground drag-tested, the paste playground exercised with real clipboard screenshots, and the infinite-scroll playground scrolled through all four pages to the end-of-data state in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
