### PR TITLE
Docs: how-to for a Slider with a runtime domain, plus setValue/initialValue reference corrections

### DIFF
--- a/website/content/docs/pages/howto/drive-a-slider-with-a-runtime-domain.md
+++ b/website/content/docs/pages/howto/drive-a-slider-with-a-runtime-domain.md
@@ -1,0 +1,70 @@
+# Drive a Slider whose min/max domain changes at runtime
+
+Bind `minValue`, `maxValue`, and `initialValue` to the same derived data and let the Slider re-seed itself — do not reset it by calling `setValue`.
+
+A range filter over fetched data has a domain that moves: the earliest and latest dates in a result set, the cheapest and most expensive item currently matching. Every time the underlying query changes, the slider's scale changes with it and the handles have to land somewhere sensible on the new scale.
+
+`Slider` already does this. Its `initialValue` is not read once on mount — it re-applies whenever `initialValue`, `minValue`, or `maxValue` change, clamping the handles into the new domain. The re-seed fires no events, so it cannot disturb whatever state your `didChange` handler owns. Bind the props and the reset comes for free.
+
+Switch datasets to watch the domain, the handles, and the readout move together.
+
+```xmlui-pg copy display name="Switch the dataset to move the domain"
+---app display /minValue="{domain[0]}"/ /maxValue="{domain[1]}"/ /initialValue="{domain}"/
+<App
+  var.dataset="q1"
+  var.selection="{null}"
+  var.readings="{{
+    q1: [12, 18, 24, 31, 37, 44],
+    q2: [140, 168, 195, 220, 244, 270]
+  }}"
+  var.current="{dataset === 'q1' ? readings.q1 : readings.q2}"
+  var.domain="{[current[0], current[current.length - 1]]}">
+
+  <HStack verticalAlignment="center" gap="$space-3">
+    <Select
+      width="200px"
+      initialValue="q1"
+      onDidChange="(v) => { dataset = v; selection = null }">
+      <Option value="q1" label="Q1 (12 – 44)" />
+      <Option value="q2" label="Q2 (140 – 270)" />
+    </Select>
+    <Text variant="secondary" value="domain: {domain[0]} – {domain[1]}" />
+  </HStack>
+
+  <Slider
+    label="Range"
+    minValue="{domain[0]}"
+    maxValue="{domain[1]}"
+    initialValue="{domain}"
+    minStepsBetweenThumbs="{1}"
+    onDidCommit="(val) => selection = val" />
+
+  <Text
+    when="{selection === null}"
+    variant="secondary"
+    value="No selection — the whole domain is in play." />
+  <Text
+    when="{selection !== null}"
+    value="Selected {selection[0]} – {selection[1]}" />
+</App>
+```
+
+## Key points
+
+**`initialValue` re-applies when the domain changes**: the property is not a mount-time-only seed. Changing `initialValue`, `minValue`, or `maxValue` re-runs the seeding step, which clamps the handles into the new range. Binding all three to the same derived value is the whole pattern.
+
+**The re-seed is silent**: it does not fire `didChange` or `didCommit`. That is what makes it safe to use as a reset — the handler that owns your filter state is not called, so the state you deliberately cleared stays cleared. Reset your own state alongside the domain change, as the example does with `selection = null`.
+
+**Do not reset with `setValue`**: it is the obvious-looking alternative and it fails two ways at once. It clamps against the `minValue` / `maxValue` current *at the moment it is called*, so a debounced or deferred call races the new domain and can strand the handles on the old scale. And it fires `didChange` and `didCommit`, so it overwrites the filter state your handler owns — and re-runs whatever expensive work you moved to `didCommit`.
+
+**Gate the slider on settled data**: derive the domain from data that has actually loaded. Seeding against a half-loaded or empty result set puts the handles somewhere arbitrary, and the re-seed will move them again when the real domain arrives. A `when` on the container, or a domain derived from a `DataSource`'s `loaded` state, is enough.
+
+**Prefer `didCommit` for expensive work on a moving domain**: `didChange` fires on every step crossed while dragging, which on a filter means re-running the query per step. `didCommit` fires once when the handle is released.
+
+---
+
+## See also
+
+- [Create a two-handle range slider](/docs/howto/create-a-two-handle-range-slider) — the static-domain case, and where `minStepsBetweenThumbs` and `valueFormat` are covered
+- [Style Slider track, thumb, and range](/docs/howto/style-slider-track-thumb-and-range) — theming the control
+- [Delay a DataSource until another is ready](/docs/howto/delay-a-datasource-until-another-datasource-is-ready) — gating on data that has actually loaded

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -614,6 +614,11 @@
                             label="Create a two-handle range slider"
                             to="/docs/howto/create-a-two-handle-range-slider"
                         />
