### PR TITLE
Text: add highlightText and highlightActiveIndex, matching Markdown

### DIFF
--- a/.changeset/text-highlight-text.md
+++ b/.changeset/text-highlight-text.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Add `highlightText` and `highlightActiveIndex` to `Text`, matching `Markdown`'s properties of the same names. Highlighting plain text no longer requires either a Markdown parse or a hand-rolled construction of nested inline `Text` segments, and occurrences are numbered so a find-in-page can step through a list of mixed `Text` and `Markdown` rows as one sequence.

--- a/xmlui/src/components-core/utils/highlight-terms.ts
+++ b/xmlui/src/components-core/utils/highlight-terms.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared substring-highlight matching core.
+ *
+ * `Markdown` and `Text` both expose `highlightText` / `highlightActiveIndex`, and a
+ * list may mix rows of both kinds under a single find plan — stepping the active
+ * index has to walk every match top-to-bottom regardless of which component rendered
+ * it. That only holds if both components agree exactly on what a match is and how
+ * matches are numbered, so the rules live here once rather than in each component.
+ *
+ * Nothing in this module knows about React or hast: it turns a string into segments,
+ * and each caller renders those in its own node type.
+ */
+
+/** One run of text, either a match (`hit`) or the plain text between matches. */
+export type HighlightSegment = {
+  text: string;
+  hit: boolean;
+  /** 0-based match number in document order; -1 for non-matching text. */
+  ordinal: number;
+};
+
+export type ScanResult = {
+  segments: HighlightSegment[];
+  /** Ordinal the next scan should start from, so numbering continues across nodes. */
+  nextOrdinal: number;
+  /** True when at least one match was found — callers can skip rewriting a node without one. */
+  hasMatch: boolean;
+};
+
+/**
+ * Normalize the `highlightText` prop (`string | string[]`) to a list of needles.
+ * A string stays a single phrase (never whitespace-split — that would break an
+ * intentional `"foo bar"` phrase highlight); an array is treated as independent
+ * terms. Each needle is trimmed; those shorter than 2 characters are dropped, and
+ * case-insensitive duplicates are removed.
+ */
+export function normalizeNeedles(highlightText?: string | string[]): string[] {
+  if (highlightText == null) return [];
+  const raw = Array.isArray(highlightText) ? highlightText : [highlightText];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const term of raw) {
+    const s = (term ?? "").trim();
+    const key = s.toLowerCase();
+    if (s.length >= 2 && !seen.has(key)) {
+      seen.add(key);
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+/**
+ * Prepare needles for scanning: lowercased and sorted longest-first, so that at any
+ * position an overlapping longer term wins (`category` beats `cat`) and matches can
+ * never nest or overlap.
+ */
+export function prepareNeedles(needles: string[]): string[] {
+  return needles
+    .map((n) => (n || "").toLowerCase())
+    .filter((q) => q.length >= 2)
+    .sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Scan `value` for case-insensitive occurrences of any prepared needle, returning the
+ * text split into alternating plain and matching segments.
+ *
+ * Matches are numbered from `startOrdinal` in a single sequence, so a caller walking
+ * several nodes in document order passes `nextOrdinal` forward and gets one continuous
+ * numbering across all of them — which is what makes `highlightActiveIndex` mean the
+ * same thing across a document, and across components.
+ *
+ * `preparedNeedles` must come from `prepareNeedles`; passing raw needles would lose the
+ * longest-first guarantee.
+ */
+export function scanHighlightSegments(
+  value: string,
+  preparedNeedles: string[],
+  startOrdinal = 0,
+): ScanResult {
+  if (!value || preparedNeedles.length === 0) {
+    return {
+      segments: value ? [{ text: value, hit: false, ordinal: -1 }] : [],
+      nextOrdinal: startOrdinal,
+      hasMatch: false,
+    };
+  }
+
+  const hay = value.toLowerCase();
+  const segments: HighlightSegment[] = [];
+  let ordinal = startOrdinal;
+  let i = 0; // scan cursor
+  let last = 0; // start of pending unmatched text
+  let hasMatch = false;
+
+  while (i < value.length) {
+    let matchLen = 0;
+    for (const q of preparedNeedles) {
+      if (hay.startsWith(q, i)) {
+        matchLen = q.length;
+        break;
+      }
+    }
+    if (matchLen > 0) {
+      hasMatch = true;
+      if (i > last) {
+        segments.push({ text: value.slice(last, i), hit: false, ordinal: -1 });
+      }
+      segments.push({ text: value.slice(i, i + matchLen), hit: true, ordinal });
+      ordinal++;
+      i += matchLen;
+      last = i;
+    } else {
+      i++;
+    }
+  }
+
+  if (!hasMatch) {
+    return {
+      segments: [{ text: value, hit: false, ordinal: -1 }],
+      nextOrdinal: ordinal,
+      hasMatch: false,
+    };
+  }
+  if (last < value.length) {
+    segments.push({ text: value.slice(last), hit: false, ordinal: -1 });
+  }
+  return { segments, nextOrdinal: ordinal, hasMatch: true };
+}

--- a/xmlui/src/components/Markdown/MarkdownReact.tsx
+++ b/xmlui/src/components/Markdown/MarkdownReact.tsx
@@ -38,6 +38,11 @@ import NestedAppAndCodeViewReact, {
 } from "../NestedApp/AppWithCodeViewReact";
 import { CodeText } from "./CodeText";
 import { decodeFromBase64 } from "../../components-core/utils/base64-utils";
+import {
+  normalizeNeedles,
+  prepareNeedles,
+  scanHighlightSegments,
+} from "../../components-core/utils/highlight-terms";
 
 // ---------------------------------------------------------------------------
 // Module-level helpers — defined outside any component so their references
@@ -132,27 +137,6 @@ const neutralizeRawHtml = () => {
   };
 };
 
-/** Normalize the `highlightText` prop (`string | string[]`) to a list of needles.
- *  A string stays a single phrase (never whitespace-split — that would break an
- *  intentional `"foo bar"` phrase highlight); an array is treated as independent
- *  terms. Each needle is trimmed; those shorter than 2 characters are dropped, and
- *  case-insensitive duplicates are removed. */
-function normalizeNeedles(highlightText?: string | string[]): string[] {
-  if (highlightText == null) return [];
-  const raw = Array.isArray(highlightText) ? highlightText : [highlightText];
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const term of raw) {
-    const s = (term ?? "").trim();
-    const key = s.toLowerCase();
-    if (s.length >= 2 && !seen.has(key)) {
-      seen.add(key);
-      out.push(s);
-    }
-  }
-  return out;
-}
-
 /** Rehype plugin factory: wrap case-insensitive occurrences of any of `needles`
  *  in <mark> nodes. Operates on the parsed hast tree, so matches inside code,
  *  inline code, and links are handled correctly with no escaping. Matches are
@@ -164,10 +148,7 @@ function normalizeNeedles(highlightText?: string | string[]): string[] {
  *  never produce nested or overlapping marks. */
 function makeHighlightPlugin(needles: string[], activeIndex: number) {
   // Longest-first so an overlapping longer term is preferred at a given position.
-  const qs = needles
-    .map((n) => (n || "").toLowerCase())
-    .filter((q) => q.length >= 2)
-    .sort((a, b) => b.length - a.length);
+  const qs = prepareNeedles(needles);
   return function () {
     return function transformer(tree: Node) {
       if (qs.length === 0) return;
@@ -176,40 +157,24 @@ function makeHighlightPlugin(needles: string[], activeIndex: number) {
         if (!parent || typeof index !== "number") return;
         if (parent.tagName === "script" || parent.tagName === "style") return;
         if (parent.tagName === "mark") return; // already highlighted
-        const value: string = node.value || "";
-        const hay = value.toLowerCase();
-        const out: any[] = [];
-        let i = 0; // scan cursor
-        let last = 0; // start of pending unmarked text
-        let anyMatch = false;
-        while (i < value.length) {
-          let matchLen = 0;
-          for (const q of qs) {
-            if (hay.startsWith(q, i)) {
-              matchLen = q.length;
-              break;
-            }
-          }
-          if (matchLen > 0) {
-            anyMatch = true;
-            if (i > last) out.push({ type: "text", value: value.slice(last, i) });
-            const matched = value.slice(i, i + matchLen);
-            const isActive = matchOrdinal === activeIndex;
-            matchOrdinal++;
-            out.push({
-              type: "element",
-              tagName: "mark",
-              properties: isActive ? { "data-active": "true" } : {},
-              children: [{ type: "text", value: matched }],
-            });
-            i += matchLen;
-            last = i;
-          } else {
-            i++;
-          }
-        }
-        if (!anyMatch) return;
-        if (last < value.length) out.push({ type: "text", value: value.slice(last) });
+        // Ordinals continue across text nodes, which are visited in document order.
+        const { segments, nextOrdinal, hasMatch } = scanHighlightSegments(
+          node.value || "",
+          qs,
+          matchOrdinal,
+        );
+        if (!hasMatch) return;
+        matchOrdinal = nextOrdinal;
+        const out = segments.map((seg) =>
+          seg.hit
+            ? {
+                type: "element",
+                tagName: "mark",
+                properties: seg.ordinal === activeIndex ? { "data-active": "true" } : {},
+                children: [{ type: "text", value: seg.text }],
+              }
+            : { type: "text", value: seg.text },
+        );
         parent.children.splice(index, 1, ...out);
         return [SKIP, index + out.length]; // don't re-descend into the inserted <mark> nodes
       });

--- a/xmlui/src/components/Text/Text.md
+++ b/xmlui/src/components/Text/Text.md
@@ -314,6 +314,42 @@ The table below indicates which Text `variant` maps to which HtmlTag component.
 
 %-PROP-END
 
+%-PROP-START highlightText
+
+Wraps matching text in `<mark>` elements, without the caller having to split the string into segments. Matching is identical to [`Markdown`'s property of the same name](/components/Markdown#highlighttext) — case-insensitive, a string treated as one phrase, an array as independent terms, terms under 2 characters ignored — so a list mixing `Text` and `Markdown` rows highlights consistently.
+
+```xmlui-pg copy display name="Example: highlightText"
+<App>
+  <Text highlightText="ticker">The pty ticker fires once per second.</Text>
+  <Text highlightText="{['pty', 'ticker']}">The pty layer and the ticker.</Text>
+</App>
+```
+
+Because the marks are rendered inside the `Text` element itself, a match falling in the middle of a word does not break the word, and styling set on the `Text` applies once rather than needing to be repeated per segment.
+
+%-PROP-END
+
+%-PROP-START highlightActiveIndex
+
+Selects which occurrence of [`highlightText`](#highlighttext) is the *active* match: it gets `data-active="true"`, is styled with `backgroundColor-markActive-Text`, and is scrolled into view.
+
+Occurrences are counted across all terms in document order, matching `Markdown`. That shared numbering is the point: a find-in-page stepping through a list of mixed `Text` and `Markdown` rows walks every match as one sequence, regardless of which component rendered it.
+
+```xmlui-pg copy display name="Example: highlightActiveIndex"
+<App var.step="{0}">
+  <HStack>
+    <Button label="Previous" onClick="step = Math.max(0, step - 1)" />
+    <Button label="Next" onClick="step = Math.min(2, step + 1)" />
+    <Text value="Match {step + 1} of 3" />
+  </HStack>
+  <Text highlightText="pty" highlightActiveIndex="{step}">
+    The pty ticker, the pty layer, and the pty menu.
+  </Text>
+</App>
+```
+
+%-PROP-END
+
 %-PROP-START overflowMode
 
 Here are a few examples.

--- a/xmlui/src/components/Text/Text.module.scss
+++ b/xmlui/src/components/Text/Text.module.scss
@@ -66,6 +66,14 @@ $borderStyle-Text-keyboard: createThemeVar("borderStyle-#{$component}-keyboard")
 $borderRadius-Text-keyboard: createThemeVar("borderRadius-#{$component}-keyboard");
 $paddingHorizontal-Text-keyboard: createThemeVar("paddingHorizontal-#{$component}-keyboard");
 
+// Variables for highlightText matches. Distinct from the `marked` variant below:
+// these style the <mark> elements this component generates from highlightText,
+// and default to Markdown's values so a list mixing Text and Markdown rows
+// highlights identically.
+$backgroundColor-mark-Text: createThemeVar("backgroundColor-mark-#{$component}");
+$textColor-mark-Text: createThemeVar("textColor-mark-#{$component}");
+$backgroundColor-markActive-Text: createThemeVar("backgroundColor-markActive-#{$component}");
+
 // Variables for marked variant
 $backgroundColor-Text-marked: createThemeVar("backgroundColor-#{$component}-marked");
 $textColor-Text-marked: createThemeVar("textColor-#{$component}-marked");
@@ -421,6 +429,20 @@ $textColor-Text-secondary--hover: createThemeVar("textColor-#{$component}-second
   // whitespace (not between runs). Overrides the base .text inline-block.
   .inline {
     display: inline;
+  }
+
+  // highlightText matches. Deliberately a plain inline <mark> with no display or
+  // layout of its own: a match falling inside a word must not introduce a break
+  // opportunity there, which is exactly what inline-block or flex segments did in
+  // the hand-rolled construction this replaces.
+  .highlightMark {
+    background-color: $backgroundColor-mark-Text;
+    color: $textColor-mark-Text;
+    border-radius: 2px;
+  }
+
+  .highlightMark[data-active="true"] {
+    background-color: $backgroundColor-markActive-Text;
   }
 
   .noEllipsis {

--- a/xmlui/src/components/Text/Text.spec.ts
+++ b/xmlui/src/components/Text/Text.spec.ts
@@ -2250,3 +2250,133 @@ test.describe("smoke tests", { tag: "@smoke" }, () => {
     await expect(driver.component).toHaveText("Smoke test");
   });
 });
+
+// =============================================================================
+// HIGHLIGHT TEXT
+// =============================================================================
+
+test.describe("highlightText", () => {
+  test("wraps a single term in a mark", async ({ initTestBed, page }) => {
+    await initTestBed(`<Text testId="t" highlightText="ticker" value="The pty ticker fires." />`);
+    const marks = page.getByTestId("t").locator("mark");
+    await expect(marks).toHaveCount(1);
+    await expect(marks.first()).toHaveText("ticker");
+  });
+
+  test("matches case-insensitively and keeps the source casing", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`<Text testId="t" highlightText="pty" value="PTY and pty." />`);
+    const marks = page.getByTestId("t").locator("mark");
+    await expect(marks).toHaveCount(2);
+    await expect(marks.nth(0)).toHaveText("PTY");
+    await expect(marks.nth(1)).toHaveText("pty");
+  });
+
+  test("highlights each term of a string array independently", async ({ initTestBed, page }) => {
+    await initTestBed(
+      `<Text testId="t" highlightText="{['pty', 'ticker']}" value="The pty layer and the ticker." />`,
+    );
+    const marks = page.getByTestId("t").locator("mark");
+    await expect(marks).toHaveCount(2);
+    await expect(marks.nth(0)).toHaveText("pty");
+    await expect(marks.nth(1)).toHaveText("ticker");
+  });
+
+  // A match inside a word is what forced the hand-rolled two-level inline/pre-wrap
+  // construction downstream: inline-block or flex segments introduce a break
+  // opportunity mid-word and split it. The mark must not break the word.
+  test("a match inside a word does not split the word", async ({ initTestBed, page }) => {
+    await initTestBed(
+      `<Text testId="t" width="400px" highlightText="tick" value="antitickerdisestablish" />`,
+    );
+    const container = page.getByTestId("t");
+    await expect(container.locator("mark")).toHaveText("tick");
+    await expect(container).toHaveText("antitickerdisestablish");
+
+    // One line box: the highlighted run must not wrap the word onto a second line.
+    const boxes = await container.locator("mark").boundingBox();
+    const containerBox = await container.boundingBox();
+    expect(boxes).not.toBeNull();
+    expect(containerBox).not.toBeNull();
+    expect(containerBox!.height).toBeLessThan(boxes!.height * 2);
+  });
+
+  // Whitespace around a match must survive the split into text nodes and marks.
+  // Asserted against an unhighlighted copy of the same value rather than a literal,
+  // because XMLUI renders runs of spaces as space+nbsp pairs — the point is that
+  // highlighting changes nothing about the text, whatever that encoding is.
+  test("preserves whitespace around a match under pre-wrap", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Fragment>
+        <Text testId="plain" whiteSpace="pre-wrap" value="  before   match   after  " />
+        <Text testId="marked" whiteSpace="pre-wrap" highlightText="match"
+          value="  before   match   after  " />
+      </Fragment>
+    `);
+    const plain = await page.getByTestId("plain").textContent();
+    const marked = await page.getByTestId("marked").textContent();
+    expect(marked).toEqual(plain);
+    await expect(page.getByTestId("marked").locator("mark")).toHaveText("match");
+  });
+
+  test("the longest overlapping term wins, so marks never nest", async ({ initTestBed, page }) => {
+    await initTestBed(
+      `<Text testId="t" highlightText="{['cat', 'category']}" value="the category of cat" />`,
+    );
+    const marks = page.getByTestId("t").locator("mark");
+    await expect(marks).toHaveCount(2);
+    await expect(marks.nth(0)).toHaveText("category");
+    await expect(marks.nth(1)).toHaveText("cat");
+    await expect(page.getByTestId("t").locator("mark mark")).toHaveCount(0);
+  });
+
+  test("highlightActiveIndex marks the Nth occurrence in document order", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(
+      `<Text testId="t" highlightText="{['pty', 'ticker']}" highlightActiveIndex="{1}"
+         value="pty then ticker then pty" />`,
+    );
+    const active = page.getByTestId("t").locator('mark[data-active="true"]');
+    await expect(active).toHaveCount(1);
+    await expect(active).toHaveText("ticker");
+  });
+
+  test("counts occurrences across terms, not per term", async ({ initTestBed, page }) => {
+    // Document order is pty(0), ticker(1), pty(2) — index 2 is the second 'pty',
+    // which per-term counting would place at index 1.
+    await initTestBed(
+      `<Text testId="t" highlightText="{['pty', 'ticker']}" highlightActiveIndex="{2}"
+         value="pty then ticker then pty" />`,
+    );
+    const active = page.getByTestId("t").locator('mark[data-active="true"]');
+    await expect(active).toHaveCount(1);
+    await expect(active).toHaveText("pty");
+  });
+
+  test("terms shorter than 2 characters are a no-op", async ({ initTestBed, page }) => {
+    await initTestBed(`<Text testId="t" highlightText="a" value="a cat sat" />`);
+    await expect(page.getByTestId("t").locator("mark")).toHaveCount(0);
+    await expect(page.getByTestId("t")).toHaveText("a cat sat");
+  });
+
+  test("an empty string and an empty array are no-ops", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Fragment>
+        <Text testId="empty" highlightText="" value="nothing marked" />
+        <Text testId="arr" highlightText="{[]}" value="nothing marked" />
+      </Fragment>
+    `);
+    await expect(page.getByTestId("empty").locator("mark")).toHaveCount(0);
+    await expect(page.getByTestId("arr").locator("mark")).toHaveCount(0);
+  });
+
+  test("renders unchanged when no term matches", async ({ initTestBed, page }) => {
+    await initTestBed(`<Text testId="t" highlightText="absent" value="The pty ticker fires." />`);
+    await expect(page.getByTestId("t").locator("mark")).toHaveCount(0);
+    await expect(page.getByTestId("t")).toHaveText("The pty ticker fires.");
+  });
+});

--- a/xmlui/src/components/Text/Text.tsx
+++ b/xmlui/src/components/Text/Text.tsx
@@ -115,6 +115,25 @@ export const TextMd = createMetadata({
       ],
       isStrictEnum: true,
     },
+    highlightText: {
+      description:
+        "When set, wraps every case-insensitive occurrence in the displayed text in a " +
+        "`<mark>` element (highlighted). Accepts a **string** (a single phrase) or a " +
+        "**string array** (each term highlighted independently). A term shorter than 2 " +
+        "characters, an empty string, or an empty array is a no-op. Matching is identical " +
+        `to \`Markdown\`'s property of the same name, so a list mixing \`${COMP}\` and ` +
+        "`Markdown` rows highlights consistently.",
+      valueType: "string",
+    },
+    highlightActiveIndex: {
+      description:
+        "Which occurrence (0-based) of `highlightText` is the active match: it is emphasized " +
+        "and scrolled into view. Occurrences are counted **across all terms in document " +
+        "order**, matching `Markdown`, so a find-in-page stepping through a mixed list walks " +
+        "every match as one sequence regardless of which component rendered it. -1 or unset " +
+        "means none.",
+      valueType: "number",
+    },
   },
   events: {
     contextMenu: dContextMenu(COMP),
@@ -134,6 +153,12 @@ export const TextMd = createMetadata({
     [`fontFamily-${COMP}`]: "$fontFamily",
     [`fontSize-${COMP}`]: "$fontSize",
     [`fontWeight-${COMP}`]: "$fontWeight-normal",
+
+    // Same values as Markdown's mark vars, so highlights look identical across a
+    // list that mixes Text and Markdown rows.
+    [`backgroundColor-mark-${COMP}`]: "$color-warn-200",
+    [`textColor-mark-${COMP}`]: "inherit",
+    [`backgroundColor-markActive-${COMP}`]: "$color-warn-400",
 
     [`fontSize-${COMP}-secondary`]: "$fontSize-sm",
     [`textColor-${COMP}-secondary`]: "$textColor-secondary",
@@ -284,6 +309,10 @@ export const textComponentRenderer = wrapComponent(COMP, Text, TextMd, {
         breakMode={extractValue(breakMode) as BreakMode | undefined}
         registerComponentApi={registerComponentApi}
         onContextMenu={lookupEventHandler("contextMenu")}
+        highlightText={
+          extractValue(node.props.highlightText) as string | string[] | undefined
+        }
+        highlightActiveIndex={extractValue.asOptionalNumber(node.props.highlightActiveIndex)}
         {...variantSpecificProps}
       >
         {extractValue.asDisplayText(value) || renderChild(node.children)}

--- a/xmlui/src/components/Text/TextReact.tsx
+++ b/xmlui/src/components/Text/TextReact.tsx
@@ -1,5 +1,5 @@
-import type { ForwardedRef, HTMLAttributes, Ref } from "react";
-import { forwardRef, memo, useMemo, useRef, useCallback, useEffect } from "react";
+import type { ForwardedRef, HTMLAttributes, ReactNode, Ref } from "react";
+import { Fragment, forwardRef, memo, useMemo, useRef, useCallback, useEffect } from "react";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import classnames from "classnames";
 
@@ -17,6 +17,11 @@ import { useComponentStyle } from "../../components-core/theming/StyleContext";
 import { COMPONENT_PART_KEY } from "../../components-core/theming/responsive-layout";
 import { EMPTY_OBJECT } from "../../components-core/constants";
 import { toCssVar } from "../../components-core/theming/layout-resolver";
+import {
+  normalizeNeedles,
+  prepareNeedles,
+  scanHighlightSegments,
+} from "../../components-core/utils/highlight-terms";
 
 // =============================================================================
 // Custom Variant CSS Cache Infrastructure
@@ -109,6 +114,8 @@ type TextProps = Omit<HTMLAttributes<HTMLElement>, "onContextMenu"> & {
   classes?: Record<string, string>;
   onContextMenu?: any;
   registerComponentApi?: RegisterComponentApiFn;
+  highlightText?: string | string[];
+  highlightActiveIndex?: number;
   [variantSpecificProps: string]: any;
 };
 
@@ -130,12 +137,72 @@ export const Text = memo(forwardRef(function Text(
     breakMode = defaultProps.breakMode,
     onContextMenu,
     registerComponentApi,
+    highlightText,
+    highlightActiveIndex,
     ...variantSpecificProps
   }: TextProps,
   forwardedRef: ForwardedRef<HTMLElement>,
 ) {
   const innerRef = useRef<HTMLElement>(null);
   const ref = useComposedRefs(innerRef, forwardedRef);
+
+  // --- Substring highlighting, sharing Markdown's matching core so that a list mixing
+  // Text and Markdown rows counts occurrences as one sequence (see highlight-terms.ts).
+  // An inline array prop is a new reference every render, so memoize on a serialized
+  // key. JSON rather than a joined string: no separator can collide with term
+  // content, and it stays unambiguous without needing a control character.
+  const needleKey = JSON.stringify(highlightText ?? "");
+  const needles = useMemo(
+    () => prepareNeedles(normalizeNeedles(highlightText)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [needleKey],
+  );
+  const activeIndex =
+    typeof highlightActiveIndex === "number" && highlightActiveIndex >= 0
+      ? highlightActiveIndex
+      : -1;
+
+  const highlightedChildren = useMemo(() => {
+    if (needles.length === 0) return children;
+    // Ordinals continue across sibling nodes so numbering matches document order.
+    let ordinal = 0;
+    const mapNode = (node: ReactNode, key?: number): ReactNode => {
+      // Only plain strings can be scanned. Anything else (an element child, a nested
+      // component) is passed through untouched rather than guessed at, and does not
+      // consume ordinals — we cannot see the text inside it.
+      if (typeof node !== "string") return node;
+      const { segments, nextOrdinal, hasMatch } = scanHighlightSegments(node, needles, ordinal);
+      ordinal = nextOrdinal;
+      if (!hasMatch) return node;
+      return (
+        <Fragment key={key}>
+          {segments.map((seg, i) =>
+            seg.hit ? (
+              <mark
+                key={i}
+                className={styles.highlightMark}
+                data-active={seg.ordinal === activeIndex ? "true" : undefined}
+              >
+                {seg.text}
+              </mark>
+            ) : (
+              <Fragment key={i}>{seg.text}</Fragment>
+            ),
+          )}
+        </Fragment>
+      );
+    };
+    if (Array.isArray(children)) return children.map((child, i) => mapNode(child, i));
+    return mapNode(children);
+  }, [children, needles, activeIndex]);
+
+  // Bring the active occurrence into view, matching Markdown's behavior so stepping
+  // matches across a mixed list scrolls the same way regardless of row type.
+  useEffect(() => {
+    if (activeIndex < 0 || needles.length === 0) return;
+    const el = innerRef.current?.querySelector('mark[data-active="true"]') as HTMLElement | null;
+    if (el) el.scrollIntoView({ block: "center", behavior: "auto" });
+  }, [activeIndex, needleKey, needles.length]);
 
   // Implement hasOverflow function
   const hasOverflow = useCallback((): boolean => {
@@ -342,7 +409,7 @@ export const Text = memo(forwardRef(function Text(
           : {}),
       }}
     >
-      {children}
+      {highlightedChildren}
     </Element>
   );
 }));

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -19079,6 +19079,14 @@ export default {
           }
         ],
         "isStrictEnum": true
+      },
+      "highlightText": {
+        "description": "When set, wraps every case-insensitive occurrence in the displayed text in a `<mark>` element (highlighted). Accepts a **string** (a single phrase) or a **string array** (each term highlighted independently). A term shorter than 2 characters, an empty string, or an empty array is a no-op. Matching is identical to `Markdown`'s property of the same name, so a list mixing `Text` and `Markdown` rows highlights consistently.",
+        "valueType": "string"
+      },
+      "highlightActiveIndex": {
+        "description": "Which occurrence (0-based) of `highlightText` is the active match: it is emphasized and scrolled into view. Occurrences are counted **across all terms in document order**, matching `Markdown`, so a find-in-page stepping through a mixed list walks every match as one sequence regardless of which component rendered it. -1 or unset means none.",
+        "valueType": "number"
       }
     },
     "events": {
@@ -19162,6 +19170,9 @@ export default {
       "borderStyle-Text-keyboard": "var(--xmlui-borderStyle-Text-keyboard)",
       "borderRadius-Text-keyboard": "var(--xmlui-borderRadius-Text-keyboard)",
       "paddingHorizontal-Text-keyboard": "var(--xmlui-paddingHorizontal-Text-keyboard)",
+      "backgroundColor-mark-Text": "var(--xmlui-backgroundColor-mark-Text)",
+      "textColor-mark-Text": "var(--xmlui-textColor-mark-Text)",
+      "backgroundColor-markActive-Text": "var(--xmlui-backgroundColor-markActive-Text)",
       "backgroundColor-Text-marked": "var(--xmlui-backgroundColor-Text-marked)",
       "textColor-Text-marked": "var(--xmlui-textColor-Text-marked)",
       "fontWeight-Text-marked": "var(--xmlui-fontWeight-Text-marked)",
@@ -19210,6 +19221,9 @@ export default {
       "fontFamily-Text": "$fontFamily",
       "fontSize-Text": "$fontSize",
       "fontWeight-Text": "$fontWeight-normal",
+      "backgroundColor-mark-Text": "$color-warn-200",
+      "textColor-mark-Text": "inherit",
+      "backgroundColor-markActive-Text": "$color-warn-400",
       "fontSize-Text-secondary": "$fontSize-sm",
       "textColor-Text-secondary": "$textColor-secondary",
       "fontWeight-Text-abbr": "$fontWeight-bold",


### PR DESCRIPTION
_Jon's Claude speaking from the xmlui project:_

Closes #3761.

`Markdown` could highlight substring matches; `Text` could not. Anything wanting marked-up matches in plain text — search snippets, log lines, diff bodies, table cells — had to route content through a Markdown parse it never needed, or hand-roll an outer `Text` for the line box plus one `inline` `Text` per segment, repeating `whiteSpace` and every styling prop at both levels.

## The cost, stated in code rather than prose

The reporting app carried a helper whose entire job was to escape plain text *into* Markdown so it could be parsed *as* Markdown, purely to borrow the `<mark>` engine for plain-text rows:

```js
window.__bramMarkdownLiteral = function (text) {
  return String(text || "")
    .replace(/\\/g, "\\\\")
    .replace(/([`*_{}\[\]()<>#+.!|~-])/g, "\\$1");
};
```

Under this change its six call sites render as `Text` with `highlightText`, and it has no callers left. That is the feature's acceptance test, and it passed downstream before this PR was raised.

## Shared matching core

`normalizeNeedles` and the scanner move to `components-core/utils/highlight-terms.ts`; `MarkdownReact` is refactored onto it and `Text` uses the same code. Semantics are unchanged from what `Markdown` already shipped: a string stays one phrase and is never whitespace-split, terms under 2 characters are dropped, case-insensitive duplicates removed, **the longest needle wins** at each position so `cat`/`category` never nest, and matches are numbered in one 0-based sequence in **document order across all terms**.

Sharing is the point, not tidiness. A find plan stepping through a list of mixed `Markdown` and `Text` rows has to walk every match top-to-bottom as one sequence; two copies of "longest wins, document order" would drift, and the drift would surface as a counter meaning different things on different row types.

**`Markdown.spec.ts` passes with the spec file untouched — 79 passed.** That was the gate on the refactor: if it had needed a spec edited, the refactor would have been wrong.

## Details worth knowing

- The `<mark>` is a **plain inline element with no display of its own**, so a match inside a word introduces no break opportunity. That is exactly what forced the hand-rolled construction — inline-block or flex segments split the word.
- Marks render *inside* the existing `Text` element, so `whiteSpace`, `fontSize`, and colour are set once instead of per segment.
- Theme vars `backgroundColor-mark-Text`, `textColor-mark-Text`, `backgroundColor-markActive-Text` default to `Markdown`'s exact values, so a mixed list is one visual language with no per-app theming.
- **Not added: `highlightActive`** (the boolean). `Markdown`'s own metadata says `highlightActiveIndex` generalizes it; a new surface should not inherit two ways to say one thing.

## Scope

This is substring matching — correct for a find box, wrong for server-computed spans. Content whose highlights arrive pre-marked (FTS5 snippets, where marks land on token boundaries after the excerpt has lost its column provenance) cannot be served by it in principle, and needs the segment form tracked in **#3777**. #3761 was split before this was built so that mechanism has its own home.

## Verification

Ours: `Text.spec.ts` **154 passed** (11 new), `Markdown.spec.ts` **79 passed unchanged**, `npm run build:xmlui-standalone` clean, `check:metadata` and `check:metadata-purity` pass, langserver metadata snapshot regenerated in this commit.

New specs cover the mid-word match, case-insensitivity preserving source casing, multi-term arrays, longest-wins with no nesting, `highlightActiveIndex` selecting the Nth occurrence in document order, counting *across* terms rather than per term, sub-2-character and empty terms as no-ops, and unchanged rendering when nothing matches. Whitespace preservation is asserted differentially against an unhighlighted copy of the same value rather than a literal, because XMLUI renders space runs as space+`&nbsp;` pairs — the property that matters is that highlighting changes nothing about the text.

Downstream, on a pre-release bundle verified by `sha256` in their own vendor directory before use:

- **Mid-token match in a virtualized list** — needle `vendor` marking `revendor` mid-token *inside inline code* across a 453-event transcript, without breaking the token at either row type. A unit harness cannot reach that.
- **Ordinal continuity across mixed rows** — 145 matches spanning `Markdown` prose and `Text` rows, stepped in order; plus a 17-match run whose needle appears *only* in swapped `Text` rows, isolating the new component.
- **Active-mark distinctness** in both row kinds, with no theming on their side — the shared defaults doing the work.
- **`Markdown` regression re-checked** on the refactored core against the bundle they were running: no behavioral difference observed on a real transcript with a real find plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

