### PR TITLE
Slider: add a didCommit event for apply-on-release handlers

### DIFF
--- a/.changeset/slider-did-commit.md
+++ b/.changeset/slider-did-commit.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Add a `didCommit` event to `Slider`, fired once when an adjustment finishes rather than on every step crossed during a drag, so expensive handlers (filtering a result set, fetching) can run per gesture while `didChange` keeps driving the live readout.

--- a/xmlui/src/components/Slider/Slider.md
+++ b/xmlui/src/components/Slider/Slider.md
@@ -49,8 +49,9 @@ This event fires once the user finishes an adjustment, while `didChange` fires o
 Drag a thumb: the first line follows every step, the second updates only when you let go.
 ```
 
-Two details worth knowing before you move expensive work here:
+Three details worth knowing before you move expensive work here:
 
+- **The two events are additive, not exclusive.** Adopting `didCommit` does not quiet `didChange` — it keeps firing per step, which is what lets a live readout follow the thumbs while the expensive work waits for the release. Move work *to* `didCommit`; do not drop `didChange`.
 - Keyboard adjustments commit **per key-down, including auto-repeat** — holding an arrow key produces one commit per repeat, not one when the key is released. If a slider is realistically keyboard-driven, the commit handler may still need a debounce.
 - The event follows values the app or the user asks for: a pointer release that actually moved the value, a keyboard adjustment, and the `setValue()` method. Re-seeding the component by changing `initialValue`, `minValue`, or `maxValue` fires neither `didCommit` nor `didChange`.
 

--- a/xmlui/src/components/Slider/Slider.md
+++ b/xmlui/src/components/Slider/Slider.md
@@ -30,3 +30,28 @@
 ```
 
 %-PROP-END
+%-EVENT-START didCommit
+
+This event fires once the user finishes an adjustment, while `didChange` fires on every step crossed during a drag. Use `didCommit` for work you do not want repeated mid-gesture — filtering a result set, fetching, recalculating — and keep `didChange` for the live readout.
+
+```xmlui-pg name="Slider 4"
+---app copy display name="Example: didCommit"
+<App var.live="{[20, 60]}" var.committed="{[20, 60]}">
+  <Slider
+    initialValue="{[20, 60]}"
+    minStepsBetweenThumbs="1"
+    onDidChange="(val) => live = val"
+    onDidCommit="(val) => committed = val" />
+  <Text value="dragging: {live[0]} – {live[1]}" />
+  <Text value="committed: {committed[0]} – {committed[1]}" />
+</App>
+---desc
+Drag a thumb: the first line follows every step, the second updates only when you let go.
+```
+
+Two details worth knowing before you move expensive work here:
+
+- Keyboard adjustments commit **per key-down, including auto-repeat** — holding an arrow key produces one commit per repeat, not one when the key is released. If a slider is realistically keyboard-driven, the commit handler may still need a debounce.
+- The event follows values the app or the user asks for: a pointer release that actually moved the value, a keyboard adjustment, and the `setValue()` method. Re-seeding the component by changing `initialValue`, `minValue`, or `maxValue` fires neither `didCommit` nor `didChange`.
+
+%-EVENT-END

--- a/xmlui/src/components/Slider/Slider.spec.ts
+++ b/xmlui/src/components/Slider/Slider.spec.ts
@@ -434,6 +434,122 @@ test.describe("Event Handling", () => {
     await expect.poll(testStateDriver.testState).toEqual(2);
   });
 
