### PR TITLE
Markdown: write the needle-key separator as an escape, not a raw NUL byte

### DIFF
--- a/xmlui/src/components/Markdown/MarkdownReact.tsx
+++ b/xmlui/src/components/Markdown/MarkdownReact.tsx
@@ -425,7 +425,7 @@ export const Markdown = memo(
     // Stable dependency key: an inline array prop is a new reference every render,
     // so memoize on the joined needle text rather than the array identity.
     const needleKey = Array.isArray(highlightText)
-      ? highlightText.join(" ")
+      ? highlightText.join("\u0000")
       : highlightText ?? "";
     const needles = useMemo(() => normalizeNeedles(highlightText), [needleKey]);
     const rehypePlugins = useMemo(


### PR DESCRIPTION
_Jon's Claude speaking from the xmlui project:_

One character, no behavior change — but it fixes a silent tooling failure in a file people grep.

## The problem

`MarkdownReact.tsx` joined highlight needles on a **literal 0x00 byte** to build a memo key:

```ts
const needleKey = Array.isArray(highlightText)
  ? highlightText.join("<a raw NUL byte here>")
  : highlightText ?? "";
```

The intent is right — a separator that cannot occur inside a search term. The problem is that it was written as a raw byte rather than an escape, so the source file contains a NUL, and `file` reports the module as `data` rather than text.

## Why that matters

`grep` treats the file as binary and, with ordinary flags, prints **nothing at all**. Not "no matches", not the usual `Binary file … matches` line — nothing, exit 1. That is indistinguishable from a true negative.

It is not a hypothetical cost. While researching #3761 I ran `grep -n "highlight" MarkdownReact.tsx`, got silence, and concluded the highlight engine was not in this file — while `normalizeNeedles` is at line 135 and `makeHighlightPlugin` at line 165. The error was caught only because `git grep` (which does not apply the same heuristic to blobs) contradicted it, and `sed -n '135,142p'` printed the code plainly. `grep -a` returns the expected 10 matches.

Anyone grepping this module — human or agent — gets the same false negative, in the shape that is hardest to notice.

## The change

`"\^@"` instead of the raw byte. Identical character at runtime, so the memo key and its `useMemo` dependency semantics are untouched; the file is text again and greps normally.

## Verification

- `file xmlui/src/components/Markdown/MarkdownReact.tsx` → `Java source, Unicode text, UTF-8 text` (was `data`)
- `grep -c highlightText …` → `10`, with no `-a`
- `Markdown.spec.ts` — **79 passed, 0 failed**, including the `highlightText` suite that exercises this memo key
- `npm run build:xmlui-standalone` clean

No changeset: nothing user-visible changes. Happy to add a patch changeset if the release tooling wants one.

Kept deliberately as its own PR rather than folded into the #3761 work that found it, so it can merge on its own and so a revert of that larger change would not take this with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

