### PR TITLE
Add mixed settings save how-to

### DIFF
--- a/.changeset/form-reset-data.md
+++ b/.changeset/form-reset-data.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Allow `Form.reset(data)` to replace the form values and establish data as a new pristine baseline.

--- a/website/content/docs/pages/howto/combine-immediate-save-settings-with-scoped-forms.md
+++ b/website/content/docs/pages/howto/combine-immediate-save-settings-with-scoped-forms.md
@@ -1,0 +1,311 @@
+# Combine immediate-save settings with scoped Forms
+
+Keep settings with different save behavior in different state boundaries: use a dedicated `APICall` for a control that saves immediately, and one scoped `Form` for each group users review and save together.
+
+A settings page often mixes both interaction styles. A preference switch should take effect as soon as it changes, while Delivery and Retention settings should remain independent drafts until the user saves each section.
+
+## Choose save boundaries
+
+This example gives the immediate switch and each grouped save its own request and progress state. The two Forms use the built-in `submitUrl` path, send only their own section, and adopt the server's normalized response as a new pristine baseline.
+
+```xmlui-pg copy display name="Choose save boundaries for settings" id="choose-save-boundaries-for-settings" height="900px"
+<App var.digestStatus="{'Saved'}" var.restoringDigest="{false}">
+  <script>
+    function deliverySection(snapshot) {
+      return {
+        delivery: {
+          senderName: snapshot.delivery.senderName,
+          replyTo: snapshot.delivery.replyTo
+        }
+      };
+    }
+
+    function retentionSection(snapshot) {
+      return { retention: { days: snapshot.retention.days } };
+    }
+  </script>
+
+  <DataSource id="settings" url="/api/settings" />
+
+  <APICall
+    id="saveDigest"
+    method="post"
+    url="/api/settings"
+    body="{$param}"
+    invalidates="{[]}"
+    onSuccess="() => { settings.refetch(); digestStatus = 'Saved'; }" />
+
+  <VStack when="{settings.value}" gap="$space-5" padding="$space-5" maxWidth="42rem">
+    <VStack gap="$space-2">
+      <H3>Notifications</H3>
+      <Switch
+        id="digestSwitch"
+        label="Weekly digest"
+        initialValue="{!!settings.value.notifications.weeklyDigest}"
+        enabled="{!saveDigest.inProgress}"
+        onDidChange="(value) => {
+          if (restoringDigest) {
+            restoringDigest = false;
+          } else {
+            digestStatus = 'Saving…';
+            saveDigest.execute({ notifications: { weeklyDigest: value } });
+          }
+        }"
+        onError="() => {
+          restoringDigest = true;
+          digestSwitch.setValue(settings.value.notifications.weeklyDigest);
+          digestStatus = 'Could not save — restored the server value';
+        }" />
+      <Text variant="caption">Status: {digestStatus}</Text>
+      <Text variant="caption">
+        Server value: {settings.value.notifications.weeklyDigest ? 'On' : 'Off'}
+      </Text>
+    </VStack>
+
+    <ContentSeparator />
+
+    <VStack gap="$space-2">
+      <H3>Delivery</H3>
+      <Form
+        id="deliveryForm"
+        data="{{
+          delivery: {
+            senderName: settings.value.delivery.senderName,
+            replyTo: settings.value.delivery.replyTo
+          }
+        }}"
+        submitUrl="/api/settings"
+        submitMethod="post"
+        onSuccess="(response) => {
+          deliveryForm.reset(deliverySection(response));
+          toast('Saved canonical sender: ' + response.delivery.senderName);
+        }"
+        errorNotificationMessage="Could not save delivery settings."
+        hideButtonRowUntilDirty="true"
+        cancelLabel=""
+        saveLabel="Save delivery settings"
+        saveInProgressLabel="Saving delivery settings…"
+        submitFeedbackDelay="0">
+        <TextBox
+          label="Sender name"
+          bindTo="delivery.senderName"
+          required="true" />
+        <TextBox
+          label="Reply-to email"
+          bindTo="delivery.replyTo"
+          required="true"
+          pattern="email" />
+      </Form>
+      <Button
+        label="Reset delivery draft"
+        variant="outlined"
+        onClick="deliveryForm.reset()" />
+      <Text variant="caption">Server sender: {settings.value.delivery.senderName}</Text>
+    </VStack>
+
+    <ContentSeparator />
+
+    <VStack gap="$space-2">
+      <H3>Retention</H3>
+      <Form
+        id="retentionForm"
+        data="{{ retention: { days: settings.value.retention.days } }}"
+        submitUrl="/api/settings"
+        submitMethod="post"
+        onSuccess="(response) => {
+          retentionForm.reset(retentionSection(response));
+          toast('Saved canonical retention: ' + response.retention.days + ' days');
+        }"
+        errorNotificationMessage="Could not save retention settings."
+        hideButtonRowUntilDirty="true"
+        cancelLabel=""
+        saveLabel="Save retention settings"
+        saveInProgressLabel="Saving retention settings…"
+        submitFeedbackDelay="0">
+        <NumberBox
+          label="Retention days"
+          bindTo="retention.days"
+          required="true"
+          integersOnly="true"
+          minValue="1"
+          maxValue="365" />
+      </Form>
+      <Button
+        label="Reset retention draft"
+        variant="outlined"
+        onClick="retentionForm.reset()" />
+      <Text variant="caption">Server retention: {settings.value.retention.days} days</Text>
+    </VStack>
+  </VStack>
+</App>
+---api
+{
+  "apiUrl": "/api",
+  "initialize": "$state.settings = { notifications: { weeklyDigest: false }, delivery: { senderName: 'Bram Team', replyTo: 'ops@example.com' }, retention: { days: 30 } }; $state.digestAttempts = 0",
+  "operations": {
+    "get-settings": {
+      "url": "/settings",
+      "method": "get",
+      "handler": "return { notifications: { ...$state.settings.notifications }, delivery: { ...$state.settings.delivery }, retention: { ...$state.settings.retention } }"
+    },
+    "update-settings": {
+      "url": "/settings",
+      "method": "post",
+      "handler": "if ($requestBody.notifications) { delay(300); $state.digestAttempts++; if ($state.digestAttempts === 1) { throw Error('Demo failure on the first immediate save'); } $state.settings.notifications = { ...$state.settings.notifications, ...$requestBody.notifications }; } if ($requestBody.delivery) { delay(500); $state.settings.delivery = { senderName: $requestBody.delivery.senderName.trim(), replyTo: $requestBody.delivery.replyTo.trim().toLowerCase() }; } if ($requestBody.retention) { delay(450); $state.settings.retention = { days: Math.max(7, Math.min(364, Math.round(Number($requestBody.retention.days) / 7) * 7)) }; } return { notifications: { ...$state.settings.notifications }, delivery: { ...$state.settings.delivery }, retention: { ...$state.settings.retention } }"
+    }
+  }
+}
+---desc
+The first Weekly digest change intentionally fails so the example can demonstrate rollback. The server trims Delivery values, lowercases the email, and rounds Retention to a whole-week boundary.
+```
+
+**Choose one state boundary per save transaction**: The Weekly digest switch is atomic, so it sends a small partial update immediately. Delivery and Retention each have their own Form because each group is validated, submitted, and retried independently. A pending save disables only that Form; drafts and controls in sibling boundaries remain usable.
+
+**Use Form's built-in submission path for grouped settings**: `submitUrl` and `submitMethod` let each Form own validation, request progress, error feedback, and its single-flight submission policy. Because each Form's `data` contains only its own branch, the API receives a partial settings payload.
+
+**Adopt server-confirmed values as the new baseline**: The API trims Delivery text, lowercases the email, and rounds Retention to a whole-week boundary. Each `onSuccess` receives that canonical response and calls `form.reset(canonicalSection)`. The Form becomes pristine, displays what the server accepted, and a later parameterless `reset()` returns to this new baseline.
+
+**Rollback an immediate control when its write fails**: The switch changes visually before its request finishes. Its local `onError` restores the DataSource value. Because `setValue()` fires `onDidChange`, the `restoringDigest` guard prevents the rollback from sending another request.
+
+## Reconcile external changes
+
+Save boundaries solve only one part of the problem. A polling result, subscription event, or another user's update can arrive while a Form is open. Route each incoming snapshot through one reconciliation function: pristine Forms adopt it; dirty Forms keep the user's draft and disclose that a newer server value is available.
+
+```xmlui-pg copy display name="Reconcile external changes with a scoped Form" id="reconcile-external-changes-with-a-scoped-form" height="640px"
+<App var.latestDelivery="{null}" var.deliveryChangedElsewhere="{false}">
+  <script>
+    function deliverySection(snapshot) {
+      return {
+        delivery: {
+          senderName: snapshot.delivery.senderName,
+          replyTo: snapshot.delivery.replyTo
+        }
+      };
+    }
+
+    function receiveDeliverySnapshot(snapshot) {
+      const incoming = deliverySection(snapshot);
+
+      if (deliveryForm.isDirty()) {
+        latestDelivery = incoming;
+        deliveryChangedElsewhere = true;
+      } else {
+        deliveryForm.reset(incoming);
+        latestDelivery = null;
+        deliveryChangedElsewhere = false;
+      }
+    }
+
+    function reloadDelivery() {
+      deliveryForm.reset(latestDelivery);
+      latestDelivery = null;
+      deliveryChangedElsewhere = false;
+    }
+  </script>
+
+  <DataSource id="settings" url="/api/settings" />
+
+  <APICall
+    id="simulateExternalUpdate"
+    method="post"
+    url="/api/settings/external"
+    invalidates="{[]}"
+    onSuccess="(snapshot) => {
+      receiveDeliverySnapshot(snapshot);
+      settings.refetch();
+    }" />
+
+  <VStack when="{settings.value}" gap="$space-4" padding="$space-5" maxWidth="42rem">
+    <Button
+      label="Simulate external update"
+      variant="outlined"
+      enabled="{!simulateExternalUpdate.inProgress}"
+      onClick="simulateExternalUpdate.execute()" />
+
+    <Form
+      id="deliveryForm"
+      data="{{
+        delivery: {
+          senderName: settings.value.delivery.senderName,
+          replyTo: settings.value.delivery.replyTo
+        }
+      }}"
+      submitUrl="/api/settings"
+      submitMethod="post"
+      onSuccess="(response) => {
+        deliveryForm.reset(deliverySection(response));
+        latestDelivery = null;
+        deliveryChangedElsewhere = false;
+      }"
+      errorNotificationMessage="Could not save delivery settings."
+      hideButtonRowUntilDirty="true"
+      cancelLabel=""
+      saveLabel="Save delivery settings"
+      saveInProgressLabel="Saving delivery settings…"
+      submitFeedbackDelay="0">
+      <TextBox
+        label="Sender name"
+        bindTo="delivery.senderName"
+        required="true" />
+      <TextBox
+        label="Reply-to email"
+        bindTo="delivery.replyTo"
+        required="true"
+        pattern="email" />
+    </Form>
+
+    <HStack when="{deliveryChangedElsewhere}" verticalAlignment="center">
+      <Text variant="strong">Settings changed elsewhere.</Text>
+      <Button label="Reload server values" onClick="reloadDelivery()" />
+    </HStack>
+
+    <Button
+      label="Reset delivery draft"
+      variant="outlined"
+      onClick="deliveryForm.reset()" />
+    <Text variant="caption">Server sender: {settings.value.delivery.senderName}</Text>
+  </VStack>
+</App>
+---api
+{
+  "apiUrl": "/api",
+  "initialize": "$state.settings = { delivery: { senderName: 'Bram Team', replyTo: 'ops@example.com' } }; $state.externalRevision = 0",
+  "operations": {
+    "get-settings": {
+      "url": "/settings",
+      "method": "get",
+      "handler": "return { delivery: { ...$state.settings.delivery } }"
+    },
+    "update-settings": {
+      "url": "/settings",
+      "method": "post",
+      "handler": "delay(400); $state.settings.delivery = { senderName: $requestBody.delivery.senderName.trim(), replyTo: $requestBody.delivery.replyTo.trim().toLowerCase() }; return { delivery: { ...$state.settings.delivery } }"
+    },
+    "external-update": {
+      "url": "/settings/external",
+      "method": "post",
+      "handler": "delay(350); $state.externalRevision++; $state.settings.delivery = { senderName: 'Server Team ' + $state.externalRevision, replyTo: 'server' + $state.externalRevision + '@example.com' }; return { delivery: { ...$state.settings.delivery } }"
+    }
+  }
+}
+---desc
+Try the external update first with a pristine Form, then edit the sender name and run it again. The dirty draft remains visible until you explicitly reload the newer server values.
+```
+
+**Use one reconciliation entry point**: The external update's actual response is passed to `receiveDeliverySnapshot()`. Its subsequent `settings.refetch()` updates the server-value caption; it does not reconcile the Form. In production, polling and subscription handlers should pass their snapshots through the same function.
+
+**Preserve dirty drafts rather than overwriting them**: A pristine Form adopts an incoming canonical section immediately with `reset(data)`. A dirty Form retains its visible draft, remembers the newest section, displays **Settings changed elsewhere**, and offers **Reload server values**. Reload is an explicit discard that installs the remembered section as the new pristine baseline.
+
+**Treat a successful save response as authoritative**: The Form's `onSuccess` installs the POST response and clears any pending external snapshot. If a save-generated subscription event arrives first, the same reconciliation function will defer it because the Form is still dirty; the later POST response establishes the authoritative baseline. This ordering is a policy choice, so document a different rule if your backend has different guarantees.
+
+**Draft preservation is not conflict resolution**: It prevents an incoming snapshot from silently erasing unsaved input. This demo's API uses last-write-wins, so saving an old draft can still overwrite a newer server value. Production systems that must prevent stale writes should send a revision or ETag and reject mismatches, or present an explicit merge UI.
+
+---
+
+## See also
+
+- [Prefill a form from an API response](/docs/howto/prefill-a-form-from-an-api-response) — initialize a Form from canonical server data
+- [Reset a form after submission](/docs/howto/reset-a-form-after-submission) — choose post-submit data behavior
+- [Show validation progress in the Save button](/docs/howto/show-validation-progress-in-the-save-button) — Form's validation and submission labels
+- [Retry a failed API call](/docs/howto/retry-a-failed-api-call) — expose retry behavior for a mutation
+- [Invalidate related data after a write](/docs/howto/control-cache-invalidation) — choose between automatic invalidation and explicit refetching

