### PR TITLE
List: re-observe virtua's scroll viewport when the mode resolves

### DIFF
--- a/.changeset/list-outside-scroll-viewport.md
+++ b/.changeset/list-outside-scroll-viewport.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Fix List in outside-scroll mode so it virtualizes and its scroll APIs work: the virtualizer bound to the list's own root instead of the resolved scroll container, leaving scrollToTop, scrollToBottom, scrollToIndex, and scrollToId inert and every row mounted.

--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -293,110 +293,185 @@ test.describe("Basic Functionality", () => {
     await expect(driver.component).toContainText("Item 2");
   });
 
-  test("scrollToTop method works", async ({ initTestBed, createListDriver, page }) => {
-    await initTestBed(`
-      <List id="testList" data="{[
-        {id: 1, name: 'Item 1'},
-        {id: 2, name: 'Item 2'},
-        {id: 3, name: 'Item 3'},
-        {id: 4, name: 'Item 4'},
-        {id: 5, name: 'Item 5'}
-      ]}">
-        <Text>{$item.name}</Text>
+  // ---------------------------------------------------------------------------
+  // Scroll API tests.
+  //
+  // These drive the component API from markup (a Button onClick) rather than
+  // from page.evaluate: component APIs are NOT exposed on `window` in the test
+  // bed, so the previous `const list = (window as any).testList; if
+  // (list?.scrollToTop) {...}` shape silently skipped every call, and the
+  // paired `toContainText` assertion passed whether or not anything scrolled.
+  //
+  // They assert the scroll container's scrollTop, for the same reason: with a
+  // short list every item is in the DOM regardless of scroll position, so a
+  // text assertion cannot distinguish "scrolled" from "did nothing".
+  //
+  // Each API is covered in BOTH scroll modes. Outside-scroll (no explicit
+  // height, an ancestor scrolls) was entirely untested and entirely broken —
+  // see xmlui-org/xmlui#3760 and the Virtualizer key comment in ListReact.tsx.
+  // ---------------------------------------------------------------------------
+
+  // 200 rows x 30px = 6000px of content.
+  const SCROLL_DATA = "{Array.from({length: 200}, (_, i) => ({id: 'row-' + i, name: 'Item ' + i}))}";
+
+  // Bounded height: the List itself scrolls.
+  const insideScrollApp = (buttons: string) => `
+    <VStack>
+      <List id="testList" height="300px" data="${SCROLL_DATA}">
+        <Text height="30px">{$item.name}</Text>
       </List>
-    `);
-    const driver = await createListDriver();
+      ${buttons}
+    </VStack>
+  `;
 
-    // Scroll down first
-    await driver.scrollTo("bottom");
+  // No explicit height: an ancestor scrolls and the List virtualizes against it.
+  const outsideScrollApp = (buttons: string) => `
+    <VStack>
+      <VStack testId="scroller" height="300px" overflowY="scroll">
+        <List id="testList" data="${SCROLL_DATA}">
+          <Text height="30px">{$item.name}</Text>
+        </List>
+      </VStack>
+      ${buttons}
+    </VStack>
+  `;
 
-    // Use API to scroll to top
-    await page.evaluate(() => {
-      const list = (window as any).testList;
-      if (list?.scrollToTop) {
-        list.scrollToTop();
-      }
+  // The element that actually scrolls, in either mode: the only descendant
+  // whose content overflows its box.
+  const scrollTopOf = (page: any) =>
+    page.evaluate(() => {
+      let found = -1;
+      document.querySelectorAll("*").forEach((el: any) => {
+        if (el.scrollHeight > el.clientHeight + 20 && el.clientHeight > 50) {
+          found = Math.round(el.scrollTop);
+        }
+      });
+      return found;
     });
 
-    // Should show first item
-    await expect(driver.component).toContainText("Item 1");
-  });
+  const setScrollTop = async (page: any, value: number) => {
+    await page.evaluate((v: number) => {
+      document.querySelectorAll("*").forEach((el: any) => {
+        if (el.scrollHeight > el.clientHeight + 20 && el.clientHeight > 50) {
+          el.scrollTop = v;
+        }
+      });
+    }, value);
+  };
 
-  test("scrollToBottom method works", async ({ initTestBed, createListDriver, page }) => {
-    await initTestBed(`
-      <List id="testList" data="{[
-        {id: 1, name: 'Item 1'},
-        {id: 2, name: 'Item 2'},
-        {id: 3, name: 'Item 3'},
-        {id: 4, name: 'Item 4'},
-        {id: 5, name: 'Item 5'}
-      ]}">
-        <Text>{$item.name}</Text>
-      </List>
-    `);
-    const driver = await createListDriver();
+  for (const [mode, app] of [
+    ["inside-scroll", insideScrollApp],
+    ["outside-scroll", outsideScrollApp],
+  ] as const) {
+    test(`scrollToTop method works (${mode})`, async ({ initTestBed, page }) => {
+      await initTestBed(
+        app(`<Button testId="act" label="top" onClick="testList.scrollToTop()" />`),
+      );
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
 
-    // Use API to scroll to bottom
-    await page.evaluate(() => {
-      const list = (window as any).testList;
-      if (list?.scrollToBottom) {
-        list.scrollToBottom();
-      }
+      await setScrollTop(page, 900);
+      await expect.poll(() => scrollTopOf(page)).toBe(900);
+
+      await page.getByTestId("act").click();
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
     });
 
-    // Should show last items
-    await expect(driver.component).toContainText("Item 5");
-  });
+    test(`scrollToBottom method works (${mode})`, async ({ initTestBed, page }) => {
+      await initTestBed(
+        app(`<Button testId="act" label="bottom" onClick="testList.scrollToBottom()" />`),
+      );
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
 
-  test("scrollToIndex method works", async ({ initTestBed, createListDriver, page }) => {
-    await initTestBed(`
-      <List id="testList" data="{[
-        {id: 1, name: 'Item 1'},
-        {id: 2, name: 'Item 2'},
-        {id: 3, name: 'Item 3'},
-        {id: 4, name: 'Item 4'},
-        {id: 5, name: 'Item 5'}
-      ]}">
-        <Text>{$item.name}</Text>
-      </List>
-    `);
-    const driver = await createListDriver();
-
-    // Use API to scroll to specific index
-    await page.evaluate(() => {
-      const list = (window as any).testList;
-      if (list?.scrollToIndex) {
-        list.scrollToIndex(2);
-      }
+      await page.getByTestId("act").click();
+      // 200 rows * 30px - 300px viewport = 5700.
+      await expect.poll(() => scrollTopOf(page)).toBe(5700);
     });
 
-    // Should show item around index 2
-    await expect(driver.component).toContainText("Item 3");
-  });
+    test(`scrollToIndex method works (${mode})`, async ({ initTestBed, page }) => {
+      await initTestBed(
+        app(`<Button testId="act" label="idx" onClick="testList.scrollToIndex(50)" />`),
+      );
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
 
-  test("scrollToId method works", async ({ initTestBed, createListDriver, page }) => {
-    await initTestBed(`
-      <List id="testList" idKey="id" data="{[
-        {id: 'item-1', name: 'First Item'},
-        {id: 'item-target', name: 'Target Item'},
-        {id: 'item-3', name: 'Third Item'}
-      ]}">
-        <Text>{$item.name}</Text>
-      </List>
-    `);
-    const driver = await createListDriver();
-
-    // Use API to scroll to specific ID
-    await page.evaluate(() => {
-      const list = (window as any).testList;
-      if (list?.scrollToId) {
-        list.scrollToId("item-target");
-      }
+      await page.getByTestId("act").click();
+      // Item 50 starts at 50 * 30px.
+      await expect.poll(() => scrollTopOf(page)).toBe(1500);
     });
 
-    // Should show target item
-    await expect(driver.component).toContainText("Target Item");
-  });
+    test(`scrollToId method works (${mode})`, async ({ initTestBed, page }) => {
+      await initTestBed(
+        app(`<Button testId="act" label="id" onClick="testList.scrollToId('row-50')" />`),
+      );
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
+
+      await page.getByTestId("act").click();
+      await expect.poll(() => scrollTopOf(page)).toBe(1500);
+    });
+
+    test(`list virtualizes rather than rendering every row (${mode})`, async ({
+      initTestBed,
+      page,
+    }) => {
+      await initTestBed(app(""));
+      // Outside-scroll used to render all 200 rows because virtua had bound its
+      // viewport to the List's own root, whose height is content-sized.
+      await expect
+        .poll(async () =>
+          page.evaluate(() => {
+            const c = document.querySelector("[data-list-container]") as HTMLElement;
+            if (!c) return -1;
+            const seen = new Set(
+              Array.from(c.querySelectorAll("*"))
+                .map((e) => (e.textContent || "").trim())
+                .filter((t) => /^Item \d+$/.test(t)),
+            );
+            return seen.size;
+          }),
+        )
+        .toBeLessThan(40);
+    });
+  }
+
+  // The original xmlui-org/xmlui#3760 report: content that appears ABOVE the
+  // list after mount. `useStartMargin` only recomputes on the scroll
+  // container's own resize (and its rAF retry is guarded on `newMargin === 0`),
+  // so the cached offset stays at its mount-time value and index-targeted
+  // scrolls land short by exactly the height of the new content.
+  //
+  // This was unreachable while the scroll APIs were inert; fixing the viewport
+  // binding exposed it. Measured: with a 200px block revealed above,
+  // scrollToIndex(50) lands at 1500 instead of 1700.
+  //
+  // Note scrollToTop is NOT affected: virtua's $scrollToIndex adds
+  // store.$getStartSpacerSize() to the caller's offset, and scrollToTop passes
+  // `offset: -startMargin`, so the stale value cancels itself at index 0.
+  test.fixme(
+    "scrollToIndex accounts for content revealed above the list (outside-scroll)",
+    async ({ initTestBed, page }) => {
+      await initTestBed(`
+        <VStack var.showTop="{false}">
+          <VStack testId="scroller" height="300px" overflowY="scroll">
+            <VStack when="{showTop}" testId="above" height="200px">
+              <Text>revealed after mount</Text>
+            </VStack>
+            <List id="testList" data="${SCROLL_DATA}">
+              <Text height="30px">{$item.name}</Text>
+            </List>
+          </VStack>
+          <Button testId="reveal" label="reveal" onClick="showTop = true" />
+          <Button testId="act" label="idx" onClick="testList.scrollToIndex(50)" />
+        </VStack>
+      `);
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
+
+      await page.getByTestId("reveal").click();
+      await expect.poll(() => scrollTopOf(page)).toBe(0);
+
+      await page.getByTestId("act").click();
+      // 200px revealed above + item 50 at 1500px within the list.
+      await expect.poll(() => scrollTopOf(page)).toBe(1700);
+    },
+  );
 
   test("shows loading state when loading is true and no data", async ({
     initTestBed,
@@ -2539,3 +2614,4 @@ test.describe("scroll event", () => {
       .toBe(true);
   });
 });
+

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -1247,7 +1247,26 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
                 })}
                 data-list-container={true}
               >
+                {/* key on the resolved scroll viewport: Virtualizer observes its
+                    viewport in a mount-only layout effect whose microtask reads
+                    scrollRef.current once and never revisits it (virtua
+                    Virtualizer.tsx, empty dep array). On the first render
+                    parentRef.current is still null, so useScrollParent returns
+                    null, hasOutsideScroll is falsy, and scrollElementRef is
+                    parentRef — the List's own root. virtua then binds to that
+                    root permanently, even though later renders pass scrollRef.
+                    The result was a dead letter in outside-scroll mode: scroll
+                    APIs set scrollTop on a non-scrollable div (no movement, no
+                    error) and the viewport sized to full content height, so
+                    every row rendered — 200 of 200 in a 200-row list, vs 17
+                    when bounded. Remounting on the flip re-runs that effect
+                    against the resolved ref. At the render-2 flip nothing is
+                    measured yet, so the remount is free; a later legitimate
+                    flip discards virtua's measurement cache, which is still
+                    better than staying bound to the wrong element.
+                    xmlui-org/xmlui#3760 */}
                 <Virtualizer
+                  key={hasOutsideScroll ? "outside-scroll" : "inside-scroll"}
                   ref={virtualizerRef}
                   scrollRef={scrollElementRef}
                   shift={shift}


### PR DESCRIPTION
Closes #3760. Full investigation, measurements, and the corrected diagnosis are in that issue's thread.

The stale-`startMargin` half of #3760 is split out to #3765 and is **not** addressed here — see "Known-unfixed" below.

## The bug

`ListReact.tsx` hands `Virtualizer` **a different ref object on the first render than on every render after**:

```ts
const scrollParent = useScrollParent(parentRef.current?.parentElement);       // 717
const hasOutsideScroll = scrollRef.current && !hasHeight && !stretchToParent; // 747
const scrollElementRef = hasOutsideScroll ? scrollRef : parentRef;           // 751
```

On the first render `parentRef.current` is still `null`, so `useScrollParent` receives `undefined` and returns `null`; `hasHeight` and `stretchToParent` are also still `false` (both are set from layout effects). `hasOutsideScroll` is therefore falsy and `scrollElementRef` is **`parentRef`** — the List's own root.

virtua observes its viewport in a **mount-only** layout effect whose microtask reads `scrollRef.current` once and never revisits it (`Virtualizer.tsx`, empty dep array). By the time that microtask runs, `parentRef.current` is populated — so virtua successfully binds to the List's own root and keeps it forever, ignoring the real scroll parent passed on every later render.

Inside-scroll mode works by coincidence of the same path: `hasOutsideScroll` stays false permanently, so `parentRef` *is* the intended viewport.

## Two consequences, both silent

**1. The scroll APIs did nothing.** They set `scrollTop` on a non-scrollable div — no movement, no error, `initialized` resolves so the scroll is genuinely attempted against the wrong element.

**2. Virtualization was off entirely.** virtua sized its viewport from the content-sized root, so every row stayed mounted. 200-row list, 30px rows:

| mode | rows in DOM |
| --- | --- |
| inside-scroll (`height="300px"`) | 17 of 200 |
| outside-scroll (ancestor scrolls) | **200 of 200** |

## The fix

Key `Virtualizer` on the resolved viewport, so the mode flip on the second render remounts it and re-runs that effect against the settled ref. Nothing is measured at that point, so the remount is free. A later legitimate flip discards virtua's measurement cache — still better than staying bound to the wrong element, which is today's behavior.

After the fix, outside-scroll renders 17 of 200, matching inside-scroll, and all four APIs land where they should:

| call | before | after |
| --- | --- | --- |
| `scrollToTop()` from 900 | 900 (no movement) | **0** |
| `scrollToIndex(50)` | no movement | **1500** (50 × 30px) |
| `scrollToBottom()` | no movement | **5700** (6000 − 300 viewport) |
| `scrollToId('row-50')` | no movement | **1500** |

The arguably-cleaner alternative — defer mounting `Virtualizer` until the layout probes settle — was rejected for now: it delays first paint of the rows by a frame and touches SSR/hydration and the `scrollAnchor="bottom"` path. The long-term home is upstream (virtua could re-run its observe effect when `scrollRef.current` resolves); the `key` is a correct local response to a prop change either way.

## Tests

The four existing scroll-API tests **could not fail**. `window.testList` is `undefined` in the test bed, so `if (list?.scrollToTop) {…}` skipped every call and the paired `toContainText` assertion passed regardless — in both scroll modes.

They now drive the API from markup (`<Button onClick="testList.scrollToTop()"/>`) and assert the scroll container's `scrollTop`, each running in **both** scroll modes; outside-scroll was previously untested for every scroll API. Added a virtualization assertion (rows in DOM < 40 of 200) in both modes — that is what would have caught the silent regression.

`List.spec.ts`: 129 passed, 1 skipped (see below). Four tests report flaky under `--workers=4`, but the same four are flaky on pristine `main` under the same load — pre-existing and unrelated, verified by stashing. Standalone build clean.

## Known-unfixed, covered by a `test.fixme`

The stale-`startMargin` gap described in #3760's original body is real but **separate**, and becomes reachable only once virtua observes the right element. With a 200px block revealed above the list after mount, `scrollToIndex(50)` lands at **1500** instead of **1700** — short by exactly the revealed height, which is what was originally reported. It was masked all along by the inert viewport.

`scrollToTop` is unaffected: virtua's `$scrollToIndex` adds `store.$getStartSpacerSize()` to the caller's `offset`, and `scrollToTop` passes `offset: -startMargin`, so the stale value cancels itself at index 0.

Left as a `test.fixme` with the measurement in a comment, so it turns green when that gap is addressed. Now tracked as #3765.

## Downstream validation

Validated in `judell/bram` against the real app that reported this ([detail](https://github.com/xmlui-org/xmlui/issues/3760#issuecomment-5309010790) and the reply below it): no regressions across four outside-scroll surfaces or the inside-scroll ones, follow-to-bottom anchoring intact, no new console-error classes. Mounted-row counts now track the viewport rather than the data. Their same-day mitigation capping initial render at 20 rows ([81ba145](https://github.com/judell/bram/commit/81ba14519649ebe713fff8f17d7391387bc554b1)) becomes redundant and will be reverted citing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
