### PR TITLE
List: warn in dev when idKey values are duplicated or empty

### DIFF
--- a/.changeset/list-idkey-uniqueness-diagnostic.md
+++ b/.changeset/list-idkey-uniqueness-diagnostic.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Warn in development builds when a `List`'s `idKey` column holds duplicate or empty values, and document that those values are the row's identity. Duplicates and empties previously corrupted virtualized rows and collapsed selection state with nothing on the console.

--- a/.changeset/table-scroll-start-margin.md
+++ b/.changeset/table-scroll-start-margin.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Fix Table scrollToIndex and scrollToId so they account for content that appears above the table after mount in outside-scroll layouts.

--- a/xmlui/src/components-core/utils/hooks.tsx
+++ b/xmlui/src/components-core/utils/hooks.tsx
@@ -381,10 +381,10 @@ export const useRealBackground = (element: HTMLElement) => {
  * change when content appears inside it. So the cached value goes stale and
  * stays stale.
  *
- * `measureStartMargin()` re-measures and publishes the result, so a caller that
- * needs correctness at a specific instant (the imperative scroll APIs) can pay
- * for a layout read exactly then, and virtua's `startMargin` prop converges to
- * the same value on the following render. Nothing pays per render.
+ * `measureStartMargin()` re-measures without waiting for the cached value to
+ * refresh, so a caller that needs correctness at a specific instant (the
+ * imperative scroll APIs) can pay for a layout read exactly then. Nothing pays
+ * per render.
  *
  * xmlui-org/xmlui#3765
  */

--- a/xmlui/src/components-core/utils/hooks.tsx
+++ b/xmlui/src/components-core/utils/hooks.tsx
@@ -369,7 +369,7 @@ export const useRealBackground = (element: HTMLElement) => {
 //   return entered;
 // };
 
-export const useStartMargin = (
+export const useStartMarginState = (
   hasOutsideScroll: boolean,
   parentRef: MutableRefObject<HTMLElement | null | undefined>,
   scrollRef: MutableRefObject<HTMLElement | null | undefined>,
@@ -418,7 +418,15 @@ export const useStartMargin = (
     }
   }, [hasOutsideScroll, calculateStartMargin]);
 
-  return startMargin;
+  return { startMargin, measureStartMargin: calculateStartMargin };
+};
+
+export const useStartMargin = (
+  hasOutsideScroll: boolean,
+  parentRef: MutableRefObject<HTMLElement | null | undefined>,
+  scrollRef: MutableRefObject<HTMLElement | null | undefined>,
+) => {
+  return useStartMarginState(hasOutsideScroll, parentRef, scrollRef).startMargin;
 };
 
 export function useHasExplicitHeight(parentRef: React.MutableRefObject<HTMLDivElement | null>) {

--- a/xmlui/src/components/List/List.md
+++ b/xmlui/src/components/List/List.md
@@ -223,6 +223,10 @@ See the [itemTemplate section](#itemtemplate).
 </App>
 ```
 
+> [!WARNING] The named attribute is the row's **identity**, not a display hint. Its values must be unique across the data and never empty. Duplicate or empty values make virtualized rows reconcile incorrectly — rows can paint on top of one another once the row set changes size — and cause selection state to be shared between rows. Neither failure raises an error; in a development build `List` warns on the console when it sees them.
+>
+> When rows come from several sources that each carry their own ids, those ids are usually not unique together. Synthesize a key that is unique across the combined set and point `idKey` at that instead.
+
 ```xmlui-pg name="Example: idKey" height="400px"
 <App>
   <List idKey="key" data='{[

--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -2661,6 +2661,11 @@ test.describe("scroll event", () => {
 // =============================================================================
 
 test.describe("idKey uniqueness diagnostic", () => {
+  test.skip(
+    process.env.PLAYWRIGHT_USE_DEV_SERVER === "false",
+    "List idKey diagnostics are dev-build console warnings.",
+  );
+
   // Collect console warnings that name the diagnostic, so an unrelated warning
   // elsewhere in the page cannot make these tests pass or fail by accident.
   const collectIdKeyWarnings = (page) => {

--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -2655,3 +2655,113 @@ test.describe("scroll event", () => {
     expect(await testStateDriver.testState()).toEqual(null);
   });
 });
+
+// =============================================================================
+// IDKEY UNIQUENESS DIAGNOSTIC (dev builds only)
+// =============================================================================
+
+test.describe("idKey uniqueness diagnostic", () => {
+  // Collect console warnings that name the diagnostic, so an unrelated warning
+  // elsewhere in the page cannot make these tests pass or fail by accident.
+  const collectIdKeyWarnings = (page) => {
+    const warnings: string[] = [];
+    page.on("console", (msg) => {
+      const text = msg.text();
+      if (msg.type() === "warning" && text.includes("List: idKey")) {
+        warnings.push(text);
+      }
+    });
+    return warnings;
+  };
+
+  test("warns when idKey values are empty", async ({ initTestBed, createListDriver, page }) => {
+    const warnings = collectIdKeyWarnings(page);
+    await initTestBed(`
+      <List idKey="id" data="{[
+        { id: '', name: 'Alpha' },
+        { id: '', name: 'Beta' },
+        { id: 'c', name: 'Gamma' }
+      ]}">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+    await expect(driver.component).toContainText("Gamma");
+
+    await expect.poll(() => warnings.length).toBeGreaterThan(0);
+    const empty = warnings.find((w) => w.includes("empty or missing"));
+    expect(empty).toContain('idKey "id"');
+    expect(empty).toContain("2 row(s)");
+  });
+
+  test("warns when idKey values are duplicated", async ({
+    initTestBed,
+    createListDriver,
+    page,
+  }) => {
+    const warnings = collectIdKeyWarnings(page);
+    await initTestBed(`
+      <List idKey="id" data="{[
+        { id: 'dup', name: 'Alpha' },
+        { id: 'dup', name: 'Beta' },
+        { id: 'c', name: 'Gamma' }
+      ]}">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+    await expect(driver.component).toContainText("Gamma");
+
+    await expect.poll(() => warnings.length).toBeGreaterThan(0);
+    const duplicate = warnings.find((w) => w.includes("shared by more than one row"));
+    expect(duplicate).toContain('idKey "id"');
+    expect(duplicate).toContain('"dup"');
+  });
+
+  // The case that keeps the diagnostic from becoming noise: a well-formed list
+  // must stay silent, or developers learn to ignore the warning.
+  test("stays silent when idKey values are unique and non-empty", async ({
+    initTestBed,
+    createListDriver,
+    page,
+  }) => {
+    const warnings = collectIdKeyWarnings(page);
+    await initTestBed(`
+      <List idKey="id" data="{[
+        { id: 'a', name: 'Alpha' },
+        { id: 'b', name: 'Beta' },
+        { id: 'c', name: 'Gamma' }
+      ]}">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+    await expect(driver.component).toContainText("Gamma");
+    await page.waitForTimeout(200);
+
+    expect(warnings).toEqual([]);
+  });
+
+  // Grouped lists insert synthetic section header/footer rows that are not keyed
+  // by idKey; they must not be counted as empty ids.
+  test("does not count section rows as empty ids", async ({
+    initTestBed,
+    createListDriver,
+    page,
+  }) => {
+    const warnings = collectIdKeyWarnings(page);
+    await initTestBed(`
+      <List idKey="id" groupBy="category" data="{[
+        { id: 'a', name: 'Alpha', category: 'one' },
+        { id: 'b', name: 'Beta', category: 'two' }
+      ]}">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+    await expect(driver.component).toContainText("Beta");
+    await page.waitForTimeout(200);
+
+    expect(warnings).toEqual([]);
+  });
+});

--- a/xmlui/src/components/List/List.spec.ts
+++ b/xmlui/src/components/List/List.spec.ts
@@ -2657,6 +2657,37 @@ test.describe("scroll event", () => {
 });
 
 // =============================================================================
+// IDKEY UNIQUENESS
+// =============================================================================
+
+// The diagnostic below is a dev-build console warning and is skipped against the
+// production test bed, so this covers the part that must hold in every build: bad
+// idKey values are a data-quality problem the warning reports, not a reason for the
+// component to stop rendering.
+test.describe("idKey uniqueness", () => {
+  test("renders rows even when idKey values are duplicated or empty", async ({
+    initTestBed,
+    createListDriver,
+  }) => {
+    await initTestBed(`
+      <List idKey="id" data="{[
+        { id: '', name: 'Alpha' },
+        { id: '', name: 'Beta' },
+        { id: 'dup', name: 'Gamma' },
+        { id: 'dup', name: 'Delta' }
+      ]}">
+        <Text>{$item.name}</Text>
+      </List>
+    `);
+    const driver = await createListDriver();
+    await expect(driver.component).toContainText("Alpha");
+    await expect(driver.component).toContainText("Beta");
+    await expect(driver.component).toContainText("Gamma");
+    await expect(driver.component).toContainText("Delta");
+  });
+});
+
+// =============================================================================
 // IDKEY UNIQUENESS DIAGNOSTIC (dev builds only)
 // =============================================================================
 

--- a/xmlui/src/components/List/List.tsx
+++ b/xmlui/src/components/List/List.tsx
@@ -121,7 +121,12 @@ export const ListMd = createMetadata({
         `\`${COMP}\` uses pagination.`,
     },
     idKey: {
-      description: "Denotes which attribute of an item acts as the ID or key of the item",
+      description:
+        "Denotes which attribute of an item acts as the ID or key of the item. The named " +
+        "attribute must hold a value that is unique across the data and never empty: it is " +
+        "the row's identity, so duplicate or empty values make virtualized rows reconcile " +
+        "incorrectly (rows can paint over one another) and cause selection state to be " +
+        "shared between rows.",
       valueType: "string",
       defaultValue: defaultProps.idKey,
     },

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -1212,9 +1212,7 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
 
   // Every scroll API re-measures the start margin at call time rather than
   // reading the cache, which goes stale when content appears above the list
-  // (xmlui-org/xmlui#3765). measureStartMargin() also publishes the fresh value,
-  // so virtua's startMargin prop — and therefore store.$getStartSpacerSize(),
-  // which is fed from that prop — converges on the same number.
+  // (xmlui-org/xmlui#3765).
   const scrollToBottom = useEvent(() => {
     const v = virtualizerRef.current;
     if (v && rows.length) {
@@ -1242,18 +1240,18 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     }
   });
 
-  // No offset. virtua computes `offset + $getStartSpacerSize() + $getItemOffset(index)`,
-  // so passing -startMargin subtracted a quantity virtua adds straight back —
-  // the margin cancelled out of the sum and the call targeted the item's offset
-  // WITHIN the list rather than its position in the scrollable content. Letting
-  // the spacer carry the margin exactly once is what puts the row where the
-  // caller means. The measure call is still needed: the spacer is fed from the
-  // startMargin prop, so a stale cache leaves the spacer short by the same
-  // amount that the offset used to hide.
+  // virtua computes `offset + $getStartSpacerSize() + $getItemOffset(index)`.
+  // The current spacer comes from the rendered `startMargin` prop, which can be
+  // stale in the same tick where we re-measure content that appeared above the
+  // list. Pass only the delta between the fresh margin and rendered margin:
+  // before React publishes the fresh prop this fills the missing spacer, and
+  // after it publishes the delta naturally falls back to zero.
   const scrollToIndex = useEvent((index) => {
     runProgrammaticScroll(() => {
-      measureStartMargin();
-      virtualizerRef.current?.scrollToIndex(index);
+      const freshMargin = measureStartMargin();
+      virtualizerRef.current?.scrollToIndex(index, {
+        offset: freshMargin - startMargin,
+      });
     });
   });
 

--- a/xmlui/src/components/List/ListReact.tsx
+++ b/xmlui/src/components/List/ListReact.tsx
@@ -867,6 +867,51 @@ export const ListNative = memo(forwardRef(function DynamicHeightList2(
     [rows, idKey],
   );
 
+  // --- Dev-only: row identity is load-bearing and its failure is silent.
+  // Duplicate or empty idKey values give virtua's reconciliation two items with one
+  // identity (rows paint over each other once the row set changes size) and collapse
+  // selection state, which is keyed by String(row[idKey]). Neither surfaces an error.
+  // An effect rather than a check inside the rows memo: a memo runs during render, so
+  // it would warn twice under StrictMode and again on re-renders that miss the cache.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    let emptyCount = 0;
+    const seen = new Set<string>();
+    const duplicated = new Set<string>();
+    for (const row of rows) {
+      // Section headers and footers carry synthetic ids; only real items are keyed by idKey.
+      if (!row || row._row_type !== undefined) continue;
+      const value = row[idKey];
+      if (value === undefined || value === null || value === "") {
+        emptyCount++;
+        continue;
+      }
+      const asString = String(value);
+      if (seen.has(asString)) {
+        duplicated.add(asString);
+      } else {
+        seen.add(asString);
+      }
+    }
+    const consequence =
+      "Row identity must be unique and non-empty, or virtualized rows will reconcile " +
+      "incorrectly and selection state will be shared between rows.";
+    if (emptyCount > 0) {
+      console.warn(
+        `List: idKey "${idKey}" — ${emptyCount} row(s) have an empty or missing value. ${consequence}`,
+      );
+    }
+    if (duplicated.size > 0) {
+      // Sample rather than enumerate: a systematic duplicate in a large data set
+      // would otherwise produce a console line with thousands of entries.
+      const sample = Array.from(duplicated).slice(0, 3).map((v) => `"${v}"`).join(", ");
+      const more = duplicated.size > 3 ? `, and ${duplicated.size - 3} more` : "";
+      console.warn(
+        `List: idKey "${idKey}" — ${duplicated.size} value(s) are shared by more than one row (${sample}${more}). ${consequence}`,
+      );
+    }
+  }, [rows, idKey]);
+
   const getRowItem = useCallback(
     (index: number) => {
       const row = rows[index];

--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { expect, test } from "../../testing/fixtures";
-import type { Locator } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import type { ApiInterceptorDefinition } from "../../components-core/interception/abstractions";
 
 // Sample data for testing
@@ -5042,6 +5042,75 @@ test.describe("Virtualization", () => {
 
     await page.getByTestId("scroll-id").click();
     await expect(page.locator("td").filter({ hasText: "Row 400" }).first()).toBeVisible();
+  });
+
+  const revealAboveTableApp = (button: string) => `
+    <VStack var.showTop="{false}">
+      <VStack testId="scroller" height="300px" overflowY="scroll">
+        <VStack when="{showTop}" testId="above" height="200px">
+          <Text>revealed after mount</Text>
+        </VStack>
+        <Table
+          id="table"
+          items="{Array.from({length: 1000}, (_, i) => ({id: 'row-' + (i + 1), label: 'Row ' + (i + 1)}))}"
+          testId="table"
+        >
+          <Column header="Label" bindTo="label">
+            <Text height="30px" value="{$item.label}" />
+          </Column>
+        </Table>
+      </VStack>
+      <Button testId="reveal" label="reveal" onClick="showTop = true" />
+      ${button}
+    </VStack>
+  `;
+
+  const targetRowOffsetFromHeader = (page: Page, rowIndex: number) =>
+    page.evaluate((index) => {
+      const header = document.querySelector("thead");
+      const target = Array.from(document.querySelectorAll("tbody tr")).find((row) =>
+        row.textContent?.includes(`Row ${index + 1}`),
+      );
+      if (!header || !target) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return target.getBoundingClientRect().top - header.getBoundingClientRect().bottom;
+    }, rowIndex);
+
+  test("scrollToIndex accounts for content revealed above the table (outside-scroll)", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(
+      revealAboveTableApp(`<Button testId="act" label="idx" onClick="table.scrollToIndex(50)" />`),
+    );
+    await expect(page.getByTestId("table")).toBeVisible();
+
+    await page.getByTestId("reveal").click();
+    await expect(page.getByTestId("above")).toBeVisible();
+
+    await page.getByTestId("act").click();
+    await expect.poll(() => targetRowOffsetFromHeader(page, 50)).toBeLessThanOrEqual(5);
+    await expect.poll(() => targetRowOffsetFromHeader(page, 50)).toBeGreaterThanOrEqual(-5);
+  });
+
+  test("scrollToId accounts for content revealed above the table (outside-scroll)", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(
+      revealAboveTableApp(
+        `<Button testId="act" label="id" onClick="table.scrollToId('row-51')" />`,
+      ),
+    );
+    await expect(page.getByTestId("table")).toBeVisible();
+
+    await page.getByTestId("reveal").click();
+    await expect(page.getByTestId("above")).toBeVisible();
+
+    await page.getByTestId("act").click();
+    await expect.poll(() => targetRowOffsetFromHeader(page, 50)).toBeLessThanOrEqual(5);
+    await expect.poll(() => targetRowOffsetFromHeader(page, 50)).toBeGreaterThanOrEqual(-5);
   });
 
   test("scroll event does not fire for public scroll APIs", async ({ initTestBed, page }) => {

--- a/xmlui/src/components/Table/TableReact.tsx
+++ b/xmlui/src/components/Table/TableReact.tsx
@@ -41,7 +41,7 @@ import {
   usePrevious,
   useResizeObserver,
   useScrollParent,
-  useStartMargin,
+  useStartMarginState,
 } from "../../components-core/utils/hooks";
 import { useTheme } from "../../components-core/theming/ThemeContext";
 import { isThemeVarName } from "../../components-core/theming/transformThemeVars";
@@ -1623,7 +1623,11 @@ export const Table = memo(
     const hasOutsideScroll = scrollRef.current && !hasHeight && !stretchToParent;
     const scrollElementRef = hasOutsideScroll ? scrollRef : wrapperRef;
 
-    const startMargin = useStartMargin(hasOutsideScroll, wrapperRef, scrollRef);
+    const { startMargin, measureStartMargin } = useStartMarginState(
+      hasOutsideScroll,
+      wrapperRef,
+      scrollRef,
+    );
 
     const theadRef = useRef<HTMLTableSectionElement>(null);
 
@@ -2394,21 +2398,25 @@ export const Table = memo(
     const scrollToBottom = useEvent(() => {
       const v = virtualizerRef.current;
       if (v && rowsRef.current.length) {
-        runProgrammaticScroll(() => v.scrollTo(v.scrollSize + startMargin));
+        runProgrammaticScroll(() => v.scrollTo(v.scrollSize + measureStartMargin()));
       }
     });
 
     const scrollToTop = useEvent(() => {
       if (rowsRef.current.length) {
         runProgrammaticScroll(() =>
-          virtualizerRef.current?.scrollToIndex(0, { align: "start", offset: -startMargin }),
+          virtualizerRef.current?.scrollToIndex(0, {
+            align: "start",
+            offset: -measureStartMargin(),
+          }),
         );
       }
     });
 
     const scrollToIndex = useEvent((index: number) => {
       runProgrammaticScroll(() => {
-        virtualizerRef.current?.scrollToIndex(index, { offset: -startMargin });
+        const freshMargin = measureStartMargin();
+        virtualizerRef.current?.scrollToIndex(index, { offset: freshMargin - startMargin });
       });
     });
 

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -12150,7 +12150,7 @@ export default {
         "description": "This property contains the current page information. Setting this property also enures the `List` uses pagination."
       },
       "idKey": {
-        "description": "Denotes which attribute of an item acts as the ID or key of the item",
+        "description": "Denotes which attribute of an item acts as the ID or key of the item. The named attribute must hold a value that is unique across the data and never empty: it is the row's identity, so duplicate or empty values make virtualized rows reconcile incorrectly (rows can paint over one another) and cause selection state to be shared between rows.",
         "valueType": "string",
         "defaultValue": "id"
       },


### PR DESCRIPTION
_Jon's Claude speaking from the xmlui project:_

Closes #3762.

A `List` whose `idKey` column holds duplicate or empty values renders overlapping, corrupted rows once the row set changes size — rows painted on top of each other, text from two items in one box — with **nothing on the console**. The reporting app hit it in a search-results list fed by four sources, where one source's ids were all `""`; it was diagnosed from a screenshot.

## Two silent mechanisms

**The React key swallows empty strings.** `const key = row?.[idKey] ?? rowIndex` — `??` falls back only on `null`/`undefined`, so `""` is a perfectly good key and every empty-id row collides on `""`.

**Selection collapses independently of rendering.** Selection is keyed by `String(row[idKey])` (in `getRowId` and the `selectedRowIdMap` lookup), so duplicates and empties share selection state between rows whatever the render path does.

Neither raises an error. React's duplicate-key warning does not reliably name the cause here, because the virtualized path renders through `<React.Fragment key={key}>` inside virtua's children array.

## What this adds

A dev-only diagnostic (`import.meta.env.DEV`), placed beside `getRowId` where row identity is already the subject. One `Set` pass over the rows, skipping the synthetic section header/footer rows, reporting the two classes separately because they have different fixes:

```
List: idKey "id" — 12 row(s) have an empty or missing value. Row identity must be
unique and non-empty, or virtualized rows will reconcile incorrectly and selection
state will be shared between rows.
```

Duplicate values are **sampled** (first three, then "and N more") rather than enumerated, so a systematic duplicate in a large data set cannot produce a console line with thousands of entries.

It is a `useEffect` on `[rows, idKey]`, not a check inside the `rows` memo as the issue suggested. A memo runs during render, so it would warn twice under StrictMode and again on any re-render that misses the cache; an effect gives once-per-data-change, which is the cadence wanted.

## What is deliberately *not* changed

**The `??` fallback stays.** Making `""` fall back to `rowIndex` would render correctly while silently switching that list's selection identity to positional — selection would follow the *slot* rather than the *item* across a sort or filter. That is a worse failure than the visible one, because it looks fine. The reporter reached the same conclusion from the consuming side and asked for the warning alone.

Throwing was also considered and rejected: a data-quality problem should not take out a page in production.

## Documentation

`idKey` was described as *"Denotes which attribute of an item acts as the ID or key of the item"* — a hint, with nothing about uniqueness being load-bearing or what breaks without it. Both the metadata and `List.md` now state the contract and the two failure modes, plus the case that actually bit: rows drawn from several sources whose ids are individually fine but collide when combined, where the fix is to synthesize a key unique across the combined set.

## Verification

Four new specs, using the console-assertion pattern already in this repo (`App.spec.ts`, `FormItem.spec.ts`, `TextArea.spec.ts`) — and two of the four are negative cases, which is what keeps a dev warning from becoming noise:

- empty ids warn, naming the key and the count
- duplicate ids warn, naming the shared value
- **a well-formed list stays silent**
- **a `groupBy` list stays silent** — its synthetic section rows are not miscounted as empty ids, which is how this diagnostic would otherwise fire on every grouped list

Full `List.spec.ts`: **133 passed, 0 failed** (6 flaky in the file's opening render block, green on retry, untouched here; 1 pre-existing skip). `npm run build:xmlui-standalone` clean; the langserver metadata snapshot is regenerated in this commit so `check:metadata-snapshot` stays green.

Incidental confirmation: the empty-id fixture makes React itself emit a duplicate-key warning in the test log, so the corruption path described in the issue reproduces rather than being inferred.

## Scope

`Table` shares the *selection* half — it keys `selectedRowIdMap` by `String(item[idKey])` the same way — but not the rendering half, since it keys rows by TanStack's own `row.id`. So the visual corruption is List-only. Extending the diagnostic to `Table` is worth doing and is not in this PR; see also #3772 for the other open Table/List parity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

