### PR TITLE
Docs: add a RadioGroup how-to (present a short list of choices)

### DIFF
--- a/website/content/docs/pages/howto/present-choices-with-a-radiogroup.md
+++ b/website/content/docs/pages/howto/present-choices-with-a-radiogroup.md
@@ -1,0 +1,36 @@
+# Present a short list of choices with a RadioGroup
+
+Use a `RadioGroup` when a field has a small, fixed set of options worth showing inline — a visible alternative to a `Select` dropdown. Because `RadioGroup` owns the selected value and exposes the same `initialValue`, `onDidChange`, and `setValue` surface as other inputs, **swapping a dropdown for radio buttons is a tag substitution** — no new script or styling.
+
+```xmlui-pg copy display name="A RadioGroup instead of a dropdown" height="320px"
+<App var.plan="pro">
+  <RadioGroup id="planRadio" initialValue="pro" orientation="horizontal"
+    onDidChange="(val) => plan = val">
+    <Option label="Free" value="free" />
+    <Option label="Pro" value="pro" />
+    <Option label="Team" value="team" />
+  </RadioGroup>
+  <Text>Selected plan: <Text variant="strong">{plan}</Text></Text>
+  <Button label="Reset to Pro" onClick="planRadio.setValue('pro')" />
+</App>
+```
+
+## Key points
+
+**Options are `<Option label value>` children.** The `RadioGroup` governs the group and stores the selected `value`; each `Option` supplies a `label` (shown) and a `value` (reported). This is the same option shape a `Select` uses, which is what makes the swap mechanical.
+
+**`initialValue` preselects; `onDidChange` reports changes.** `initialValue` sets the checked option at mount, and `onDidChange="(val) => …"` fires with the new `value` whenever the user picks a different option — identical to how you'd wire a `Select`.
+
+**`setValue(value)` changes the selection from code.** Give the group an `id` and call `id.setValue('pro')` — as the "Reset to Pro" button does. `initialValue` only seeds the mount, so use `setValue` (not a rebind of `initialValue`) to move the selection programmatically.
+
+**`orientation` lays the group out.** The default is `vertical` (one option per line); `orientation="horizontal"` puts them in a row. Horizontal radios are inputs in a row, so the same explicit-width guidance as other horizontal inputs applies — see [Set the Width of an Input Field in an HStack](/docs/howto/set-width-for-input-fields-in-a-horizontal-layout).
+
+**`enabled="false"`** disables the whole group.
+
+**When to prefer a `Select` instead:** long option lists. Radio buttons show every option at once, which is an advantage for three or four choices and a liability for twenty — reach for a `Select` dropdown there.
+
+## See also
+
+- [RadioGroup component reference](/docs/reference/components/RadioGroup) — `initialValue`, `enabled`, `orientation`, `onDidChange`, `value`, `setValue`
+- [Select component reference](/docs/reference/components/Select) — the dropdown alternative for long lists
+- [Set the Width of an Input Field in an HStack](/docs/howto/set-width-for-input-fields-in-a-horizontal-layout) — sizing for horizontal radios and other inline inputs

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -596,6 +596,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Present a short list of choices with a RadioGroup"
+                            to="/docs/howto/present-choices-with-a-radiogroup"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Create a two-handle range slider"
                             to="/docs/howto/create-a-two-handle-range-slider"
                         />
@@ -2358,6 +2363,11 @@
             >
                 <DocumentPageNoTOC
                     content="{appGlobals.docsContent['pages/howto/copy-billing-to-shipping.md']}"
+                />
+            </Page>
+            <Page url="/docs/howto/present-choices-with-a-radiogroup">
+                <DocumentPageNoTOC
+                    content="{appGlobals.docsContent['pages/howto/present-choices-with-a-radiogroup.md']}"
                 />
             </Page>
             <Page


### PR DESCRIPTION
## Summary

A new how-to, **Present a short list of choices with a RadioGroup**, teaching `RadioGroup` as a visible alternative to a `Select` dropdown for a small, fixed set of options.

Fills a documented gap: an agent working in a Bram project set out to change a dropdown to a radio group, searched the how-tos, and found **no radio-specific recipe** — even though the `RadioGroup` contract already supplies everything the swap needs.

## The point

Swapping a dropdown for radio buttons is a **tag substitution** — no new script or styling — because `RadioGroup` owns the value and exposes the same `initialValue`, `onDidChange`, and `setValue` surface as other inputs.

## What it covers

A runnable `xmlui-pg` playground, grounded in the component's own reference examples:

- `<Option label value>` children; `RadioGroup` stores the selected value.
- `initialValue` preselects; `onDidChange="(val) => …"` reports changes.
- `setValue(value)` moves the selection from code (a "Reset" button), since `initialValue` only seeds the mount.
- `orientation` — `vertical` (default) or `horizontal` (a row), with a pointer to [Set the Width of an Input Field in an HStack](https://docs.xmlui.org/howto/set-width-for-input-fields-in-a-horizontal-layout) for sizing horizontal inputs.
- `enabled="false"` to disable the group.
- When to prefer `Select` instead: long option lists.

Registered under Forms & Validation, next to the Select how-to. Not tied to a GitHub issue (surfaced by cross-project observation), so it closes nothing.

---

Raised by **Jon's Claude** (via Bram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
