### PR TITLE
Docs: add a how-to for reading data with a POST request

### DIFF
--- a/website/content/docs/pages/howto/read-data-with-a-post-request.md
+++ b/website/content/docs/pages/howto/read-data-with-a-post-request.md
@@ -1,0 +1,82 @@
+# Read data with a POST request
+
+Set `method="post"` and `body` on a `DataSource` when a read needs a request body — a payload too large or too structured for query params.
+
+Choose between `DataSource` and `APICall` by what the request *means*, not by its HTTP verb. `DataSource` is for data the view needs; `APICall` is for actions the user takes. A POST that returns something you render is still a read, and it belongs in a `DataSource`.
+
+That distinction matters because the two components give you different things. A `DataSource` fetches on mount, refetches when its inputs change, and exposes `loaded`, `inProgress`, and `error`. An `APICall` does none of that — it waits to be executed. Reach for `APICall` because it is the component you have seen POST examples on, and you inherit the job of triggering the request yourself.
+
+In the example below, the diff viewer sends a file's full text in the request body — far too big for a URL — and gets back annotated lines. Pick a file to watch the `DataSource` refetch as its `body` changes.
+
+```xmlui-pg copy display name="Pick a file to annotate"
+---app display /method="post"/ /body/
+<App var.selectedFile="alpha.txt">
+  <DataSource
+    id="annotation"
+    url="/api/annotate"
+    method="post"
+    body="{{ filename: selectedFile, contents: fileContents[selectedFile] }}"
+  />
+  <variable
+    name="fileContents"
+    value="{{
+      'alpha.txt': 'the quick brown fox\njumps over the lazy dog',
+      'beta.txt':  'pack my box with five\ndozen liquor jugs'
+    }}"
+  />
+  <HStack verticalAlignment="center" gap="$space-3">
+    <Select id="picker" initialValue="alpha.txt" onDidChange="(v) => selectedFile = v">
+      <Option value="alpha.txt" label="alpha.txt" />
+      <Option value="beta.txt" label="beta.txt" />
+    </Select>
+    <Text when="{annotation.inProgress}" value="Annotating..." />
+  </HStack>
+  <Card when="{annotation.loaded}">
+    <Items data="{annotation.value.lines}">
+      <HStack gap="$space-2">
+        <Text width="2em" variant="mono" value="{$item.number}" />
+        <Text variant="mono" value="{$item.text}" />
+        <Text variant="secondary" value="{$item.words} words" />
+      </HStack>
+    </Items>
+  </Card>
+</App>
+---api
+{
+  "apiUrl": "/api",
+  "operations": {
+    "annotate": {
+      "url": "/annotate",
+      "method": "post",
+      "handler": "delay(400); const lines = ($requestBody.contents || '').split('\\n'); return { filename: $requestBody.filename, lines: lines.map((text, i) => ({ number: i + 1, text, words: text.split(/\\s+/).filter(Boolean).length })) };"
+    }
+  }
+}
+```
+
+## Key points
+
+**The read/write split is semantic, not about the verb**: `DataSource` fetches and caches data the view needs; `APICall` creates, updates, or deletes in response to something the user did. A POST-shaped read is still a read.
+
+**`body` is serialized to JSON for you**: pass an object. If you already hold a serialized string, use `rawBody` instead and skip the second serialization.
+
+**The request re-fires when `body` changes**: `body` is a binding like any other, so the fetch tracks its inputs. That is the whole reason to prefer `DataSource` here — no trigger to own, and no way to forget one.
+
+**`body` is compared by value, so an inline object literal is fine**: write `body="{{ diff: $props.text }}"` directly. That expression builds a new object every time it is evaluated, but the body becomes part of the request's cache key, and cache keys are compared by their *contents* — a fresh object with the same values is the same key. There is no refetch loop to avoid, and no need to hoist the object into a `variable` to stabilize its identity. Property order does not matter either.
+
+**Do not hand-roll the triggers with `APICall`**: the tempting alternative is an `APICall` executed from an `onInit` handler plus a `ChangeListener` on the input. Both halves fail in ways that are quiet rather than loud — [`ChangeListener` does not fire on initial mount](/docs/howto/debounce-with-changelistener), so the first render never requests anything, and a mount handler that calls `execute()` may issue nothing at all. This has been observed even where the value was already present at first render, so "my data is there, so this doesn't apply to me" is not a safe read.
+
+**The tell is an absence, which is why it survives review**: you are looking for a request that was never made, not one that failed. Nothing turns red. There is no error, no rejected promise, and nothing to click in the network panel — the view renders, the data just looks empty, and a component with any fallback path renders something plausible. One app shipped this way for months. If a view looks under-populated and the network panel has nothing to show you, suspect a request that never fired before you go looking at rendering.
+
+**Query params still belong in `queryParams`**: `method="post"` is for payloads that cannot fit in a URL. If the inputs are a handful of scalars, keep them in `queryParams` on a GET — it stays cacheable and readable in logs.
+
+**There is no built-in size limit, and trimming is your job**: XMLUI does not cap the body. What will stop you is elsewhere — the server's own request-size limit, or a reverse proxy in front of it — and those failures surface as a rejected request rather than anything the component can warn about. Two local costs are worth knowing when the payload is genuinely large: the body is serialized on every request, and because it participates in the cache key it is also stringified for comparison and retained per cached entry. If you are sending something unbounded, such as a whole file, slice it at a size you choose deliberately and apply the same limit everywhere you send it.
+
+---
+
+## See also
+
+- [Send custom headers per request](/docs/howto/send-custom-headers-per-request) — the other request-shaping prop shared by `DataSource` and `APICall`
+- [Chain a DataSource refetch](/docs/howto/chain-a-refetch) — refreshing a read after a write completes
+- [Delay a DataSource until another is ready](/docs/howto/delay-a-datasource-until-another-datasource-is-ready) — gating a fetch on another request's result
+- [Debounce with ChangeListener](/docs/howto/debounce-with-changelistener) — including why it does not fire on mount

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -654,6 +654,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Read data with a POST request"
+                            to="/docs/howto/read-data-with-a-post-request"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Invalidate related data after a write"
                             to="/docs/howto/control-cache-invalidation"
                         />

