### PR TITLE
Markdown: interpolateBindings + allowHtml props for safe data-fed content

### DIFF
--- a/xmlui/src/components/Markdown/Markdown.defaults.ts
+++ b/xmlui/src/components/Markdown/Markdown.defaults.ts
@@ -3,6 +3,7 @@ import type { BreakMode, OverflowMode } from "../abstractions";
 export const defaultProps = {
   removeIndents: true,
   removeBr: false,
+  interpolateBindings: true,
   overflowMode: undefined as OverflowMode | undefined,
   breakMode: "normal" as BreakMode | undefined,
 };

--- a/xmlui/src/components/Markdown/Markdown.defaults.ts
+++ b/xmlui/src/components/Markdown/Markdown.defaults.ts
@@ -4,6 +4,7 @@ export const defaultProps = {
   removeIndents: true,
   removeBr: false,
   interpolateBindings: true,
+  allowHtml: true,
   overflowMode: undefined as OverflowMode | undefined,
   breakMode: "normal" as BreakMode | undefined,
 };

--- a/xmlui/src/components/Markdown/Markdown.md
+++ b/xmlui/src/components/Markdown/Markdown.md
@@ -188,6 +188,27 @@ Set `interpolateBindings="false"` for data-fed content so every `@{...}` sequenc
 
 %-PROP-END
 
+%-PROP-START allowHtml
+
+By default, `Markdown` renders a subset of raw HTML embedded in the content as real elements — a `<table>` in the text builds a table. That is fine for markup you author, but for content that arrives at runtime as **data** (transcripts, logs, user input) any quoted HTML would render as live markup and can break layout.
+
+Set `allowHtml="false"` so raw HTML tags render as **literal text** instead. Only the HTML-tag interpretation is neutralized — markdown formatting, code fences, and inline code are untouched, and an unterminated tag survives verbatim rather than being dropped.
+
+This axis is independent of `interpolateBindings`. Pair the two (`interpolateBindings="false" allowHtml="false"`) for a fully data-safe render: nothing is evaluated, nothing is rewritten, and no HTML is activated.
+
+```xmlui-pg copy display name="Example: allowHtml"
+<App var.dataLine="{'Rendered row: <tr><td>oops</td></tr> — and a bare <script> tag'}">
+  <VStack gap="8px">
+    <Text variant="strong">allowHtml="true" (default)</Text>
+    <Markdown content="{dataLine}" />
+    <Text variant="strong">allowHtml="false"</Text>
+    <Markdown allowHtml="false" content="{dataLine}" />
+  </VStack>
+</App>
+```
+
+%-PROP-END
+
 %-PROP-START removeIndents
 
 ```xmlui-pg copy display name="Example: removeIndents property"

--- a/xmlui/src/components/Markdown/Markdown.md
+++ b/xmlui/src/components/Markdown/Markdown.md
@@ -172,6 +172,22 @@ Use this property when the text you provide is not static but a result of calcul
 
 %-PROP-END
 
+%-PROP-START interpolateBindings
+
+By default, `Markdown` evaluates `@{...}` binding expressions in its content. That is convenient for text you author, but risky for text that arrives at runtime as **data** — transcripts, logs, or user input.
+
+The collision is a bare `@` immediately followed by `{`, which is common in real code and markup: PowerShell hashtables (`@{ LogName = "System" }`), Razor/Blazor code blocks (`@{ ... }`), Objective-C dictionary literals (`@{ @"k": v }`), Perl dereferences (`@{ $ref }`), and LaTeX column specs (`@{...}`). When such text is evaluated as a binding it produces wrong output or an error — and an empty `@{}` (e.g. a LaTeX inter-column spec) is silently **removed** rather than shown.
+
+Set `interpolateBindings="false"` for data-fed content so every `@{...}` sequence renders literally:
+
+```xmlui-pg copy display name="Example: interpolateBindings"
+<App var.logLine="{'Get-WinEvent -FilterHashtable @{ LogName = System; Id = 3077 }'}">
+  <Markdown interpolateBindings="false" content="{logLine}" />
+</App>
+```
+
+%-PROP-END
+
 %-PROP-START removeIndents
 
 ```xmlui-pg copy display name="Example: removeIndents property"

--- a/xmlui/src/components/Markdown/Markdown.spec.ts
+++ b/xmlui/src/components/Markdown/Markdown.spec.ts
@@ -1065,3 +1065,128 @@ test.describe("highlightText", () => {
     await expect(page.locator("mark")).toHaveCount(0);
   });
 });
