### PR TITLE
Add Form.reset(data) support for new pristine baselines

### DIFF
--- a/.changeset/form-reset-data.md
+++ b/.changeset/form-reset-data.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Allow `Form.reset(data)` to replace the form values and establish data as a new pristine baseline.

--- a/website/content/docs/reference/components/Form.md
+++ b/website/content/docs/reference/components/Form.md
@@ -432,9 +432,28 @@ This method returns a deep clone of the current form data object. Changes to the
 
 ### `reset` [#reset]
 
-This method resets the form to its initial state, clearing all user input.
+This method resets the form to its initial state. When `data` is provided, the form adopts it as both the current value and the new initial baseline, leaving the form pristine.
 
-**Signature**: `reset(): void`
+**Signature**: `reset(data?: Record<string, any>): void`
+
+- `data`: Optional form data to install as the new initial baseline.
+
+Pass data to `reset` to replace the current values and establish a new clean initial baseline.
+Later parameterless resets return to that baseline.
+
+```xmlui-pg copy display name="Example: reset with new initial data"
+<App>
+  <Form id="profileForm"
+    data="{{ name: 'Original name' }}"
+    padding="0.5rem"
+    onSubmit="(toSave) => toast(JSON.stringify(toSave))">
+    <FormItem bindTo="name" label="Name" />
+  </Form>
+  <Button
+    label="Adopt canonical data"
+    onClick="profileForm.reset({ name: 'Canonical name' })" />
+</App>
+```
 
 ### `update` [#update]
 

--- a/xmlui/src/components/Form/Form.md
+++ b/xmlui/src/components/Form/Form.md
@@ -175,6 +175,27 @@ The following example uses the first argument to inspect what will be submitted,
 
 %-EVENT-END
 
+%-API-START reset
+
+Pass data to `reset` to replace the current values and establish a new clean initial baseline.
+Later parameterless resets return to that baseline.
+
+```xmlui-pg copy display name="Example: reset with new initial data"
+<App>
+  <Form id="profileForm"
+    data="{{ name: 'Original name' }}"
+    padding="0.5rem"
+    onSubmit="(toSave) => toast(JSON.stringify(toSave))">
+    <FormItem bindTo="name" label="Name" />
+  </Form>
+  <Button
+    label="Adopt canonical data"
+    onClick="profileForm.reset({ name: 'Canonical name' })" />
+</App>
+```
+
+%-API-END
+
 %-API-START update
 
 This method updates the form data with the change passed in its parameter. The parameter is a hash object, and this method updates the Form's properties accordingly. 

--- a/xmlui/src/components/Form/Form.spec.ts
+++ b/xmlui/src/components/Form/Form.spec.ts
@@ -1618,6 +1618,55 @@ test.describe("Basic Functionality", () => {
       await expect(nameInput.field).toHaveValue("Initial");
     });
 