--- a/website/content/docs/reference/components/Form.md
+++ b/website/content/docs/reference/components/Form.md
@@ -432,9 +432,28 @@ This method returns a deep clone of the current form data object. Changes to the
 
 ### `reset` [#reset]
 
-This method resets the form to its initial state, clearing all user input.
+This method resets the form to its initial state. When `data` is provided, the form adopts it as both the current value and the new initial baseline, leaving the form pristine.
 
-**Signature**: `reset(): void`
+**Signature**: `reset(data?: Record<string, any>): void`
+
+- `data`: Optional form data to install as the new initial baseline.
+
+Pass data to `reset` to replace the current values and establish a new clean initial baseline.
+Later parameterless resets return to that baseline.
+
+```xmlui-pg copy display name="Example: reset with new initial data"
+<App>
+  <Form id="profileForm"
+    data="{{ name: 'Original name' }}"
+    padding="0.5rem"
+    onSubmit="(toSave) => toast(JSON.stringify(toSave))">
+    <FormItem bindTo="name" label="Name" />
+  </Form>
+  <Button
+    label="Adopt canonical data"
+    onClick="profileForm.reset({ name: 'Canonical name' })" />
+</App>
+```
 
 ### `update` [#update]
 

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -511,6 +511,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Combine immediate-save settings with scoped Forms"
+                            to="/docs/howto/combine-immediate-save-settings-with-scoped-forms"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Build a multi-step wizard form"
                             to="/docs/howto/build-a-multi-step-wizard-form"
                         />