+
+test.describe("interpolateBindings", () => {
+  test("default (true) evaluates @{...} bindings", async ({ initTestBed, createMarkdownDriver }) => {
+    await initTestBed(`<Markdown><![CDATA[sum is @{1 + 1}]]></Markdown>`);
+    await expect((await createMarkdownDriver()).component).toHaveText("sum is 2");
+  });
+
+  test("interpolateBindings=false renders @{...} literally", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(
+      `<Markdown interpolateBindings="false"><![CDATA[sum is @{1 + 1}]]></Markdown>`,
+    );
+    await expect((await createMarkdownDriver()).component).toHaveText("sum is @{1 + 1}");
+  });
+
+  test("interpolateBindings=false leaves colliding PowerShell syntax intact", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(
+      `<Markdown interpolateBindings="false"><![CDATA[Get-WinEvent -FilterHashtable @{ LogName = 3077 }]]></Markdown>`,
+    );
+    await expect((await createMarkdownDriver()).component).toHaveText(
+      "Get-WinEvent -FilterHashtable @{ LogName = 3077 }",
+    );
+  });
+
+  test("default (true) removes an empty @{} expression", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // Same syntax as a LaTeX inter-column spec `@{}`; the default path strips it.
+    await initTestBed(`<Markdown><![CDATA[col@{}spec]]></Markdown>`);
+    await expect((await createMarkdownDriver()).component).toHaveText("colspec");
+  });
+
+  test("interpolateBindings=false preserves an empty @{} expression", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // The LaTeX `@{}` column-spec case: with interpolation off it must render
+    // literally rather than being silently deleted.
+    await initTestBed(`<Markdown interpolateBindings="false"><![CDATA[col@{}spec]]></Markdown>`);
+    await expect((await createMarkdownDriver()).component).toHaveText("col@{}spec");
+  });
+
+  test("a binding that throws during evaluation fails soft (renders literally, no crash)", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // `LogName = 22` assigns to an identifier not in scope, which throws in the
+    // script engine. With fail-soft, the expression renders as its literal text
+    // instead of propagating and crashing the whole Markdown surface.
+    await initTestBed(`<Markdown><![CDATA[cmd @{ LogName = 22 }]]></Markdown>`);
+    const driver = await createMarkdownDriver();
+    await expect(driver.component).toBeAttached();
+    await expect(driver.component).toContainText("@{ LogName = 22 }");
+  });
+
+  test("interpolateBindings=false does not rewrite a quoted xmlui-pg fence into a playground", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // Content that merely *quotes* a playground fence (transcripts do this) must
+    // render as an ordinary code block, not be rewritten into a live playground.
+    await initTestBed(
+      "<Markdown interpolateBindings=\"false\"><![CDATA[```xmlui-pg\n<App><Text>hello</Text></App>\n```]]></Markdown>",
+    );
+    const driver = await createMarkdownDriver();
+    await expect(driver.component).toBeAttached();
+    // The raw fence source survives as text; no NestedApp playground is mounted.
+    await expect(driver.component).toContainText("<App><Text>hello</Text></App>");
+  });
+
+  test("interpolateBindings=false preserves a quoted four-backtick xmlui-pg fence (no 4->3 rewrite)", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // A four-backtick `xmlui-pg` fence displayed literally inside a five-backtick
+    // display fence. The ungated engine's playground observer rewrites the inner
+    // fence 4->3 even here; with interpolation off the observer is skipped, so the
+    // four backticks survive and no playground UI is mounted.
+    const md =
+      "`````\n" +
+      "````xmlui-pg\n" +
+      '<App>\n  <Text value="quoted example, not a live playground" />\n</App>\n' +
+      "````\n" +
+      "`````";
+    await initTestBed(`<Markdown interpolateBindings="false"><![CDATA[${md}]]></Markdown>`);
+    const driver = await createMarkdownDriver();
+    await expect(driver.component).toBeAttached();
+    // The inner fence keeps all four backticks (would be three if the observer ran).
+    await expect(driver.component).toContainText("````xmlui-pg");
+    await expect(driver.component).toContainText('quoted example, not a live playground');
+  });
+});
+
+// Pins the raw-inline-HTML behavior for downstream consumers of data-fed content.
+// `Markdown` renders a subset of raw HTML via rehype-raw; `interpolateBindings`
+// gates only the XMLUI authoring transforms (bindings, playground, tree display),
+// NOT the HTML pass-through. So quoted markup in data content still renders as
+// real elements — consumers that must show HTML literally have to escape it first.
+test.describe("raw HTML in content", () => {
+  test("raw inline HTML renders as a real element (default)", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(`<Markdown><![CDATA[Say <mark>flagged</mark> here]]></Markdown>`);
+    const driver = await createMarkdownDriver();
+    await expect(driver.component.locator("mark")).toHaveText("flagged");
+  });
+
+  test("raw inline HTML still renders as an element with interpolateBindings=false", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(
+      `<Markdown interpolateBindings="false"><![CDATA[Say <mark>flagged</mark> here]]></Markdown>`,
+    );
+    const driver = await createMarkdownDriver();
+    await expect(driver.component.locator("mark")).toHaveText("flagged");
+  });
+});