+    test("reset with data establishes a new pristine baseline", async ({
+      initTestBed,
+      page,
+      createFormItemDriver,
+      createTextBoxDriver,
+    }) => {
+      const { testStateDriver } = await initTestBed(`
+        <Fragment>
+          <Form
+            id="testForm"
+            data="{{ name: 'Initial', address: { city: 'Old city' } }}">
+            <FormItem label="Name" bindTo="name" testId="nameField" />
+            <FormItem label="City" bindTo="address.city" testId="cityField" />
+          </Form>
+          <Button
+            testId="adopt"
+            label="Adopt"
+            onClick="testForm.reset({ name: 'Canonical', address: { city: 'New city' } })" />
+          <Button testId="reset" label="Reset" onClick="testForm.reset()" />
+          <Button
+            testId="inspect"
+            label="Inspect"
+            onClick="testState = { data: testForm.getData(), dirty: testForm.isDirty() }" />
+        </Fragment>
+      `);
+
+      const nameItem = await createFormItemDriver("nameField");
+      const nameInput = await createTextBoxDriver(nameItem.input);
+      const cityItem = await createFormItemDriver("cityField");
+      const cityInput = await createTextBoxDriver(cityItem.input);
+
+      await nameInput.field.fill("Draft");
+      await page.getByTestId("adopt").click();
+
+      await expect(nameInput.field).toHaveValue("Canonical");
+      await expect(cityInput.field).toHaveValue("New city");
+      await page.getByTestId("inspect").click();
+      await expect.poll(testStateDriver.testState).toEqual({
+        data: { name: "Canonical", address: { city: "New city" } },
+        dirty: false,
+      });
+
+      await nameInput.field.fill("Another draft");
+      await page.getByTestId("reset").click();
+
+      await expect(nameInput.field).toHaveValue("Canonical");
+      await expect(cityInput.field).toHaveValue("New city");
+    });
+
     test("validate method returns validation results without submitting", async ({
       initTestBed,
       page,

--- a/xmlui/src/components/Form/Form.tsx
+++ b/xmlui/src/components/Form/Form.tsx
@@ -365,8 +365,13 @@ export const FormMd = createMetadata({
   },
   apis: {
     reset: {
-      description: "This method resets the form to its initial state, clearing all user input.",
-      signature: "reset(): void",
+      description:
+        "This method resets the form to its initial state. When `data` is provided, the form " +
+        "adopts it as both the current value and the new initial baseline, leaving the form pristine.",
+      signature: "reset(data?: Record<string, any>): void",
+      parameters: {
+        data: "Optional form data to install as the new initial baseline.",
+      },
     },
     update: {
       description:

--- a/xmlui/src/components/Form/FormReact.tsx
+++ b/xmlui/src/components/Form/FormReact.tsx
@@ -236,8 +236,17 @@ const formReducer = produce((state: FormState, action: ContainerAction | FormAct
       break;
     }
     case FormActionKind.RESET: {
+      const resetBaseline = action.payload.hasData
+        ? cloneDeep(action.payload.data)
+        : state.resetBaseline;
       return {
         ...initialState,
+        subject: action.payload.clear
+          ? {}
+          : resetBaseline === undefined
+            ? {}
+            : cloneDeep(resetBaseline),
+        resetBaseline,
         resetVersion: (state.resetVersion ?? 0) + 1,
       };
     }
@@ -254,6 +263,7 @@ interface FormState {
   noSubmitFields: Record<string, boolean>; // Track noSubmit flag for each field
   submitInProgress?: boolean;
   resetVersion?: number;
+  resetBaseline?: any;
 }
 
 const initialState: FormState = {
@@ -264,6 +274,7 @@ const initialState: FormState = {
   noSubmitFields: {},
   submitInProgress: false,
   resetVersion: 0,
+  resetBaseline: undefined,
 };
 
 type OnSubmit = (
@@ -809,7 +820,7 @@ const Form = memo(forwardRef(function (
       } else if (dataAfterSubmit === "clear") {
         flushSync(() => {
           onClearAfterSubmit?.();
-          doReset();
+          doReset(undefined, true);
         });
       } else {
         // "keep" (default): fire the reset event (backward compat) without resetting form state
@@ -936,8 +947,19 @@ const Form = memo(forwardRef(function (
     }
   });
 
-  const doReset = useEvent(() => {
-    dispatch(formReset());
+  const doReset = useEvent((data?: Record<string, any>, clear = false) => {
+    const hasData = data !== undefined;
+    if (hasData && (typeof data !== "object" || data === null || Array.isArray(data))) {
+      return;
+    }
+    dispatch({
+      ...formReset(),
+      payload: {
+        data,
+        hasData,
+        clear,
+      },
+    });
     onReset?.();
   });
 
@@ -1068,7 +1090,7 @@ const Form = memo(forwardRef(function (
         style={style}
         className={classnames(styles.formWrapper, { [styles.stickyForm]: stickyButtonRow }, classes?.[COMPONENT_PART_KEY], className)}
         onSubmit={doSubmit}
-        onReset={doReset}
+        onReset={() => doReset()}
         id={id}
         key={formState.resetVersion}
         ref={formRef}
@@ -1238,7 +1260,9 @@ export const FormWithContextVar = forwardRef(function (
   const effectiveInitialValue =
     clearedAtResetVersion !== null && clearedAtResetVersion === formState.resetVersion
       ? EMPTY_OBJECT
-      : rawInitialValue;
+      : formState.resetBaseline === undefined
+        ? rawInitialValue
+        : formState.resetBaseline;
   const submitMethod =
     extractValue.asOptionalString(node.props.submitMethod) || (rawInitialValue ? "put" : "post");
   const inProgressNotificationMessage =

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -7218,8 +7218,11 @@ export default {
     },
     "apis": {
       "reset": {
-        "description": "This method resets the form to its initial state, clearing all user input.",
-        "signature": "reset(): void"
+        "description": "This method resets the form to its initial state. When `data` is provided, the form adopts it as both the current value and the new initial baseline, leaving the form pristine.",
+        "signature": "reset(data?: Record<string, any>): void",
+        "parameters": {
+          "data": "Optional form data to install as the new initial baseline."
+        }
       },
       "update": {
         "description": "You can pass a data object to update the form data. The properties in the passed data object are updated to their values accordingly. Other form properties remain intact.",


### PR DESCRIPTION
## Motivation

Bram's settings form receives canonical settings after a successful save. It needs to display those server-confirmed values and treat them as the new pristine baseline. Previously, Form.update(data) installed the values but marked the form dirty, while parameterless Form.reset() could only return to the existing baseline. Bram therefore had to wait for a separate settings-changed snapshot and coordinate its own rehydration.

## Change

- Add Form.reset(data?) while preserving parameterless reset behavior.
- When data is supplied, replace the form values and establish a deep-cloned pristine baseline.
- Clear dirty, touched, validation, and submission state as part of the reset.
- Document the API with a runnable playground and update generated metadata/reference docs.
- Add regression coverage and a patch changeset.

## Verification

- Form component Playwright suite: 230 passed, 1 skipped.
- Metadata snapshot check passed.
- Full XMLUI framework build passed (24/24 tasks).
- Documentation build passed, and the playground was exercised in the local docs site.