+  test("didCommit fires once per drag while didChange fires per step", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Fragment var.changes="{0}" var.commits="{0}">
+        <Slider
+          initialValue="20"
+          maxValue="100"
+          onDidChange="changes++; testState = { changes, commits }"
+          onDidCommit="commits++; testState = { changes, commits }" />
+      </Fragment>
+    `);
+    const thumb = page.getByRole("slider");
+    const box = await thumb.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2 + 80, box!.y + box!.height / 2, { steps: 10 });
+    await page.mouse.up();
+
+    await expect.poll(async () => (await testStateDriver.testState())?.commits).toEqual(1);
+    expect((await testStateDriver.testState())?.changes).toBeGreaterThan(1);
+  });
+
+  test("didCommit does not fire when a drag ends where it started", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Fragment var.changes="{0}" var.commits="{0}">
+        <Slider
+          initialValue="20"
+          maxValue="100"
+          onDidChange="changes++; testState = { changes, commits }"
+          onDidCommit="commits++; testState = { changes, commits }" />
+      </Fragment>
+    `);
+    const thumb = page.getByRole("slider");
+    const box = await thumb.boundingBox();
+    const startX = box!.x + box!.width / 2;
+    const startY = box!.y + box!.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 60, startY, { steps: 8 });
+    await page.mouse.move(startX, startY, { steps: 8 });
+    await page.mouse.up();
+
+    // The value moved and came back, so didChange fired but nothing was committed.
+    await expect.poll(async () => (await testStateDriver.testState())?.changes).toBeGreaterThan(1);
+    expect((await testStateDriver.testState())?.commits).toEqual(0);
+  });
+
+  test("didCommit event fires on keyboard adjustment and passes the value", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Slider onDidCommit="arg => testState = arg" initialValue="1" />
+    `);
+    const slider = page.getByRole("slider");
+    await slider.focus();
+    await slider.press("ArrowRight");
+    await expect.poll(testStateDriver.testState).toEqual(2);
+  });
+
+  test("didCommit event fires for range sliders with both values", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Slider onDidCommit="arg => testState = arg" initialValue="{[20, 60]}" maxValue="100" />
+    `);
+    const firstThumb = page.getByRole("slider").first();
+    await firstThumb.focus();
+    await firstThumb.press("ArrowRight");
+    await expect.poll(testStateDriver.testState).toEqual([21, 60]);
+  });
+
+  test("didCommit does not fire when disabled", async ({ initTestBed, page }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Slider enabled="false" onDidCommit="testState = 'committed'" />
+    `);
+    const slider = page.getByRole("slider");
+    await slider.focus();
+    await slider.press("ArrowRight");
+    await expect.poll(testStateDriver.testState).toEqual(null);
+  });
+
+  test("re-seeding from initialValue/minValue/maxValue fires neither event", async ({
+    initTestBed,
+    page,
+  }) => {
+    // Downstream apps reset their own filter state when a slider's domain changes and
+    // rely on the re-seed staying silent; an event here would overwrite that reset.
+    const { testStateDriver } = await initTestBed(`
+      <Fragment var.seed="{20}" var.lo="{0}" var.hi="{100}">
+        <Slider
+          initialValue="{seed}"
+          minValue="{lo}"
+          maxValue="{hi}"
+          onDidChange="testState = 'changed'"
+          onDidCommit="testState = 'committed'" />
+        <Button testId="reseed" onClick="seed = 40; lo = 10; hi = 80" />
+      </Fragment>
+    `);
+    const slider = page.getByRole("slider");
+    await expect(slider).toHaveAttribute("aria-valuenow", "20");
+
+    await page.getByTestId("reseed").click();
+    await expect(slider).toHaveAttribute("aria-valuenow", "40");
+    await expect.poll(testStateDriver.testState).toEqual(null);
+  });
+
   test("gotFocus event fires on focus", async ({ initTestBed, page }) => {
     const { testStateDriver } = await initTestBed(`
       <Slider onGotFocus="testState = 'focused'" />
@@ -534,6 +650,17 @@ test.describe("Api", () => {
     `);
     await page.getByTestId("setBtn").click();
     await expect.poll(testStateDriver.testState).toEqual("api-changed");
+  });
+
+  test("setValue API triggers didCommit", async ({ initTestBed, page }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Fragment>
+        <Slider id="mySlider" maxValue="100" onDidCommit="arg => testState = arg" />
+        <Button testId="setBtn" onClick="mySlider.setValue(75)" />
+      </Fragment>
+    `);
+    await page.getByTestId("setBtn").click();
+    await expect.poll(testStateDriver.testState).toEqual(75);
   });
 
   test("focus API focuses the slider", async ({ initTestBed, page }) => {

--- a/xmlui/src/components/Slider/Slider.tsx
+++ b/xmlui/src/components/Slider/Slider.tsx
@@ -93,6 +93,16 @@ export const SliderMd = createMetadata({
   },
   events: {
     didChange: dDidChange(COMP),
+    didCommit: {
+      description:
+        `This event is triggered when the user finishes an adjustment of \`${COMP}\`, ` +
+        `rather than on every step crossed while dragging. Use it for expensive work ` +
+        `(filtering a result set, fetching) and keep \`didChange\` for live display.`,
+      signature: "didCommit(newValue: any): void",
+      parameters: {
+        newValue: "The committed value of the component.",
+      },
+    },
     gotFocus: dGotFocus(COMP),
     lostFocus: dLostFocus(COMP),
   },
@@ -192,6 +202,7 @@ export const sliderComponentRenderer = wrapComponent(COMP, Slider, SliderMd, {
         initialValue={extractValue(node.props.initialValue)}
         updateState={updateState}
         onDidChange={lookupEventHandler("didChange")}
+        onDidCommit={lookupEventHandler("didCommit")}
         onFocus={lookupEventHandler("gotFocus")}
         onBlur={lookupEventHandler("lostFocus")}
         registerComponentApi={registerComponentApi}

--- a/xmlui/src/components/Slider/SliderReact.tsx
+++ b/xmlui/src/components/Slider/SliderReact.tsx
@@ -28,6 +28,7 @@ export type Props = Omit<React.HTMLAttributes<HTMLDivElement>, "onFocus" | "onBl
   invalidMessages?: string[];
   minStepsBetweenThumbs?: number;
   onDidChange?: (newValue: number | number[]) => void;
+  onDidCommit?: (newValue: number | number[]) => void;
   onFocus?: (ev: React.FocusEvent<HTMLDivElement>) => void;
   onBlur?: (ev: React.FocusEvent<HTMLDivElement>) => void;
   updateState?: UpdateStateFn;
@@ -93,6 +94,7 @@ export const Slider = memo(forwardRef(
       inverted,
       updateState,
       onDidChange = noop,
+      onDidCommit = noop,
       onFocus = noop,
       onBlur = noop,
       registerComponentApi,
@@ -187,6 +189,21 @@ export const Slider = memo(forwardRef(
       [onDidChange, updateState],
     );
 
+    // Fired once per completed adjustment rather than per step crossed: Radix's own
+    // commit (pointer release, and each arrow/Page/Home/End keydown), the small-step
+    // keyboard path below that Radix never sees, and the setValue() API. Deliberately
+    // NOT fired by the initialValue/min/max effect above — that is the component
+    // re-seeding itself from new props, not a value anyone asked for.
+    const commitValue = useCallback(
+      (value: number[]) => {
+        if (readOnly || !enabled) {
+          return;
+        }
+        onDidCommit(value.length === 1 ? value[0] : value);
+      },
+      [onDidCommit, readOnly, enabled],
+    );
+
     const onInputChange = useCallback(
       (value: number[]) => {
         if (readOnly) {
@@ -240,6 +257,7 @@ export const Slider = memo(forwardRef(
       const formattedValue = formatValue(newValue, min, min, max);
       const valueToUpdate = formattedValue.length === 1 ? formattedValue[0] : formattedValue;
       updateValue(valueToUpdate);
+      commitValue(formattedValue);
     });
 
     useEffect(() => {
@@ -286,8 +304,10 @@ export const Slider = memo(forwardRef(
         const newValues = [...displayValue];
         newValues[focusedThumbIndex] = newThumbValue;
         onInputChange(newValues);
+        // Radix never sees this key, so its onValueCommit cannot fire for it.
+        commitValue(newValues);
       },
-      [step, readOnly, enabled, displayValue, min, max, onInputChange],
+      [step, readOnly, enabled, displayValue, min, max, onInputChange, commitValue],
     );
 
       return (
@@ -309,6 +329,7 @@ export const Slider = memo(forwardRef(
               onFocus={handleOnFocus}
               onBlur={handleOnBlur}
               onValueChange={onInputChange}
+              onValueCommit={commitValue}
               onMouseOver={onShowTooltip}
               onMouseLeave={onHideTooltip}
               onPointerDown={onShowTooltip}

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -15936,6 +15936,13 @@ export default {
           "newValue": "The new value of the component."
         }
       },
+      "didCommit": {
+        "description": "This event is triggered when the user finishes an adjustment of `Slider`, rather than on every step crossed while dragging. Use it for expensive work (filtering a result set, fetching) and keep `didChange` for live display.",
+        "signature": "didCommit(newValue: any): void",
+        "parameters": {
+          "newValue": "The committed value of the component."
+        }
+      },
       "gotFocus": {
         "description": "This event is triggered when the Slider has received the focus.",
         "signature": "gotFocus(): void",


### PR DESCRIPTION
Closes #3768.

`Slider` wired only Radix's continuous `onValueChange`, so `didChange` fires once per step crossed during a drag — right for a live readout, wrong for anything expensive. Radix already supplies the other half through `onValueCommit`; it was never surfaced, so no markup could say "apply on release." The motivating case is a two-handled date-range filter over a search result set, where one sweep of the track re-filters and re-renders up to 100 rows per step crossed.

`didCommit` fires once per completed adjustment, payload identical in shape to `didChange`.

## Where it fires, and where it deliberately does not

| Source | Commits? |
| --- | --- |
| Pointer release that moved the value | yes — Radix gates on `hasChanged` since pointer-down, so a click that lands on the current value is silent |
| Arrow / Page / Home / End | yes, per **key-down** (see caveat below) |
| Small-step keyboard path (`step < 1e-7`) | yes, raised explicitly |
| `setValue()` API | yes |
| `initialValue` / `minValue` / `maxValue` change | **no** |

Two of those rows are the judgment calls, and both were settled with the downstream reporter in [#3768](https://github.com/xmlui-org/xmlui/issues/3768#issuecomment-5311959384) rather than guessed:

**`setValue()` commits.** A programmatic set is a value the app *asked for*. An app that moved its expensive work to `didCommit` and then resets programmatically would otherwise show results silently disagreeing with the thumbs — a failure invisible until a user notices wrong data.

**The `initialValue` / `min` / `max` re-seed stays silent.** That effect is the component re-seeding itself from new props, not a value anyone asked for, and it fires no event today (`SliderReact.tsx:135-177` calls `updateState` only). Downstream apps derive a slider's domain from a result set that changes as the query is edited, reset their own filter state to "unfiltered" on that change, and let the thumbs re-seed. A commit here would write the full range back over that reset on every keystroke. A test pins the silence so it cannot regress.

That distinction — an app *asking* for a value commits; the component *re-seeding itself* does not — is the line the whole change rests on, and it's what `Slider.md` documents.

## Caveats documented rather than left to a profiler

- Keyboard adjustments commit **per key-down, including auto-repeat** (`@radix-ui/react-slider` calls `updateValues(..., { commit: true })` straight from the keydown handlers), so a held arrow key is not one-commit-per-gesture the way a drag is. A keyboard-driven slider may still want a debounce.
- **No thumb identity in the payload.** With `minStepsBetweenThumbs`, moving one thumb can push the other, so "which thumb moved" is ambiguous exactly where it would be interesting. Omitting the field beats reporting a guess, and it stays addable.
- **The events are additive, not exclusive.** `didChange` keeps firing per step; `didCommit` is added alongside it. Second commit here documents that explicitly, at the reporter's request — they read the caveats first and noted that a skimmer could conclude `didCommit` replaces `didChange` and drop their live readout.

## Verified downstream on a real surface, not just in specs

The reporting app re-vendored a pre-release build of this branch, deleted its debounce workaround, wired `onDidCommit` to its filter, and measured ([full report](https://github.com/xmlui-org/xmlui/issues/3768#issuecomment-5312261459)). Every commit line in their trace is tagged `"via":"didCommit"`, so these are this event and not a residual timer.

**One commit and one rebuild per gesture**, with the timer gone:

| gesture | step events | commits | rebuilds |
| --- | --- | --- | --- |
| A | 4 | 1 | 1 |
| B | 17 (over 2.6 s) | 1 | 1 |
| C | 4 | 1 | 1 |
| D | 4 | 1 | 1 |

Gesture B is the one that shows the event means what it says: it contains a 1.44 s pause mid-drag and nothing fires during it, where their 120 ms debounce would have fired twice. The commit lands on release.

**Release-to-results: 6–10 ms**, against ~900 ms through the debounce. Their caveat, carried rather than dropped: that instrument measures the data half (derived-binding recompute); paint is not instrumented on that surface.

**The re-seed silence holds in the wild.** While typing, their slider re-seeded 4 times as its domain was re-derived, and zero commits fired — the live counterpart of the spec below.

## Verification

- Six new specs: one commit per drag while `didChange` fires many; nothing committed when a drag ends where it started; keyboard commit; range payload; silent when disabled; and re-seeding `initialValue`/`minValue`/`maxValue` fires neither event.
- Full `Slider.spec.ts`: **112 passed, 0 failed** (6 pre-existing flakes in the file's opening render tests, green on retry, untouched by this diff).
- `npm run build:xmlui-standalone` clean; `check:metadata` and `check:metadata-purity` pass; the langserver metadata snapshot is regenerated in this commit so `check:metadata-snapshot` stays green.

Based on `main`, independent of #3764 and #3766. The change is also carried locally on the pre-release integration branch so the downstream app can exercise `didCommit` on its real surface before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
