### PR TITLE
Add armed evaluation-trace probe (evalTrace) with host-registered sink

### DIFF
--- a/xmlui/src/components-core/rendering/reducer.ts
+++ b/xmlui/src/components-core/rendering/reducer.ts
@@ -7,6 +7,7 @@ import { ContainerActionKind } from "./containers";
 import type { IDebugViewContext } from "../DebugViewProvider";
 import { pushXsLog } from "../inspector/inspectorUtils";
 import { isRenderInProgress } from "../scheduler";
+import { evalTrace } from "../script-runner/eval-trace";
 
 const MAX_STATE_TRANSITION_LENGTH = 100;
 
@@ -22,6 +23,9 @@ export function createContainerReducer(debugView: IDebugViewContext) {
 
   // --- The reducer function
   return produce((state: ContainerState, action: ContainerAction) => {
+    // --- Evaluation trace (see eval-trace.ts): names each container
+    // --- action while the host-armed window is open. No-op otherwise.
+    evalTrace("action", () => String(action.type ?? "") + " uid:" + String(action.payload?.uid ?? ""));
     if (isRenderInProgress()) {
       pushXsLog({
         kind: "scheduler",

--- a/xmlui/src/components-core/script-runner/eval-trace.ts
+++ b/xmlui/src/components-core/script-runner/eval-trace.ts
@@ -1,0 +1,22 @@
+// Evaluation trace probe: names every binding evaluation, statement, and
+// container action the engine runs — but ONLY inside a short window the
+// host arms by setting `window.__xmluiEvalTraceUntil` to a
+// performance.now() deadline. Emission goes through the host-registered
+// sink `window.__xmluiEvalTraceSink(op, detail)`; with no sink or no armed
+// window this is a few property reads per call and no allocation (the
+// detail thunk is never invoked). Synchronous by design: a hang inside one
+// evaluation never returns, so the last emitted line names the hanging
+// site. The probe must never break the engine.
+export function evalTrace(op: string, detail: () => string): void {
+  try {
+    const w = typeof window !== "undefined" ? (window as any) : null;
+    if (!w) return;
+    const until = w.__xmluiEvalTraceUntil;
+    if (!until || performance.now() > until) return;
+    const emit = w.__xmluiEvalTraceSink;
+    if (typeof emit !== "function") return;
+    emit(op, detail());
+  } catch (e) {
+    // Never break the engine.
+  }
+}

--- a/xmlui/src/components-core/script-runner/eval-tree-sync.ts
+++ b/xmlui/src/components-core/script-runner/eval-tree-sync.ts
@@ -67,6 +67,7 @@ import {
   setExprValue,
 } from "./eval-tree-common";
 import { ensureMainThread } from "./process-statement-common";
+import { evalTrace } from "./eval-trace";
 import { processDeclarations, processStatementQueue } from "./process-statement-sync";
 import { assertSyncResult, callSyncFunction } from "./sync-runtime";
 import { evaluateCompiledBinding } from "../script-compiler";
@@ -126,6 +127,12 @@ export function evalBinding(
   const thisStack: any[] = [];
   ensureMainThread(evalContext);
   thread ??= evalContext.mainThread;
+  // --- Evaluation trace (see eval-trace.ts): names the binding about to
+  // --- evaluate. Placed before the compiled-bindings branch so both paths
+  // --- log. No-op outside the host-armed window.
+  evalTrace("eval", () =>
+    String((expr as any)?.source ?? "").slice(0, 80) || "type:" + String((expr as any)?.type ?? "?"),
+  );
   if (evalContext.options?.compileBindings && expr.type !== T_ARROW_EXPRESSION) {
     const previousArrowInvoker = evalContext.compiledArrowInvoker;
     evalContext.compiledArrowInvoker = (arrowExpr, args, arrowEvalContext, arrowThread) =>

--- a/xmlui/src/components-core/script-runner/process-statement-sync.ts
+++ b/xmlui/src/components-core/script-runner/process-statement-sync.ts
@@ -54,6 +54,7 @@ import {
   closing,
   guard,
 } from "./process-statement-common";
+import { evalTrace } from "./eval-trace";
 import type { BindingTreeEvaluationContext } from "./BindingTreeEvaluationContext";
 import { evalBinding, executeArrowExpressionSync } from "./eval-tree-sync";
 import type {
@@ -118,6 +119,13 @@ export function processStatementQueue(
     try {
       // --- Sign that the statement is about to start
       void evalContext?.onStatementStarted?.(evalContext, queueItem!.statement);
+
+      // --- Evaluation trace (see eval-trace.ts): names the statement about
+      // --- to run. No-op outside the host-armed window.
+      evalTrace("stmt", () => {
+        const s: any = queueItem!.statement;
+        return String(s?.type ?? "") + " " + String(s?.source ?? "").slice(0, 80);
+      });
 
       // --- Execute the statement
       outcome = processStatement(


### PR DESCRIPTION
An inert-by-default probe that names every binding evaluation, statement, and container action the engine runs — only inside a short window the host arms by setting window.__xmluiEvalTraceUntil to a performance.now() deadline, emitting through the host-registered window.__xmluiEvalTraceSink(op, detail). Unarmed or sinkless: a few property reads per call, the detail thunk never invoked.

Hook sites: evalBinding (before the compiled-bindings branch, so both paths log), the statement-queue loop, and the container reducer. Synchronous by design — a hang inside one evaluation never returns, so the last emitted line names the hanging site (freeze forensics), and high-volume output inside a deliberate window is the diagnostic, not a defect.