### PR TITLE
Take the shadow-collision probe off the standalone boot path; parallelize it

### DIFF
--- a/xmlui/src/components-core/StandaloneApp.tsx
+++ b/xmlui/src/components-core/StandaloneApp.tsx
@@ -2058,7 +2058,11 @@ function useStandalone(
         );
       }
       warnBuiltInComponentNameCollisions(componentsWithCodeBehinds, extensionManager);
-      await warnShadowedLocalComponentFiles(
+      // Advisory only — never block boot on it. Awaiting these probes held
+      // startup hostage to one network round-trip per referenced built-in
+      // tag (~4.5 s of serial 404s on a real deployment, #3787); the app
+      // rendered nothing until the last probe answered.
+      void warnShadowedLocalComponentFiles(
         entryPointWithCodeBehind,
         componentsWithCodeBehinds,
         async (componentName) => {
@@ -2295,22 +2299,27 @@ export async function warnShadowedLocalComponentFiles(
       visitComponent(component.component as ComponentDef, null, visitor, {}, metadataHandler);
     }
 
-    for (const componentName of candidates) {
-      let exists = false;
-      try {
-        exists = await componentFileExists(componentName);
-      } catch {
-        exists = false;
-      }
-      if (exists) {
-        warn(
-          `[xmlui] Local component file "components/${componentName}.${componentFileExtension}" ` +
-            `was not loaded because <${componentName}> already resolves to the built-in ` +
-            `"${componentName}" component. Rename the custom component or reference it with ` +
-            `an app namespace to avoid the collision.`,
-        );
-      }
-    }
+    // Probe all candidates concurrently: each probe is a network request
+    // in the browser, and a serial for-await loop costs sum(RTT) — measured
+    // at ~4.5 s for ~43 built-in tags on a GitHub Pages deployment (#3787).
+    await Promise.all(
+      Array.from(candidates).map(async (componentName) => {
+        let exists = false;
+        try {
+          exists = await componentFileExists(componentName);
+        } catch {
+          exists = false;
+        }
+        if (exists) {
+          warn(
+            `[xmlui] Local component file "components/${componentName}.${componentFileExtension}" ` +
+              `was not loaded because <${componentName}> already resolves to the built-in ` +
+              `"${componentName}" component. Rename the custom component or reference it with ` +
+              `an app namespace to avoid the collision.`,
+          );
+        }
+      }),
+    );
   } finally {
     componentRegistry.destroy();
   }


### PR DESCRIPTION
Jon's Claude speaking from the community-calendar project:

Fixes #3787.

`warnShadowedLocalComponentFiles` (introduced in #3659) probes `components/<Name>.xmlui` for every built-in tag the markup references, serially, awaited on the standalone boot path. On a real deployment each probe is a network round-trip, so startup pays sum(RTT) before anything renders. Local serving hides the cost (~1 ms/probe), which is why it shipped unnoticed.

Two changes, either sufficient, both cheap:

- **Call site no longer awaits the check** — it is advisory (a console warning about a collision that rarely exists) and nothing downstream consumes its result: `void warnShadowedLocalComponentFiles(...)`.
- **The probe loop runs concurrently** (`Promise.all`), sum(RTT) → max(RTT), so even the off-path pass completes in ~one round-trip.

The existing coverage (`standalone-import-resolution.test.ts`, 7 tests) awaits the function directly and passes unchanged — the function's contract (async, resolves after warnings emitted) is preserved; only the boot path stops waiting for it.

## Validated on a production deployment

We vendored this exact build to our GitHub Pages app (judell/community-calendar, ~43 built-in tags referenced) and measured with `performance.mark` instrumentation bracketing the engine-start → data-subscribe window. Same site, same machine, before/after:

| Milestone | current main | with this fix |
|---|---|---|
| Engine start | 1031 ms | 677 ms |
| Events payload downloaded | 1348 ms | 999 ms |
| Engine subscribes its data source | **6716 ms** | **2169 ms** |
| First page build | ~7.4 s | **2880 ms** |

The before-timeline's resource log shows the mechanism directly: ~43 serial `.xmlui` probes (`App.xmlui`, `VStack.xmlui`, `Table.xmlui`, …) one every ~95 ms from 2.0 s to 6.5 s, with subscription immediately after the last probe. Full capture on #3787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
