### PR TITLE
Reuse compiled binding functions instead of recompiling per evaluation

### DIFF
--- a/.changeset/compiled-binding-function-reuse.md
+++ b/.changeset/compiled-binding-function-reuse.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Reuse compiled binding functions across component instances and mounts instead of recompiling on every evaluation, removing per-instance `new Function` cost from render.

--- a/xmlui/src/components-core/script-compiler/artifact.ts
+++ b/xmlui/src/components-core/script-compiler/artifact.ts
@@ -81,17 +81,75 @@ export function deserializeCompiledScriptArtifact(serialized: string): CompiledS
   return JSON.parse(serialized) as CompiledScriptArtifact;
 }
 
-export function instantiateCompiledScriptArtifact<TValue = unknown>(
+/**
+ * Compiled function products, keyed by artifact identity and then by the
+ * options that affect the emitted body.
+ *
+ * A `new Function` product has global scope only — it closes over nothing, and
+ * `runtime` / `evalContext` / `thread` all arrive as parameters — so a single
+ * function is correct for every instance, evaluation context, and thread that
+ * shares an artifact. Compiling per evaluation was the cost behind
+ * xmlui-org/xmlui#3763: the artifact (the compiled JS *source*) was already
+ * cached by source text in binding-sync-executor.ts, but every evaluation still
+ * paid `new Function` — and, when source maps are on, a fresh inline source map
+ * from createCompiledScriptFunctionBody. That is why the profile scaled with
+ * component instance count rather than with the number of distinct expressions.
+ *
+ * Keyed on artifact identity rather than on the body text: the artifact cache
+ * already yields one stable object per unique expression, so this is an O(1)
+ * lookup that does not have to build the body just to compute a key. A WeakMap
+ * keeps the entries collectable as soon as the bounded artifact cache evicts
+ * the artifact, so memory tracks distinct expressions, not instances.
+ */
+let nativeFnCache = new WeakMap<CompiledScriptArtifact, Map<string, Function>>();
+
+function createNativeFnCacheKey(options: CompiledScriptInstantiateOptions): string {
+  return JSON.stringify([
+    options.sourceMapMode ?? "",
+    options.generatedSourceUrl ?? "",
+    options.sourceMapUrl ?? "",
+  ]);
+}
+
+function getOrCreateNativeFn(
   artifact: CompiledScriptArtifact,
-  runtime: CompiledScriptRuntime = {},
-  options: CompiledScriptInstantiateOptions = {},
-): CompiledScriptInstance<TValue> {
+  options: CompiledScriptInstantiateOptions,
+): Function {
+  const key = createNativeFnCacheKey(options);
+  let byOptions = nativeFnCache.get(artifact);
+  if (!byOptions) {
+    byOptions = new Map<string, Function>();
+    nativeFnCache.set(artifact, byOptions);
+  }
+  const cached = byOptions.get(key);
+  if (cached) {
+    return cached;
+  }
   const nativeFn = new Function(
     "runtime",
     "evalContext",
     "thread",
     createCompiledScriptFunctionBody(artifact, options),
   );
+  byOptions.set(key, nativeFn);
+  return nativeFn;
+}
+
+/** Drops every memoized function product. Exposed for tests. */
+export function clearCompiledScriptNativeFnCache(): void {
+  nativeFnCache = new WeakMap<CompiledScriptArtifact, Map<string, Function>>();
+}
+
+export function instantiateCompiledScriptArtifact<TValue = unknown>(
+  artifact: CompiledScriptArtifact,
+  runtime: CompiledScriptRuntime = {},
+  options: CompiledScriptInstantiateOptions = {},
+): CompiledScriptInstance<TValue> {
+  // Only the function is shared. The instance wrapper is rebuilt per call
+  // because `execute` closes over `runtime`, and the async event executor
+  // passes a fresh per-invocation runtime — sharing the wrapper would leak one
+  // invocation's runtime into another's call.
+  const nativeFn = getOrCreateNativeFn(artifact, options);
 
   return {
     artifact,

--- a/xmlui/tests/components-core/script-compiler/artifact.test.ts
+++ b/xmlui/tests/components-core/script-compiler/artifact.test.ts
@@ -12,6 +12,7 @@ import {
   throwUnsupportedCompiledScriptNode,
   UnsupportedCompiledScriptNodeError,
 } from "../../../src/components-core/script-compiler";
+import { clearCompiledScriptNativeFnCache } from "../../../src/components-core/script-compiler/artifact";
 
 describe("compiled script artifacts", () => {
   it("derives source ranges from scripting tokens", () => {
@@ -138,6 +139,79 @@ describe("compiled script artifacts", () => {
     );
     expect(body).toContain("//# sourceMappingURL=/@xmlui-source/src/Main.xmlui.map");
     expect(body).not.toContain("base64");
+  });
+
+  // xmlui-org/xmlui#3763. The artifact — the compiled JS *source* — was already
+  // cached by source text in binding-sync-executor.ts, but every evaluation
+  // still ran `new Function` on it, so compile cost scaled with component
+  // instance count. These assert reference identity rather than timing: a
+  // second call returning the same function object IS "new Function did not run
+  // again", with nothing to flake.
+  describe("native function reuse", () => {
+    const makeArtifact = (js: string) =>
+      createCompiledScriptArtifact({
+        target: "binding-sync",
+        sourceId: "Main.xmlui#reuse",
+        sourceText: "{count + 1}",
+        js,
+      });
+
+    it("reuses one compiled function across instantiations of the same artifact", () => {
+      clearCompiledScriptNativeFnCache();
+      const artifact = makeArtifact("return runtime.resolve('count') + 1;");
+
+      const first = instantiateCompiledScriptArtifact<number>(artifact, {
+        resolve: () => 2,
+      });
+      const second = instantiateCompiledScriptArtifact<number>(artifact, {
+        resolve: () => 5,
+      });
+
+      expect(second.nativeFn).toBe(first.nativeFn);
+      // The wrapper is still per call, so each keeps its own runtime.
+      expect(first.execute({ evalContext: createEvalContext({}) })).toBe(3);
+      expect(second.execute({ evalContext: createEvalContext({}) })).toBe(6);
+    });
+
+    it("keeps a per-call runtime out of a shared function", () => {
+      clearCompiledScriptNativeFnCache();
+      const artifact = makeArtifact("return runtime.tag;");
+
+      const a = instantiateCompiledScriptArtifact<string>(artifact, { tag: "a" } as any);
+      const b = instantiateCompiledScriptArtifact<string>(artifact, { tag: "b" } as any);
+
+      expect(b.nativeFn).toBe(a.nativeFn);
+      // Interleaved, because the async event executor passes a fresh runtime per
+      // invocation: a shared instance wrapper would cross-contaminate these.
+      expect(a.execute({ evalContext: createEvalContext({}) })).toBe("a");
+      expect(b.execute({ evalContext: createEvalContext({}) })).toBe("b");
+      expect(a.execute({ evalContext: createEvalContext({}) })).toBe("a");
+    });
+
+    it("compiles separately when the emitted body differs", () => {
+      clearCompiledScriptNativeFnCache();
+      const artifact = makeArtifact("return 1;");
+
+      const plain = instantiateCompiledScriptArtifact(artifact, {});
+      const mapped = instantiateCompiledScriptArtifact(artifact, {}, { sourceMapMode: "inline" });
+
+      // Source maps change the function body, so they must not share a product.
+      expect(mapped.nativeFn).not.toBe(plain.nativeFn);
+      expect(instantiateCompiledScriptArtifact(artifact, {}).nativeFn).toBe(plain.nativeFn);
+    });
+
+    it("does not share a function between distinct artifacts", () => {
+      clearCompiledScriptNativeFnCache();
+      const one = makeArtifact("return 1;");
+      const two = makeArtifact("return 2;");
+
+      const first = instantiateCompiledScriptArtifact<number>(one, {});
+      const second = instantiateCompiledScriptArtifact<number>(two, {});
+
+      expect(second.nativeFn).not.toBe(first.nativeFn);
+      expect(first.execute({ evalContext: createEvalContext({}) })).toBe(1);
+      expect(second.execute({ evalContext: createEvalContext({}) })).toBe(2);
+    });
   });
 
   it("throws a structured error for unsupported nodes", () => {


### PR DESCRIPTION
Closes #3763.

## The ask was half already done, and not the expensive half

`binding-sync-executor.ts:11` has held a module-level `bindingSyncCache` all along, and both entry points already memoize compilation **to JS source** keyed by source text:

```ts
const artifact = bindingSyncCache.getOrCreate(key, () =>
  compileBindingSyncExpressionSource(source, sourceId),
);
```

What ran unconditionally on every evaluation was the next line — `instantiateCompiledScriptArtifact` → `new Function` (`artifact.ts:89`). That is the `Function` self-time in the reported profile, and it explains the issue's decisive observation: cost scaled with *component instance count* rather than with the number of distinct expressions, **while the existing cache sat there hitting**.

A second cost rode the same path that the profile could not separate out: `createCompiledScriptFunctionBody` rebuilt the body on every call, and with source maps on (the dev-server default per `vite-xmlui-plugin.ts:432`) that means generating a fresh inline base64 source map per evaluation.

Confirmed the path is live in the reporting app before changing anything: Bram sets `"compileScripts": true` and `compileBindings` inherits it (`xmluiPluginOptions.ts:15`). Worth checking, because `compileScripts` defaults to **false** (`vite-xmlui-plugin.ts:423`) and the whole ask is moot on the interpreted path.

## The change

Memoize the `new Function` product in a `WeakMap` keyed on artifact identity, then options.

**Identity rather than body text** because building the body is itself part of the cost being removed — a body-keyed cache would pay much of what it saves. The artifact cache already yields one stable object per unique expression, so this is an O(1) lookup, and a `WeakMap` keeps entries collectable as soon as the bounded 1000-entry artifact cache evicts the artifact. Memory tracks distinct expressions, not instances.

**Only the function is shared.** The instance wrapper is still built per call, because `execute` closes over `runtime` and `event-async-executor.ts` passes a fresh per-invocation runtime — sharing the wrapper would leak one invocation's runtime into another's call. That has its own test rather than a comment.

Safety rests on `new Function` products having global scope only: `runtime`, `evalContext`, and `thread` all arrive as parameters, so one function is correct for every instance, context, and thread sharing an artifact.

## Tests

Reference identity, not timing — a second call returning the same function object *is* "`new Function` did not run again", with nothing to flake:

- reuses one compiled function across instantiations of the same artifact
- keeps a per-call runtime out of a shared function (the regression this change could plausibly cause)
- compiles separately when the emitted body differs (`sourceMapMode`)
- does not share a function between distinct artifacts

Verified **red before green**. The first red run failed only on a missing import, which proves nothing about the assertions, so the reset calls were stripped and the run repeated against unpatched code to watch the assertions themselves fail on `Object.is equality`. Three of the four fail that way; the fourth passes either way and is a guard against over-sharing rather than a red-green test.

## Suite results, and a load artifact worth naming

Full Playwright suite under `XMLUI_COMPILE_SCRIPTS=true` — the configuration this affects — reported 7557 passed / 12 failed. **Those 12 are load artifacts, not regressions:**

| run | conditions | result |
| --- | --- | --- |
| full suite, with change | 49 min, full parallelism | 12 failed |
| same specs, pristine | 3.3 min, 4 workers | 1 failed, 1 flaky |
| same specs, with change | 3.3 min, 4 workers | 1 failed, 1 flaky |

Equal load with differing code gives identical results. Nearly all 12 are timing assertions (`spinnerDelay`, `debounceWaitInMs`, "respects numeric delay prop", "renders quickly") buckling on a saturated machine. The remaining `DateInput` failure reproduces on pristine, as do 4 date-related unit failures — all time-of-day dependent, none related here.

Unit suite: 11,132 passed (script-compiler 231).

## Downstream validation

Validated in `judell/bram` on a build carrying this plus the two List fixes (#3764, #3765), with their initial-render cap reverted first ([1e52bf6](https://github.com/judell/bram/commit/1e52bf6ceccc385c1023893ce7fda9a37f57042d)) so the comparison would not measure the cap:

- query-settle row rebuild **3.9s → 1.3s** on a cap-free 100-row page;
- the route-switch cycle that produced the original 8.1s profile now **1.4–2.6s** of main-thread block;
- List fixes intact — 6–11 DOM rows for 100 hits, no short landings, zero console errors.

Method caveat, stated by them and worth repeating: the after-numbers are trace long-tasks (main-thread blocks), **not** a like-for-like Timeline `Function` self-time breakdown, so this is not a direct 8.1s → *x* comparison. The residual is the render/measurement half, tracked separately.

## Note for review: a null artifact cannot poison the cache

`judell/bram` flagged an adjacent crash where `parseParameterString` can push a null expression that reaches artifact creation. Checked, since it touches this path:

- `WeakMap.get(null)` returns `undefined` — no throw;
- `WeakMap.set(null, …)` throws `TypeError: Invalid value used as weak map key` and **stores nothing**, so no poisoned entry survives and a retry behaves identically.

A null artifact threw before this change too (`Cannot read properties of null (reading 'js')`); only the message differs. Their crash is upstream in `collectVariableDependencies`, so it never reaches instantiate in practice. Deliberately not adding a null guard here — the fix belongs in the parse path they are filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