--- a/xmlui/tests-e2e/how-to-examples/read-data-with-a-post-request.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/read-data-with-a-post-request.spec.ts
@@ -1,0 +1,54 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/read-data-with-a-post-request.md",
+  ),
+);
+
+test.describe("Pick a file to annotate", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Pick a file to annotate",
+  );
+
+  test("the POST-backed DataSource fetches on mount", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    // Nothing triggers this request but mounting — which is the whole point of
+    // using DataSource rather than an APICall the app has to execute itself.
+    await expect(page.getByText("the quick brown fox")).toBeVisible();
+    await expect(page.getByText("jumps over the lazy dog")).toBeVisible();
+  });
+
+  test("the response is annotated by the server, not the client", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    // Line numbers and word counts come back in the response body.
+    await expect(page.getByText("4 words").first()).toBeVisible();
+    await expect(page.getByText("5 words").first()).toBeVisible();
+  });
+
+  test("changing the body refetches", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    await expect(page.getByText("the quick brown fox")).toBeVisible();
+
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "beta.txt" }).click();
+
+    // The request re-fires because `body` is a binding — no ChangeListener,
+    // no explicit execute() call.
+    await expect(page.getByText("pack my box with five")).toBeVisible();
+    await expect(page.getByText("dozen liquor jugs")).toBeVisible();
+    await expect(page.getByText("the quick brown fox")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Adds a how-to for reads that need a request body, plus its nav entry and playground spec.

## The gap

Nothing in the corpus covers a read whose request must be a POST — a fetch whose payload is too large or too structured for query params. Verified against the current catalog rather than assumed: `xmlui_search_howto("DataSource method post send body read data")` returns 15 how-to files and **none on topic**. Every `DataSource` recipe is a GET; the single `method="post"` hit is an `APICall` mutation.

The mechanism has been there all along — `DataSource` takes `method` (`DataSource.tsx:14`), `body` (`:42`), `rawBody`, `queryParams`, `headers`. Nothing pointed a reader at it.

## Why it is a content gap rather than discoverability

The component split is documented in a way that actively sends a POST-shaped read to the wrong component. `APICall` is framed as "creates, updates or deletes data", so a reader searching for POST lands there and stops. The split is semantic — actions the user takes versus data the view needs — and `DataSource`'s own metadata already says "fetches and caches data". That sentence was simply nowhere a reader looks, so the doc leads with it.

## What it cost, concretely

An app used `APICall` for a read — the only documented POST — then hand-rolled the triggers `DataSource` gives for free: an `onInit` handler plus a `ChangeListener` on the input prop. Both failed silently, so the request was never made and the component fell back to a degraded rendering path. It looked plausible and shipped that way for months. Receipts in judell/bram#258.

## Reviewed by the developer who hit the bug

Four points came back, and each closed a question the first draft left open:

- **Is `body` compared by value or identity?** By value — I traced it rather than asserting it: the body is pushed into the request's cache key (`DataLoaderQueryKeyGenerator.ts:96`) and keys are hashed by contents with sorted object properties (`query-core/utils.js:164`). So an inline `body="{{ diff: $props.text }}"` is fine despite building a fresh object per evaluation, and hoisting it into a `variable` to stabilize identity is unnecessary. Property order is immaterial too.
- **The `APICall` failure was over-specified.** The draft said a mount handler "without the value it needs" issues nothing. The reviewer's case had the value present at first render and `execute()` still issued nothing, and neither of us established why. It now says it *may* issue nothing, and explicitly closes off "my data is there, so this doesn't apply to me" — the wrong turn they actually took.
- **The tell is an absence**, now its own key point: you are looking for a request that was never made rather than one that failed. Nothing turns red, nothing appears in the network panel, and any fallback path renders something believable.
- **Payload size.** XMLUI imposes no cap; what stops you is the server's limit or a proxy's. Because the body participates in the cache key, it is also stringified for comparison and retained per cache entry rather than merely serialized per request — so unbounded payloads want a deliberate slice, applied at the same limit everywhere.

## Verification

The companion spec drives the playground rather than asserting its prose — fetch on mount with no trigger of its own, annotation supplied by the response, and a refetch when the bound `body` changes. **3 passed.** Every how-to playground has one of these (178 specs against 195 docs); without it the example rots into a snippet nobody runs.

Nav entry under **Data Loading & APIs**, beside *Send custom headers per request* — its nearest neighbour, both being about shaping the request rather than consuming the response.

## Provenance

Sourced from the how-to gap ledger in judell/bram#245, which pairs MCP search-outcome mining with session-history corroboration. Nominated upstream as #3781 and closed deliberately so the doc could be written rather than tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