--- a/xmlui/src/components/Form/Form.md
+++ b/xmlui/src/components/Form/Form.md
@@ -175,6 +175,27 @@ The following example uses the first argument to inspect what will be submitted,
 
 %-EVENT-END
 
+%-API-START reset
+
+Pass data to `reset` to replace the current values and establish a new clean initial baseline.
+Later parameterless resets return to that baseline.
+
+```xmlui-pg copy display name="Example: reset with new initial data"
+<App>
+  <Form id="profileForm"
+    data="{{ name: 'Original name' }}"
+    padding="0.5rem"
+    onSubmit="(toSave) => toast(JSON.stringify(toSave))">
+    <FormItem bindTo="name" label="Name" />
+  </Form>
+  <Button
+    label="Adopt canonical data"
+    onClick="profileForm.reset({ name: 'Canonical name' })" />
+</App>
+```
+
+%-API-END
+
 %-API-START update
 
 This method updates the form data with the change passed in its parameter. The parameter is a hash object, and this method updates the Form's properties accordingly. 

--- a/xmlui/src/components/Form/Form.spec.ts
+++ b/xmlui/src/components/Form/Form.spec.ts
@@ -1618,6 +1618,55 @@ test.describe("Basic Functionality", () => {
       await expect(nameInput.field).toHaveValue("Initial");
     });
 
