### PR TITLE
List: carry the start margin once, and measure it when it matters

### DIFF
--- a/.changeset/list-scroll-index-start-margin.md
+++ b/.changeset/list-scroll-index-start-margin.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Fix List scrollToIndex and scrollToId so they account for content that appears above the list after mount, by measuring the start margin when the call is made and letting the virtualizer's spacer carry it exactly once.

--- a/xmlui/src/components-core/utils/hooks.tsx
+++ b/xmlui/src/components-core/utils/hooks.tsx
@@ -369,7 +369,26 @@ export const useRealBackground = (element: HTMLElement) => {
 //   return entered;
 // };
 
-export const useStartMargin = (
+/**
+ * Tracks how far down the scrollable content a list starts, and exposes a
+ * call-time re-measure.
+ *
+ * The cached value only refreshes on mount, on `hasOutsideScroll` change, on
+ * the *scroll container's* resize, and on one rAF retry guarded by
+ * `newMargin === 0`. None of those fire when content appears ABOVE the list:
+ * `parentRef` is the list's own root, which moves rather than resizes, and in
+ * outside-scroll mode `scrollRef` is an ancestor scroller whose box does not
+ * change when content appears inside it. So the cached value goes stale and
+ * stays stale.
+ *
+ * `measureStartMargin()` re-measures and publishes the result, so a caller that
+ * needs correctness at a specific instant (the imperative scroll APIs) can pay
+ * for a layout read exactly then, and virtua's `startMargin` prop converges to
+ * the same value on the following render. Nothing pays per render.
+ *
+ * xmlui-org/xmlui#3765
+ */
+export const useStartMarginState = (
   hasOutsideScroll: boolean,
   parentRef: MutableRefObject<HTMLElement | null | undefined>,
   scrollRef: MutableRefObject<HTMLElement | null | undefined>,
@@ -418,8 +437,27 @@ export const useStartMargin = (
     }
   }, [hasOutsideScroll, calculateStartMargin]);
 
-  return startMargin;
+  // Re-measure now, publish for the next render, and hand the caller the fresh
+  // value to use immediately.
+  const measureStartMargin = useEvent(() => {
+    const fresh = calculateStartMargin();
+    setStartMargin(fresh);
+    return fresh;
+  });
+
+  return { startMargin, measureStartMargin };
 };
