### PR TITLE
Docs: fix show-validation e2e spec broken by #3737

### DIFF
--- a/xmlui/tests-e2e/how-to-examples/show-validation-on-blur-not-on-type.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/show-validation-on-blur-not-on-type.spec.ts
@@ -9,43 +9,31 @@ const markdown = getExampleSource(
   path.join(__dirname, "../../../website/content/docs/pages/howto/show-validation-on-blur-not-on-type.md"),
 );
 
-test.describe("Debounced username availability check", { tag: "@website" }, () => {
-  const { app, components, apiInterceptor } = extractXmluiExample(
-    markdown,
-    "Debounced username availability check",
-  );
+test.describe("Validation timing: on type vs on blur", { tag: "@website" }, () => {
+  const { app } = extractXmluiExample(markdown, "Validation timing: on type vs on blur");
 
-  test("initial state renders form with Register button", async ({ initTestBed, page }) => {
-    await initTestBed(app, { components, apiInterceptor });
-    await expect(page.getByRole("textbox", { name: "Username" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Email" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Register" })).toBeVisible();
+  test("renders both fields and the Save button", async ({ initTestBed, page }) => {
+    await initTestBed(app);
+    await expect(page.getByRole("textbox", { name: /Handle/ })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: /Display name/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
   });
 
-  test("API returns taken=true so username shows 'already taken' error after debounce", async ({
-    initTestBed,
-    page,
-  }) => {
-    // The raw fetch('/check-username') inside onValidate goes through MSW but the
-    // relative URL pattern ("/check-username") isn't reliably matched when apiUrl
-    // is empty — the service worker intercepts but never responds.  The equivalent
-    // pattern using Actions.callApi() works fine (see add-an-async-uniqueness-check).
-    // Skip rather than hang for 10 s on every CI run.
-    test.skip(
-      true,
-      "raw fetch() in onValidate cannot be intercepted via MSW with an empty apiUrl; use Actions.callApi() for testable async validation",
-    );
+  test("onChanged field shows the minLength error while typing", async ({ initTestBed, page }) => {
+    await initTestBed(app);
+    await page.getByRole("textbox", { name: /Handle/ }).fill("ab");
+    // onChanged: the error appears immediately, without leaving the field
+    await expect(page.getByText(/at least 3/i)).toBeVisible();
   });
 
-  test("username shorter than 3 characters shows built-in minLength error on submit", async ({
-    initTestBed,
-    page,
-  }) => {
-    await initTestBed(app, { apiInterceptor });
-    const usernameInput = page.getByRole("textbox", { name: "Username" });
-    await usernameInput.fill("ab");
-    await page.getByRole("button", { name: "Register" }).click();
-    // Built-in minLength fires immediately (not debounced)
+  test("onLostFocus field shows the error only after blur", async ({ initTestBed, page }) => {
+    await initTestBed(app);
+    const display = page.getByRole("textbox", { name: /Display name/ });
+    await display.fill("ab");
+    // onLostFocus: still focused, so no error yet
+    await expect(page.getByText(/at least 3/i)).toHaveCount(0);
+    await display.blur();
+    // after blur, the error appears
     await expect(page.getByText(/at least 3/i)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `@website` e2e spec that #3737 left broken, reddening CI on `main`.

## Why

#3737 rewrote `show-validation-on-blur-not-on-type` — renaming its playground ("Debounced username availability check" → "Validation timing: on type vs on blur") and switching it from a debounced-`fetch` demo to a `validationMode` (`onChanged` vs `onLostFocus`) demo. But its paired spec still extracted the example **by the old name**, so `extractXmluiExample` threw "example not found" and the `All Tests (Fast)` / smoke run failed. (My oversight — the spec should have been updated in that same commit.)

## Change

`xmlui/tests-e2e/how-to-examples/show-validation-on-blur-not-on-type.spec.ts` now:
- extracts by the new name, and
- asserts the new behavior — both fields + **Save** render, the `onChanged` field shows the built-in minLength error (`"Input should be at least 3 characters"`) while typing, and the `onLostFocus` field shows it only after blur.

Verified locally: **3 passed**.

The react/bridge specs from #3737 kept their example names and only assert "renders," so they were unaffected.

---

Raised by **Jon's Claude** (via Bram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