+                        <NavLink
+                            icon="article"
+                            label="Drive a Slider with a runtime domain"
+                            to="/docs/howto/drive-a-slider-with-a-runtime-domain"
+                        />
                     </NavGroup>
 
                     <NavGroup label="Data Loading & APIs">

--- a/xmlui/src/components/Slider/Slider.tsx
+++ b/xmlui/src/components/Slider/Slider.tsx
@@ -42,6 +42,11 @@ export const SliderMd = createMetadata({
   props: {
     initialValue: {
       ...dInitialValue(),
+      description:
+        `This property sets the ${COMP}'s initial value. It is not read only at mount: ` +
+        `changing \`initialValue\`, \`minValue\`, or \`maxValue\` re-seeds the thumbs into the ` +
+        `current range. That re-seeding fires no events, which makes binding all three to a ` +
+        `derived value the way to drive a slider whose domain changes at runtime.`,
       valueType: "any",
     },
     minValue: {
@@ -116,7 +121,14 @@ export const SliderMd = createMetadata({
       signature: "get value(): number | [number, number] | undefined",
     },
     setValue: {
-      description: `This API sets the value of the \`${COMP}\`. You can use it to programmatically change the value.`,
+      description:
+        `This API sets the value of the \`${COMP}\`. You can use it to programmatically ` +
+        `change the value. The new value is clamped against the \`minValue\` and \`maxValue\` ` +
+        `in effect **at the moment of the call**, so a deferred or debounced call made while ` +
+        `those props are changing may clamp against the previous range. The call also fires ` +
+        `\`didChange\` and \`didCommit\`, exactly as a user adjustment would. To reset a slider ` +
+        `whose domain changes at runtime, rebind \`initialValue\` instead — that re-seeds ` +
+        `without firing events.`,
       signature: "setValue(value: number | [number, number] | undefined): void",
       parameters: {
         value:

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -15846,7 +15846,7 @@ export default {
     },
     "props": {
       "initialValue": {
-        "description": "This property sets the component's initial value.",
+        "description": "This property sets the Slider's initial value. It is not read only at mount: changing `initialValue`, `minValue`, or `maxValue` re-seeds the thumbs into the current range. That re-seeding fires no events, which makes binding all three to a derived value the way to drive a slider whose domain changes at runtime.",
         "valueType": "any"
       },
       "minValue": {
@@ -15968,7 +15968,7 @@ export default {
         "signature": "get value(): number | [number, number] | undefined"
       },
       "setValue": {
-        "description": "This API sets the value of the `Slider`. You can use it to programmatically change the value.",
+        "description": "This API sets the value of the `Slider`. You can use it to programmatically change the value. The new value is clamped against the `minValue` and `maxValue` in effect **at the moment of the call**, so a deferred or debounced call made while those props are changing may clamp against the previous range. The call also fires `didChange` and `didCommit`, exactly as a user adjustment would. To reset a slider whose domain changes at runtime, rebind `initialValue` instead — that re-seeds without firing events.",
         "signature": "setValue(value: number | [number, number] | undefined): void",
         "parameters": {
           "value": "The new value to set. Can be a single value or an array of values for range sliders."

--- a/xmlui/tests-e2e/how-to-examples/drive-a-slider-with-a-runtime-domain.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/drive-a-slider-with-a-runtime-domain.spec.ts
@@ -1,0 +1,66 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/drive-a-slider-with-a-runtime-domain.md",
+  ),
+);
+
+test.describe("Switch the dataset to move the domain", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Switch the dataset to move the domain",
+  );
+
+  test("the slider seeds to the initial domain", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByText("domain: 12 – 44")).toBeVisible();
+    const thumbs = page.getByRole("slider");
+    await expect(thumbs).toHaveCount(2);
+    await expect(thumbs.first()).toHaveAttribute("aria-valuenow", "12");
+    await expect(thumbs.last()).toHaveAttribute("aria-valuenow", "44");
+
+  });
+
+  test("changing the domain re-seeds the thumbs onto the new scale", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    await expect(page.getByText("domain: 12 – 44")).toBeVisible();
+
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Q2 (140 – 270)" }).click();
+
+    // The whole point of the pattern: no listener, no setValue call — the thumbs
+    // land on the new domain because initialValue re-applies with min/max.
+    await expect(page.getByText("domain: 140 – 270")).toBeVisible();
+    const thumbs = page.getByRole("slider");
+    await expect(thumbs.first()).toHaveAttribute("aria-valuenow", "140");
+    await expect(thumbs.last()).toHaveAttribute("aria-valuenow", "270");
+  });
+
+  test("the re-seed does not fire didCommit", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    // Establish a selection, then move the domain. If re-seeding fired didCommit,
+    // the handler would overwrite `selection` with the new full range instead of
+    // the app's own reset — the silent-reset guarantee the how-to rests on.
+    const thumbs = page.getByRole("slider");
+    await thumbs.first().focus();
+    await thumbs.first().press("ArrowRight");
+    await expect(page.getByText(/^Selected /)).toBeVisible();
+
+    await page.getByRole("combobox").click();
+    await page.getByRole("option", { name: "Q2 (140 – 270)" }).click();
+
+    await expect(page.getByText("No selection — the whole domain is in play.")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Adds a how-to for sliders whose domain is derived from data, and corrects two `Slider` reference descriptions that currently point readers at the trap it describes.

## The gap

A range filter over fetched data has a moving domain — the earliest and latest dates in a result set, the price band of whatever currently matches. Only the static case is covered: `xmlui_search_howto("slider min max domain changes at runtime")` returns `confidence=medium` with [create-a-two-handle-range-slider](https://docs.xmlui.org/howto/create-a-two-handle-range-slider) and the theming doc as the on-topic hits, neither of which applies.

## The pattern is props-only, and already works

Bind `minValue`, `maxValue`, and `initialValue` to the same derived value. `initialValue` is not a mount-time-only seed — its effect depends on `[initialValue, min, max]` (`SliderReact.tsx:135-169`), so it re-runs when the domain changes and clamps the thumbs into the new range. **The re-seed fires no events**, which is what makes it usable as a reset: it cannot clobber the filter state the app's own handler owns.

## The reference corrections, and why they are in the same PR

A how-to teaching the props-only pattern while the reference still describes `setValue` as *"sets the value… programmatically change the value"* would be patching around a page that misleads. A reader weighing "bind the props" against "call `setValue`" has nothing to go on.

- **`setValue`** now states that it clamps against the `minValue`/`maxValue` in effect **at the moment of the call** — so a deferred or debounced call made while the domain is changing can clamp against the previous range and strand the thumbs — that it fires `didChange` **and** `didCommit` exactly as a user adjustment would, and that rebinding `initialValue` is how to reset a moving domain without events.
- **`initialValue`** now states that it re-applies when it or the domain props change, re-seeding silently.

Both verified against this source rather than inferred: `SliderReact.tsx:135-169` for the effect and its dependencies, `:253-261` for the clamp and the two event calls. The `didCommit` half is **newly true** — `setValue` began firing it when #3769 landed — so an app that moved expensive work to `didCommit` gets it re-run by a programmatic reset.

## Verification

Three specs drive the playground. The third is the load-bearing one: it establishes a selection, moves the domain, and asserts the selection was cleared *by the app* rather than overwritten by a re-seed event — the guarantee the whole pattern rests on, pinned rather than described.

`Slider.spec.ts` 118 passed, standalone build clean, metadata regenerated and drift check green.

## One thing I could not verify automatically

The playground's `Select` carries an explicit `width`. Unconstrained it stretches and pushes the domain readout outside the docs playground frame. I tried twice to pin that with a test and removed it both times: a document-level overflow assertion passes with *and* without the fix, at the default viewport and at 640px, because the overflow happens in the docs site's nested app frame — which the test bed does not reproduce. Better to say so than keep a green check that discriminates nothing. The fix was confirmed by eye in the rendered docs.

## Provenance

From the how-to gap ledger in judell/bram#245 (2026-08-15 #1), ranked first in triage because it is the only nomination where the reference is *wrong* rather than merely absent — and a wrong doc costs more, because it forecloses the search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