+    test("reset with data establishes a new pristine baseline", async ({
+      initTestBed,
+      page,
+      createFormItemDriver,
+      createTextBoxDriver,
+    }) => {
+      const { testStateDriver } = await initTestBed(`
+        <Fragment>
+          <Form
+            id="testForm"
+            data="{{ name: 'Initial', address: { city: 'Old city' } }}">
+            <FormItem label="Name" bindTo="name" testId="nameField" />
+            <FormItem label="City" bindTo="address.city" testId="cityField" />
+          </Form>
+          <Button
+            testId="adopt"
+            label="Adopt"
+            onClick="testForm.reset({ name: 'Canonical', address: { city: 'New city' } })" />
+          <Button testId="reset" label="Reset" onClick="testForm.reset()" />
+          <Button
+            testId="inspect"
+            label="Inspect"
+            onClick="testState = { data: testForm.getData(), dirty: testForm.isDirty() }" />
+        </Fragment>
+      `);
+
+      const nameItem = await createFormItemDriver("nameField");
+      const nameInput = await createTextBoxDriver(nameItem.input);
+      const cityItem = await createFormItemDriver("cityField");
+      const cityInput = await createTextBoxDriver(cityItem.input);
+
+      await nameInput.field.fill("Draft");
+      await page.getByTestId("adopt").click();
+
+      await expect(nameInput.field).toHaveValue("Canonical");
+      await expect(cityInput.field).toHaveValue("New city");
+      await page.getByTestId("inspect").click();
+      await expect.poll(testStateDriver.testState).toEqual({
+        data: { name: "Canonical", address: { city: "New city" } },
+        dirty: false,
+      });
+
+      await nameInput.field.fill("Another draft");
+      await page.getByTestId("reset").click();
+
+      await expect(nameInput.field).toHaveValue("Canonical");
+      await expect(cityInput.field).toHaveValue("New city");
+    });
+
     test("validate method returns validation results without submitting", async ({
       initTestBed,
       page,

--- a/xmlui/src/components/Form/Form.tsx
+++ b/xmlui/src/components/Form/Form.tsx
@@ -365,8 +365,13 @@ export const FormMd = createMetadata({
   },
   apis: {
     reset: {
-      description: "This method resets the form to its initial state, clearing all user input.",
-      signature: "reset(): void",
+      description:
+        "This method resets the form to its initial state. When `data` is provided, the form " +
+        "adopts it as both the current value and the new initial baseline, leaving the form pristine.",
+      signature: "reset(data?: Record<string, any>): void",
+      parameters: {
+        data: "Optional form data to install as the new initial baseline.",
+      },
     },
     update: {
       description:

--- a/xmlui/src/components/Form/FormReact.tsx
+++ b/xmlui/src/components/Form/FormReact.tsx
@@ -236,8 +236,17 @@ const formReducer = produce((state: FormState, action: ContainerAction | FormAct
       break;
     }
     case FormActionKind.RESET: {
+      const resetBaseline = action.payload.hasData
+        ? cloneDeep(action.payload.data)
+        : state.resetBaseline;
       return {
         ...initialState,
+        subject: action.payload.clear
+          ? {}
+          : resetBaseline === undefined
+            ? {}
+            : cloneDeep(resetBaseline),
+        resetBaseline,
         resetVersion: (state.resetVersion ?? 0) + 1,
       };
     }
@@ -254,6 +263,7 @@ interface FormState {
   noSubmitFields: Record<string, boolean>; // Track noSubmit flag for each field
   submitInProgress?: boolean;
   resetVersion?: number;
+  resetBaseline?: any;
 }
 
 const initialState: FormState = {
@@ -264,6 +274,7 @@ const initialState: FormState = {
   noSubmitFields: {},
   submitInProgress: false,
   resetVersion: 0,
+  resetBaseline: undefined,
 };
 
 type OnSubmit = (
@@ -809,7 +820,7 @@ const Form = memo(forwardRef(function (
       } else if (dataAfterSubmit === "clear") {
         flushSync(() => {
           onClearAfterSubmit?.();
-          doReset();
+          doReset(undefined, true);
         });
       } else {
         // "keep" (default): fire the reset event (backward compat) without resetting form state
@@ -936,8 +947,19 @@ const Form = memo(forwardRef(function (
     }
   });
 
-  const doReset = useEvent(() => {
-    dispatch(formReset());
+  const doReset = useEvent((data?: Record<string, any>, clear = false) => {
+    const hasData = data !== undefined;
+    if (hasData && (typeof data !== "object" || data === null || Array.isArray(data))) {
+      return;
+    }
+    dispatch({
+      ...formReset(),
+      payload: {
+        data,
+        hasData,
+        clear,
+      },
+    });
     onReset?.();
   });
 
@@ -1068,7 +1090,7 @@ const Form = memo(forwardRef(function (
         style={style}
         className={classnames(styles.formWrapper, { [styles.stickyForm]: stickyButtonRow }, classes?.[COMPONENT_PART_KEY], className)}
         onSubmit={doSubmit}
-        onReset={doReset}
+        onReset={() => doReset()}
         id={id}
         key={formState.resetVersion}
         ref={formRef}
@@ -1238,7 +1260,9 @@ export const FormWithContextVar = forwardRef(function (
   const effectiveInitialValue =
     clearedAtResetVersion !== null && clearedAtResetVersion === formState.resetVersion
       ? EMPTY_OBJECT
-      : rawInitialValue;
+      : formState.resetBaseline === undefined
+        ? rawInitialValue
+        : formState.resetBaseline;
   const submitMethod =
     extractValue.asOptionalString(node.props.submitMethod) || (rawInitialValue ? "put" : "post");
   const inProgressNotificationMessage =

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -7218,8 +7218,11 @@ export default {
     },
     "apis": {
       "reset": {
-        "description": "This method resets the form to its initial state, clearing all user input.",
-        "signature": "reset(): void"
+        "description": "This method resets the form to its initial state. When `data` is provided, the form adopts it as both the current value and the new initial baseline, leaving the form pristine.",
+        "signature": "reset(data?: Record<string, any>): void",
+        "parameters": {
+          "data": "Optional form data to install as the new initial baseline."
+        }
       },
       "update": {
         "description": "You can pass a data object to update the form data. The properties in the passed data object are updated to their values accordingly. Other form properties remain intact.",

--- a/xmlui/tests-e2e/how-to-examples/combine-immediate-save-settings-with-scoped-forms.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/combine-immediate-save-settings-with-scoped-forms.spec.ts
@@ -1,0 +1,172 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/combine-immediate-save-settings-with-scoped-forms.md",
+  ),
+);
+
+test.describe("Choose save boundaries for settings", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "choose-save-boundaries-for-settings",
+  );
+
+  test("isolates save progress and adopts canonical Form baselines", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const digestSwitch = page.getByRole("switch", { name: "Weekly digest" });
+    const senderName = page.getByRole("textbox", { name: "Sender name" });
+    const replyTo = page.getByRole("textbox", { name: "Reply-to email" });
+    const retentionDays = page.getByRole("spinbutton", { name: "Retention days" });
+
+    await expect(digestSwitch).not.toBeChecked();
+    await expect(page.getByText("Status: Saved", { exact: true })).toBeVisible();
+    await expect(page.getByText("Server value: Off", { exact: true })).toBeVisible();
+    await expect(senderName).toHaveValue("Bram Team");
+    await expect(replyTo).toHaveValue("ops@example.com");
+    await expect(retentionDays).toHaveValue("30");
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Save retention settings" })).not.toBeVisible();
+
+    await digestSwitch.check();
+    await expect.poll(() => digestSwitch.isDisabled()).toBe(true);
+    await expect(page.getByText("Status: Saving…", { exact: true })).toBeVisible();
+    await expect
+      .poll(() =>
+        page
+          .getByText("Status: Could not save — restored the server value", { exact: true })
+          .isVisible(),
+      )
+      .toBe(true);
+    await expect(digestSwitch).not.toBeChecked();
+    await expect(digestSwitch).toBeEnabled();
+    await expect(page.getByText("Server value: Off", { exact: true })).toBeVisible();
+
+    await digestSwitch.check();
+
+    await expect
+      .poll(() => page.getByText("Server value: On", { exact: true }).isVisible())
+      .toBe(true);
+    await expect(digestSwitch).toBeChecked();
+    await expect(digestSwitch).toBeEnabled();
+    await expect(page.getByText("Status: Saved", { exact: true })).toBeVisible();
+
+    await senderName.fill("  XMLUI Team  ");
+    await replyTo.fill("TEAM@XMLUI.ORG");
+    await retentionDays.fill("31");
+    await page.getByRole("button", { name: "Save delivery settings" }).click();
+
+    const deliverySavingButton = page.getByRole("button", { name: "Saving delivery settings…" });
+    await expect.poll(() => deliverySavingButton.isVisible()).toBe(true);
+    await expect(deliverySavingButton).toBeDisabled();
+    await expect(senderName).toBeDisabled();
+    await expect(replyTo).toBeDisabled();
+    await expect(retentionDays).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Save retention settings" })).toBeVisible();
+    await expect(digestSwitch).toBeEnabled();
+
+    await expect(senderName).toHaveValue("XMLUI Team");
+    await expect(replyTo).toHaveValue("team@xmlui.org");
+    await expect(page.getByText("Server sender: XMLUI Team", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Saved canonical sender: XMLUI Team", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).not.toBeVisible();
+    await expect(retentionDays).toHaveValue("31");
+    await expect(page.getByRole("button", { name: "Save retention settings" })).toBeVisible();
+
+    await senderName.fill("Another draft");
+    await page.getByRole("button", { name: "Reset delivery draft" }).click();
+    await expect(senderName).toHaveValue("XMLUI Team");
+    await expect(replyTo).toHaveValue("team@xmlui.org");
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).not.toBeVisible();
+
+    await senderName.fill("Unsaved delivery draft");
+    await page.getByRole("button", { name: "Save retention settings" }).click();
+
+    const retentionSavingButton = page.getByRole("button", { name: "Saving retention settings…" });
+    await expect.poll(() => retentionSavingButton.isVisible()).toBe(true);
+    await expect(retentionSavingButton).toBeDisabled();
+    await expect(retentionDays).toBeDisabled();
+    await expect(senderName).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).toBeVisible();
+
+    await expect(retentionDays).toHaveValue("28");
+    await expect(page.getByText("Server retention: 28 days", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Saved canonical retention: 28 days", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save retention settings" })).not.toBeVisible();
+    await expect(senderName).toHaveValue("Unsaved delivery draft");
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).toBeVisible();
+
+    await retentionDays.fill("35");
+    await page.getByRole("button", { name: "Reset retention draft" }).click();
+    await expect(retentionDays).toHaveValue("28");
+    await expect(page.getByRole("button", { name: "Save retention settings" })).not.toBeVisible();
+  });
+});
+
+test.describe("Reconcile external changes with a scoped Form", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "reconcile-external-changes-with-a-scoped-form",
+  );
+
+  test("adopts pristine snapshots and preserves dirty drafts until reload", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const senderName = page.getByRole("textbox", { name: "Sender name" });
+    const replyTo = page.getByRole("textbox", { name: "Reply-to email" });
+
+    await expect(senderName).toHaveValue("Bram Team");
+    await expect(replyTo).toHaveValue("ops@example.com");
+    await expect(page.getByText("Server sender: Bram Team", { exact: true })).toBeVisible();
+    await expect(page.getByText("Settings changed elsewhere.", { exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).not.toBeVisible();
+
+    await page.getByRole("button", { name: "Simulate external update" }).click();
+
+    await expect.poll(() => senderName.inputValue()).toBe("Server Team 1");
+    await expect(replyTo).toHaveValue("server1@example.com");
+    await expect(page.getByText("Server sender: Server Team 1", { exact: true })).toBeVisible();
+    await expect(page.getByText("Settings changed elsewhere.", { exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).not.toBeVisible();
+
+    await senderName.fill("Temporary draft");
+    await page.getByRole("button", { name: "Reset delivery draft" }).click();
+    await expect(senderName).toHaveValue("Server Team 1");
+
+    await senderName.fill("My unsaved draft");
+    await page.getByRole("button", { name: "Simulate external update" }).click();
+
+    await expect
+      .poll(() => page.getByText("Server sender: Server Team 2", { exact: true }).isVisible())
+      .toBe(true);
+    await expect(senderName).toHaveValue("My unsaved draft");
+    await expect(replyTo).toHaveValue("server1@example.com");
+    await expect(page.getByText("Settings changed elsewhere.", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Reload server values" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Reload server values" }).click();
+
+    await expect(senderName).toHaveValue("Server Team 2");
+    await expect(replyTo).toHaveValue("server2@example.com");
+    await expect(page.getByText("Settings changed elsewhere.", { exact: true })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Save delivery settings" })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- add two focused runnable examples for mixed settings save boundaries
- demonstrate canonical Form.reset(data) baselines and dirty-state reconciliation
- register the how-to in Forms & Validation navigation
- cover immediate rollback, sibling Form independence, and external snapshots with website E2E tests

## Dependency

Depends on #3744 because these examples use the new Form.reset(data) behavior. This PR targets form-reset-data so the review diff contains only its single follow-up commit; retarget it to main after #3744 merges.

## Testing

- npm run test:e2e-website-examples -- tests-e2e/how-to-examples/combine-immediate-save-settings-with-scoped-forms.spec.ts --workers=10

Closes #3745