--- a/xmlui/src/components/Markdown/Markdown.spec.ts
+++ b/xmlui/src/components/Markdown/Markdown.spec.ts
@@ -1190,3 +1190,64 @@ test.describe("raw HTML in content", () => {
     await expect(driver.component.locator("mark")).toHaveText("flagged");
   });
 });
+
+test.describe("allowHtml", () => {
+  test("default (true) renders raw inline HTML as an element", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(`<Markdown><![CDATA[Say <mark>flagged</mark> here]]></Markdown>`);
+    const driver = await createMarkdownDriver();
+    await expect(driver.component.locator("mark")).toHaveText("flagged");
+  });
+
+  test("allowHtml=false renders raw inline HTML as literal text", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(
+      `<Markdown allowHtml="false"><![CDATA[Say <mark>flagged</mark> here]]></Markdown>`,
+    );
+    const driver = await createMarkdownDriver();
+    // No element is produced; the raw tags render as literal characters.
+    await expect(driver.component.locator("mark")).toHaveCount(0);
+    await expect(driver.component).toContainText("Say <mark>flagged</mark> here");
+  });
+
+  test("allowHtml=false preserves a lone unterminated tag as literal text (no data loss)", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // Dropping rehype-raw / skipHtml would delete this tag entirely; the remark
+    // text-conversion keeps it verbatim.
+    await initTestBed(`<Markdown allowHtml="false"><![CDATA[trailing <notclosed]]></Markdown>`);
+    const driver = await createMarkdownDriver();
+    await expect(driver.component).toContainText("trailing <notclosed");
+  });
+
+  test("allowHtml=false does not disturb a fenced code block", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // Content inside a code fence is already literal (rehype-raw never touched it),
+    // so neutralization must not double-escape it.
+    await initTestBed(
+      "<Markdown allowHtml=\"false\"><![CDATA[```\n<div>in a fence</div>\n```]]></Markdown>",
+    );
+    const driver = await createMarkdownDriver();
+    await expect(driver.component.locator("code")).toContainText("<div>in a fence</div>");
+    await expect(driver.component).not.toContainText("&lt;div&gt;");
+  });
+
+  test("interpolateBindings=false + allowHtml=false is fully data-safe on a mixed payload", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    await initTestBed(
+      `<Markdown interpolateBindings="false" allowHtml="false"><![CDATA[cmd @{ LogName = 22 } then <b>bold?</b>]]></Markdown>`,
+    );
+    const driver = await createMarkdownDriver();
+    await expect(driver.component.locator("b")).toHaveCount(0);
+    await expect(driver.component).toContainText("cmd @{ LogName = 22 } then <b>bold?</b>");
+  });
+});