+
+/**
+ * Value-only form, for callers that consume `startMargin` solely as virtua's
+ * prop and never scroll imperatively (Table). Prefer `useStartMarginState`
+ * when call-time accuracy matters.
+ */
+export const useStartMargin = (
+  hasOutsideScroll: boolean,
+  parentRef: MutableRefObject<HTMLElement | null | undefined>,
+  scrollRef: MutableRefObject<HTMLElement | null | undefined>,
+) => useStartMarginState(hasOutsideScroll, parentRef, scrollRef).startMargin;
 
 export function useHasExplicitHeight(parentRef: React.MutableRefObject<HTMLDivElement | null>) {
   const [hasHeight, setHasHeight] = useState(false);

--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -336,6 +336,23 @@ test.describe("Basic Functionality", () => {
     </VStack>
   `;
 
+  // Outside-scroll, plus a 200px block that appears ABOVE the list only after
+  // mount — the shape that makes the start margin go stale.
+  const revealAboveApp = (buttons: string) => `
+    <VStack var.showTop="{false}">
+      <VStack testId="scroller" height="300px" overflowY="scroll">
+        <VStack when="{showTop}" testId="above" height="200px">
+          <Text>revealed after mount</Text>
+        </VStack>
+        <List id="testList" data="${SCROLL_DATA}">
+          <Text height="30px">{$item.name}</Text>
+        </List>
+      </VStack>
+      <Button testId="reveal" label="reveal" onClick="showTop = true" />
+      ${buttons}
+    </VStack>
+  `;
+
   // The element that actually scrolls, in either mode: the only descendant
   // whose content overflows its box.
   const scrollTopOf = (page: any) =>
@@ -358,6 +375,22 @@ test.describe("Basic Functionality", () => {
       });
     }, value);
   };
+
+  // The list's offset from the top of the scrollable content, measured from the
+  // DOM independently of anything the component caches. Not the same as the
+  // revealed block's height: stack gaps count too.
+  const startMarginOf = (page: any) =>
+    page.evaluate(() => {
+      const scroller = document.querySelector('[data-testid="scroller"]') as HTMLElement;
+      const container = scroller?.querySelector("[data-list-container]") as HTMLElement;
+      const listRoot = container?.parentElement as HTMLElement;
+      if (!scroller || !listRoot) return -1;
+      return Math.round(
+        listRoot.getBoundingClientRect().top -
+          scroller.getBoundingClientRect().top +
+          scroller.scrollTop,
+      );
+    });
 
   for (const [mode, app] of [
     ["inside-scroll", insideScrollApp],
@@ -432,46 +465,76 @@ test.describe("Basic Functionality", () => {
     });
   }
 
-  // The original xmlui-org/xmlui#3760 report: content that appears ABOVE the
-  // list after mount. `useStartMargin` only recomputes on the scroll
-  // container's own resize (and its rAF retry is guarded on `newMargin === 0`),
-  // so the cached offset stays at its mount-time value and index-targeted
-  // scrolls land short by exactly the height of the new content.
+  // Content that appears ABOVE the list after mount (xmlui-org/xmlui#3765).
   //
-  // This was unreachable while the scroll APIs were inert; fixing the viewport
-  // binding exposed it. Measured: with a 200px block revealed above,
-  // scrollToIndex(50) lands at 1500 instead of 1700.
+  // Two defects had to be fixed together. virtua computes the target as
+  // `offset + $getStartSpacerSize() + $getItemOffset(index)`, so passing
+  // `offset: -startMargin` subtracted a quantity virtua adds straight back and
+  // the margin cancelled out of the sum. And $getStartSpacerSize() is not an
+  // independent measurement — it is fed from the startMargin prop, i.e. the
+  // useStartMargin cache, which never recomputes when content appears above.
+  // With a block revealed above (M, measured below — 200px of content plus the
+  // stack gap) and item 50 at 1500px within the list:
   //
-  // Note scrollToTop is NOT affected: virtua's $scrollToIndex adds
-  // store.$getStartSpacerSize() to the caller's offset, and scrollToTop passes
-  // `offset: -startMargin`, so the stale value cancels itself at index 0.
-  test.fixme(
-    "scrollToIndex accounts for content revealed above the list (outside-scroll)",
-    async ({ initTestBed, page }) => {
-      await initTestBed(`
-        <VStack var.showTop="{false}">
-          <VStack testId="scroller" height="300px" overflowY="scroll">
-            <VStack when="{showTop}" testId="above" height="200px">
-              <Text>revealed after mount</Text>
-            </VStack>
-            <List id="testList" data="${SCROLL_DATA}">
-              <Text height="30px">{$item.name}</Text>
-            </List>
-          </VStack>
-          <Button testId="reveal" label="reveal" onClick="showTop = true" />
-          <Button testId="act" label="idx" onClick="testList.scrollToIndex(50)" />
-        </VStack>
-      `);
-      await expect.poll(() => scrollTopOf(page)).toBe(0);
+  //   offset: -M_stale  ->  -0 + 0 + 1500 = 1500      (was the bug)
+  //   offset: 0, stale  ->   0 + 0 + 1500 = 1500      (offset alone: insufficient)
+  //   offset: 0, fresh  ->   0 + M + 1500 = M + 1500  (correct)
+  //
+  // Every other test here has a zero margin, where all three readings agree,
+  // which is why this survived.
+  test("scrollToIndex accounts for content revealed above the list (outside-scroll)", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(revealAboveApp(`<Button testId="act" label="idx" onClick="testList.scrollToIndex(50)" />`));
+    await expect.poll(() => scrollTopOf(page)).toBe(0);
 
-      await page.getByTestId("reveal").click();
-      await expect.poll(() => scrollTopOf(page)).toBe(0);
+    await page.getByTestId("reveal").click();
+    await expect.poll(() => scrollTopOf(page)).toBe(0);
 
-      await page.getByTestId("act").click();
-      // 200px revealed above + item 50 at 1500px within the list.
-      await expect.poll(() => scrollTopOf(page)).toBe(1700);
-    },
-  );
+    // Measured, not assumed: the block is 200px but the stack gap counts too.
+    const margin = await startMarginOf(page);
+    expect(margin).toBeGreaterThan(0);
+
+    await page.getByTestId("act").click();
+    // Item 50 sits at 50 * 30px within the list, which starts `margin` down.
+    await expect.poll(() => scrollTopOf(page)).toBe(margin + 1500);
+  });
+
+  test("scrollToId accounts for content revealed above the list (outside-scroll)", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(revealAboveApp(`<Button testId="act" label="id" onClick="testList.scrollToId('row-50')" />`));
+    await expect.poll(() => scrollTopOf(page)).toBe(0);
+
+    await page.getByTestId("reveal").click();
+    const margin = await startMarginOf(page);
+    expect(margin).toBeGreaterThan(0);
+
+    await page.getByTestId("act").click();
+    await expect.poll(() => scrollTopOf(page)).toBe(margin + 1500);
+  });
+
+  // scrollToTop and scrollToBottom deliberately KEEP their margin-carrying
+  // offsets: they mean "the scroll container to its absolute start/end", which
+  // spans the content above the list, not "row 0 to the top of the viewport".
+  // Pinned by a test so the divergence is a decision rather than an accident.
+  test("scrollToTop reaches absolute top past content revealed above (outside-scroll)", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(revealAboveApp(`<Button testId="act" label="top" onClick="testList.scrollToTop()" />`));
+    await page.getByTestId("reveal").click();
+    await expect.poll(() => scrollTopOf(page)).toBe(0);
+
+    await setScrollTop(page, 900);
+    await expect.poll(() => scrollTopOf(page)).toBe(900);
+
+    await page.getByTestId("act").click();
+    // 0, not 200: past the revealed block, not to the list's own first row.
+    await expect.poll(() => scrollTopOf(page)).toBe(0);
+  });
 
   test("shows loading state when loading is true and no data", async ({
     initTestBed,

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -31,7 +31,7 @@ import {
   useHasExplicitHeight,
   useIsomorphicLayoutEffect,
   useScrollParent,
-  useStartMargin,
+  useStartMarginState,
 } from "../../components-core/utils/hooks";
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import styles from "./List.module.scss";
@@ -1165,6 +1165,11 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     });
   });
 
+  // Every scroll API re-measures the start margin at call time rather than
+  // reading the cache, which goes stale when content appears above the list
+  // (xmlui-org/xmlui#3765). measureStartMargin() also publishes the fresh value,
+  // so virtua's startMargin prop — and therefore store.$getStartSpacerSize(),
+  // which is fed from that prop — converges on the same number.
   const scrollToBottom = useEvent(() => {
     const v = virtualizerRef.current;
     if (v && rows.length) {
@@ -1174,23 +1179,36 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
       // landing short of the settled bottom. scrollTo(scrollSize) clamps to
       // the true bottom regardless of item boundaries — the same call the
       // scrollAnchor="bottom" internals use for exactly this reason.
-      runProgrammaticScroll(() => v.scrollTo(v.scrollSize + startMargin));
+      runProgrammaticScroll(() => v.scrollTo(v.scrollSize + measureStartMargin()));
     }
   });
 
+  // scrollToTop and scrollToBottom keep their margin-carrying offsets: their
+  // intent is "the scroll container to its absolute start/end", which spans the
+  // content above the list, not "row 0 to the top of the viewport".
   const scrollToTop = useEvent(() => {
     if (rows.length) {
       runProgrammaticScroll(() =>
-        virtualizerRef.current?.scrollToIndex(0, { align: "start", offset: -startMargin }),
+        virtualizerRef.current?.scrollToIndex(0, {
+          align: "start",
+          offset: -measureStartMargin(),
+        }),
       );
     }
   });
 
+  // No offset. virtua computes `offset + $getStartSpacerSize() + $getItemOffset(index)`,
+  // so passing -startMargin subtracted a quantity virtua adds straight back —
+  // the margin cancelled out of the sum and the call targeted the item's offset
+  // WITHIN the list rather than its position in the scrollable content. Letting
+  // the spacer carry the margin exactly once is what puts the row where the
+  // caller means. The measure call is still needed: the spacer is fed from the
+  // startMargin prop, so a stale cache leaves the spacer short by the same
+  // amount that the offset used to hide.
   const scrollToIndex = useEvent((index) => {
     runProgrammaticScroll(() => {
-      virtualizerRef.current?.scrollToIndex(index, {
-        offset: -startMargin,
-      });
+      measureStartMargin();
+      virtualizerRef.current?.scrollToIndex(index);
     });
   });
 
@@ -1223,7 +1241,11 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
 
   const rowCount = rows?.length ?? 0;
 
-  const startMargin = useStartMargin(hasOutsideScroll, parentRef, scrollRef);
+  const { startMargin, measureStartMargin } = useStartMarginState(
+    hasOutsideScroll,
+    parentRef,
+    scrollRef,
+  );
 
   return (
     <ListItemTypeContext.Provider value={rowTypeContextValue}>


### PR DESCRIPTION
Closes #3765.

`scrollToIndex` and `scrollToId` land short whenever content appears above a `List` after mount. Two defects, neither fixable alone, both reachable only once virtua observes the right scroll viewport (#3764, now on `main`).

## Why neither half works alone

virtua computes a scroll target as `offset + $getStartSpacerSize() + $getItemOffset(index)`. `scrollToIndex` passed `offset: -startMargin` — subtracting a quantity virtua adds straight back, so the margin cancelled out of the sum and the call targeted the item's offset *within the list* rather than its position in the scrollable content.

And `$getStartSpacerSize()` is not an independent measurement: it is fed from the `startMargin` prop, i.e. the `useStartMargin` cache, which recomputes only on mount, on `hasOutsideScroll` change, on the scroll container's own resize, and on one rAF retry guarded by `newMargin === 0`. None of those fire when content appears above the list — the list root *moves* rather than resizes, and the ancestor scroller's box does not change when content appears inside it.

With a block of margin M revealed above, and item 50 at 1500px:

| | sum | result |
| --- | --- | --- |
| `offset: -M`, stale cache | `-0 + 0 + 1500` | 1500 — the bug |
| offset removed, stale cache | `0 + 0 + 1500` | 1500 — no better |
| offset removed, fresh measure | `0 + M + 1500` | **M + 1500 — correct** |

So both halves land together. `scrollToIndex` passes no offset, letting the spacer carry the margin exactly once, and `scrollToId` inherits it. `useStartMarginState` exposes `measureStartMargin()`, which re-measures *and publishes*, so the prop — and therefore the spacer — converges on the value the API just used. Nothing pays per render and no observer is added: the cost falls at the one moment correctness is required.

## Deliberate non-changes

`scrollToTop` and `scrollToBottom` keep their margin-carrying offsets. Their intent is "the scroll container to its absolute start/end", spanning the content above the list — not "row 0 to the top of the viewport". That divergence is now pinned by a test rather than a comment. `useStartMargin` survives as a value-only wrapper, so `TableReact.tsx` is untouched by this PR — see the parity note below.

## @dotneteer — Table has the same bug now, and this PR does not fix it

Worth flagging before review, because it was created after this branch was written and I have deliberately left it alone rather than grow a validated PR.

`2ad3a15` gave `Table` the scroll API family it previously lacked. `scrollToIndex` was **absent from `TableReact.tsx` before that commit**; the version it added is:

```ts
// TableReact.tsx:2411
virtualizerRef.current?.scrollToIndex(index, { offset: -startMargin });
```

That is the exact shape this PR removes from `List` — `offset: -startMargin` cancelling against virtua's spacer, reading `useStartMargin`, the cache that goes stale when content appears above the component. So `Table` should now reproduce #3765 wherever content appears above it after mount, which is why the issue title says "List/Table".

I scoped this PR to `List` because it is the half that has been validated downstream on a real surface; extending it to `Table` would mean new arithmetic-sensitive Table tests and an unvalidated second half riding along. The fix is mechanically the same edit: point `Table` at `useStartMarginState` and call `measureStartMargin()` in its four scroll APIs, where it currently reads the cached value.

Happy to do that as a follow-up PR, or to fold it in here if you would rather they land together — your call. Flagging rather than silently shipping a fix whose issue names both components.

## Reconciled with the newer scroll work, not landed beside it

This branch predates `2ad3a1565` / `e1798b2ae`, which introduced `runProgrammaticScroll` — the wrapper that flags a scroll as programmatic so `onScroll` does not fire for it — around the same three APIs. The rebase conflicted at four hunks, and they compose rather than collide: that work changed the *wrapper*, this changes the *arguments inside it*. Each call site now does both, e.g.

```ts
runProgrammaticScroll(() => {
  measureStartMargin();
  virtualizerRef.current?.scrollToIndex(index);
});
```

## Verification

- `List.spec.ts` **138 passed**, `Table.spec.ts` **237 passed / 0 failed** (6 flaky in Table's opening render and loading-indicator tests, green on retry, untouched here), `npm run build:xmlui-standalone` clean — all run **after** the rebase, not before it, since `main`'s new virtualization work touches these surfaces and this fix is specifically sensitive to layout ordering.
- Tests measure the margin from the DOM rather than assuming it equals the revealed block's height: an early run failed at 1716 against an asserted 1700 because the stack gap counts. The code was right and the expectation was wrong.
- Promotes the `test.fixme` left by #3764 and adds `scrollToId` and `scrollToTop` cases.

## Validated downstream

Exercised in judell/bram on a standalone carrying this fix: index-targeted reading-position restore beneath a sticky header (their natural content-above case) landed **40 of 40** with zero violations across repeated tab switches; bounded-list find-stepping confirmed the offset change is a clean no-op where the margin is zero; no regression in virtualization or follow-to-bottom. Their page-scroller pin was confirmed a design choice rather than a workaround.

## Known residual

The predicted first-scroll-after-move case — where the scheduler's closure reads the spacer before the state update lands — was **not observed in either harness**, ours or downstream's. Left unmitigated rather than pre-emptively awaiting a frame; it is timing-dependent by nature, so treat that as "not observed" rather than "cannot happen".

## Note on this issue's history

#3765 was closed as completed on 2026-08-16 while this fix was absent from `main` and had never been in a PR — collateral from tooling, not a judgment. Reopened, with the details in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