--- a/xmlui/src/components/Markdown/Markdown.tsx
+++ b/xmlui/src/components/Markdown/Markdown.tsx
@@ -80,6 +80,17 @@ export const MarkdownMd = createMetadata({
       valueType: "boolean",
       defaultValue: defaultProps.interpolateBindings,
     },
+    allowHtml: {
+      description:
+        "When `true` (default), a subset of raw HTML embedded in the content is rendered " +
+        "as real elements. Set this to `false` for content that arrives at runtime as " +
+        "**data** so that raw HTML tags render as literal text instead of markup — a " +
+        "quoted `<table>` shows its tags rather than building a table. Only the HTML-tag " +
+        "interpretation is affected; markdown formatting, code fences, and inline code are " +
+        "untouched. Pair with `interpolateBindings=\"false\"` for a fully data-safe render.",
+      valueType: "boolean",
+      defaultValue: defaultProps.allowHtml,
+    },
     showHeadingAnchors: {
       description:
         "This boolean property specifies whether heading anchors should be " +
@@ -297,6 +308,7 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
     "removeIndents",
     "removeBr",
     "interpolateBindings",
+    "allowHtml",
     "codeHighlighter",
     "showHeadingAnchors",
     "grayscale",
@@ -342,6 +354,10 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
           node.props.interpolateBindings,
           defaultProps.interpolateBindings,
         )}
+        allowHtml={extractValue.asOptionalBoolean(
+          node.props.allowHtml,
+          defaultProps.allowHtml,
+        )}
         codeHighlighter={extractValue(node.props.codeHighlighter)}
         extractValue={extractValue}
         showHeadingAnchors={extractValue.asOptionalBoolean(node.props.showHeadingAnchors)}
@@ -377,6 +393,7 @@ type TransformedMarkdownProps = {
   removeIndents?: boolean;
   removeBr?: boolean;
   interpolateBindings?: boolean;
+  allowHtml?: boolean;
   className?: string;
   classes?: Record<string, string>;
   extractValue: ValueExtractor;
@@ -401,6 +418,7 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
       removeIndents,
       removeBr,
       interpolateBindings,
+      allowHtml,
       className,
       classes,
       extractValue,
@@ -467,6 +485,7 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
         ref={ref}
         removeIndents={removeIndents}
         removeBr={removeBr}
+        allowHtml={allowHtml}
         codeHighlighter={codeHighlighter}
         className={className}
         classes={classes}

--- a/xmlui/src/components/Markdown/Markdown.tsx
+++ b/xmlui/src/components/Markdown/Markdown.tsx
@@ -67,6 +67,19 @@ export const MarkdownMd = createMetadata({
       valueType: "boolean",
       defaultValue: defaultProps.removeBr,
     },
+    interpolateBindings: {
+      description:
+        "When `true` (default), the content is treated as **authored** markup: `@{...}` " +
+        "binding expressions are evaluated and replaced with their values, and `xmlui-pg` " +
+        "playground fences and tree-display blocks are rendered as live examples. Set this " +
+        "to `false` for content that arrives at runtime as **data** (transcripts, logs, " +
+        "user text) so that `@{...}` sequences — which collide with real-world syntax such " +
+        "as PowerShell hashtable literals (`@{ ... }`) — render literally instead of being " +
+        "evaluated, and a quoted `xmlui-pg` fence renders as a code block instead of being " +
+        "rewritten into a live playground.",
+      valueType: "boolean",
+      defaultValue: defaultProps.interpolateBindings,
+    },
     showHeadingAnchors: {
       description:
         "This boolean property specifies whether heading anchors should be " +
@@ -283,6 +296,7 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
     "content",
     "removeIndents",
     "removeBr",
+    "interpolateBindings",
     "codeHighlighter",
     "showHeadingAnchors",
     "grayscale",
@@ -324,6 +338,10 @@ export const markdownComponentRenderer = wrapComponent(COMP, Markdown, MarkdownM
         classes={classes}
         removeIndents={extractValue.asOptionalBoolean(node.props.removeIndents, true)}
         removeBr={extractValue.asOptionalBoolean(node.props.removeBr, false)}
+        interpolateBindings={extractValue.asOptionalBoolean(
+          node.props.interpolateBindings,
+          defaultProps.interpolateBindings,
+        )}
         codeHighlighter={extractValue(node.props.codeHighlighter)}
         extractValue={extractValue}
         showHeadingAnchors={extractValue.asOptionalBoolean(node.props.showHeadingAnchors)}
@@ -358,6 +376,7 @@ type TransformedMarkdownProps = {
   children: React.ReactNode;
   removeIndents?: boolean;
   removeBr?: boolean;
+  interpolateBindings?: boolean;
   className?: string;
   classes?: Record<string, string>;
   extractValue: ValueExtractor;
@@ -381,6 +400,7 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
       children,
       removeIndents,
       removeBr,
+      interpolateBindings,
       className,
       classes,
       extractValue,
@@ -408,30 +428,39 @@ const TransformedMarkdown = forwardRef<HTMLDivElement, TransformedMarkdownProps>
       // --- Resolve xmlui playground definitions
 
       let resolvedMd = children;
-      while (true) {
-        const nextPlayground = observePlaygroundPattern(resolvedMd);
-        if (!nextPlayground) break;
 
-        resolvedMd =
-          resolvedMd.slice(0, nextPlayground[0]) +
-          convertPlaygroundPatternToMarkdown(nextPlayground[2], {
-            enableTracing: enablePlaygroundTracing,
-          }) +
-          resolvedMd.slice(nextPlayground[1]);
+      // `interpolateBindings="false"` means "this content is data, not authoring":
+      // skip every transform that treats the text as authored markup. That covers
+      // playground-fence rewriting and tree-display rewriting (content that merely
+      // *quotes* an `xmlui-pg` fence — chat transcripts do this constantly — must
+      // not be rewritten as if it declared one), as well as `@{...}` binding
+      // interpolation (runtime `@{...}` should render literally, not evaluate).
+      if (interpolateBindings !== false) {
+        while (true) {
+          const nextPlayground = observePlaygroundPattern(resolvedMd);
+          if (!nextPlayground) break;
+
+          resolvedMd =
+            resolvedMd.slice(0, nextPlayground[0]) +
+            convertPlaygroundPatternToMarkdown(nextPlayground[2], {
+              enableTracing: enablePlaygroundTracing,
+            }) +
+            resolvedMd.slice(nextPlayground[1]);
+        }
+
+        while (true) {
+          const nextTreeDisplay = observeTreeDisplay(resolvedMd);
+          if (!nextTreeDisplay) break;
+          resolvedMd =
+            resolvedMd.slice(0, nextTreeDisplay[0]) +
+            convertTreeDisplayToMarkdown(nextTreeDisplay[2]) +
+            resolvedMd.slice(nextTreeDisplay[1]);
+        }
+
+        resolvedMd = parseBindingExpression(resolvedMd, extractValue);
       }
-
-      while (true) {
-        const nextTreeDisplay = observeTreeDisplay(resolvedMd);
-        if (!nextTreeDisplay) break;
-        resolvedMd =
-          resolvedMd.slice(0, nextTreeDisplay[0]) +
-          convertTreeDisplayToMarkdown(nextTreeDisplay[2]) +
-          resolvedMd.slice(nextTreeDisplay[1]);
-      }
-
-      resolvedMd = parseBindingExpression(resolvedMd, extractValue);
       return resolvedMd;
-    }, [children, enablePlaygroundTracing, extractValue]);
+    }, [children, enablePlaygroundTracing, extractValue, interpolateBindings]);
 
     return (
       <Markdown

--- a/xmlui/src/components/Markdown/MarkdownReact.tsx
+++ b/xmlui/src/components/Markdown/MarkdownReact.tsx
@@ -115,6 +115,23 @@ const preventPlaygroundParagraphWrap = () => {
   };
 };
 
+/**
+ * Remark plugin (mdast level, so it runs before `rehypeRaw` reparses raw HTML)
+ * that neutralizes raw HTML for data-fed content: each raw `html` node is turned
+ * into a `text` node carrying the same source string, so `<b>hi</b>` renders as
+ * the literal characters `<b>hi</b>` instead of a bold element. Because it targets
+ * only `html` nodes, code fences, inline code, blockquotes, and markdown syntax are
+ * untouched — and a lone unclosed `<tag>` survives as literal text (no data loss,
+ * unlike dropping `rehypeRaw` / `skipHtml`). Included only when `allowHtml === false`.
+ */
+const neutralizeRawHtml = () => {
+  return function transformer(tree: Node) {
+    visit(tree, "html", (node: any) => {
+      node.type = "text";
+    });
+  };
+};
+
 /** Normalize the `highlightText` prop (`string | string[]`) to a list of needles.
  *  A string stays a single phrase (never whitespace-split — that would break an
  *  intentional `"foo bar"` phrase highlight); an array is treated as independent
@@ -254,6 +271,7 @@ import { defaultProps } from "./Markdown.defaults";
 type MarkdownProps = {
   removeIndents?: boolean;
   removeBr?: boolean;
+  allowHtml?: boolean;
   children: ReactNode;
   style?: CSSProperties;
   className?: string;
@@ -314,6 +332,7 @@ export const Markdown = memo(
     {
       removeIndents = defaultProps.removeIndents,
       removeBr = defaultProps.removeBr,
+      allowHtml = defaultProps.allowHtml,
       children,
       style,
       className,
@@ -452,8 +471,13 @@ export const Markdown = memo(
     // Stable remark plugins array — only changes when markdownImgParser changes (never, with [] deps above).
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const remarkPlugins = useMemo(
-      () => [remarkGfm, markdownCodeBlockParser, markdownImgParser],
-      [markdownImgParser],
+      () => {
+        const plugins: any[] = [remarkGfm, markdownCodeBlockParser, markdownImgParser];
+        // For data-fed content, render raw HTML as literal text instead of elements.
+        if (allowHtml === false) plugins.push(neutralizeRawHtml);
+        return plugins;
+      },
+      [markdownImgParser, allowHtml],
     );
 
     return (

--- a/xmlui/src/components/Markdown/parse-binding-expr.ts
+++ b/xmlui/src/components/Markdown/parse-binding-expr.ts
@@ -72,14 +72,21 @@ export function parseBindingExpression(text: string, extractValue: ValueExtracto
     // The (?<!\\) is a "negative lookbehind" in regex that ensures that
     // if escaping the @{...} expression like this: \@{...}, we don't match it
     const regex = /(?<!\\)\@\{((?:[^{}]|\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\})*)\}/g;
-    return segText.replace(regex, (_, expr) => {
-      const extracted = extractValue(`{${expr}}`);
-      const resultExpr = mapByType(extracted);
-      // The result expression might be an object, in that case we stringify it here,
-      // at the last step, so that there are no unnecessary apostrophes
-      return typeof resultExpr === "object" && resultExpr !== null
-        ? JSON.stringify(resultExpr)
-        : resultExpr;
+    return segText.replace(regex, (match, expr) => {
+      try {
+        const extracted = extractValue(`{${expr}}`);
+        const resultExpr = mapByType(extracted);
+        // The result expression might be an object, in that case we stringify it here,
+        // at the last step, so that there are no unnecessary apostrophes
+        return typeof resultExpr === "object" && resultExpr !== null
+          ? JSON.stringify(resultExpr)
+          : resultExpr;
+      } catch {
+        // Fail soft: a `@{...}` that fails to parse or throws during evaluation
+        // renders as its literal text rather than propagating out of the useMemo
+        // and crashing the whole Markdown surface via the error boundary.
+        return match;
+      }
     });
   }
 

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -13060,6 +13060,16 @@ export default {
         "valueType": "boolean",
         "defaultValue": false
       },
+      "interpolateBindings": {
+        "description": "When `true` (default), the content is treated as **authored** markup: `@{...}` binding expressions are evaluated and replaced with their values, and `xmlui-pg` playground fences and tree-display blocks are rendered as live examples. Set this to `false` for content that arrives at runtime as **data** (transcripts, logs, user text) so that `@{...}` sequences — which collide with real-world syntax such as PowerShell hashtable literals (`@{ ... }`) — render literally instead of being evaluated, and a quoted `xmlui-pg` fence renders as a code block instead of being rewritten into a live playground.",
+        "valueType": "boolean",
+        "defaultValue": true
+      },
+      "allowHtml": {
+        "description": "When `true` (default), a subset of raw HTML embedded in the content is rendered as real elements. Set this to `false` for content that arrives at runtime as **data** so that raw HTML tags render as literal text instead of markup — a quoted `<table>` shows its tags rather than building a table. Only the HTML-tag interpretation is affected; markdown formatting, code fences, and inline code are untouched. Pair with `interpolateBindings=\"false\"` for a fully data-safe render.",
+        "valueType": "boolean",
+        "defaultValue": true
+      },
       "showHeadingAnchors": {
         "description": "This boolean property specifies whether heading anchors should be displayed. If set to `true`, heading anchors will be displayed on hover next to headings.",
         "valueType": "boolean"


### PR DESCRIPTION
## Summary

Two related props that let `Markdown` render content that arrives at runtime as **data** (transcripts, logs, user input) safely — as data, not as authored markup. Both default to today's behavior; each is an explicit opt-out.

### `interpolateBindings` (default `true`) — Closes #3757

`Markdown` evaluated `@{...}` binding expressions in **all** content. A bare `@{` collides with real-world syntax (PowerShell hashtables, Razor/Blazor blocks, Objective-C dictionaries, Perl derefs, LaTeX column specs), so quoted code was evaluated as bindings — wrong output, or a throw that took down the whole surface via the error boundary — and an empty `@{}` was silently deleted.

- `interpolateBindings="false"` treats content as data, not authoring: it skips all three XMLUI string transforms — `@{...}` binding interpolation, `xmlui-pg` playground rewriting, and `xmlui-tree` tree-display rewriting. A quoted playground fence renders as a plain code block (four backticks preserved, no 4→3 rewrite).
- Binding evaluation is now **fail-soft**: a `@{...}` that fails to parse or throws renders as its literal text instead of crashing the surface.

### `allowHtml` (default `true`) — Closes #3758

`Markdown` renders a subset of raw HTML via `rehype-raw` regardless of context, so data content quoting HTML (a transcript showing a `<table>`, or a bare `<script>`) rendered it as live markup — tags activated, surrounding content silently mangled.

- `allowHtml="false"` makes raw HTML render as **literal text**. Implemented as a remark plugin that converts raw-HTML mdast nodes to text nodes before `rehype-raw` runs — surgical (only raw HTML; code fences, inline code, blockquotes, and markdown syntax are untouched) and with **no data loss** (a lone unterminated `<tag>` survives verbatim, unlike dropping `rehype-raw` / `skipHtml`).

The two axes are independent; pair them (`interpolateBindings="false" allowHtml="false"`) for a fully data-safe render.

## Tests

`Markdown.spec.ts` — full suite green (85/85). New cases cover binding opt-out and collision, empty-`@{}` removal vs preservation, fail-soft, quoted four-backtick `xmlui-pg` fences, raw-HTML pass-through in both modes, `allowHtml="false"` literal rendering, the fenced-code guard, and the lone-unterminated-tag data-loss guard.

---

Raised by Jon's Claude on Jon's behalf.
