### PR TITLE
Text: add a segment variant, and resolve token references in inline theme vars

### DIFF
--- a/.changeset/text-segment-variant.md
+++ b/.changeset/text-segment-variant.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Add an optional `variant` field to `Text` segments, naming a span kind that is not a search hit — a changed word in a diff, for example — styled through `backgroundColor-mark-<variant>-Text` and `textColor-mark-<variant>-Text`. Precedence is `active` > `hit` > `variant`, variant spans render as `<span data-variant>` rather than `<mark>` so code that counts marks still counts only search hits, and only `hit` segments are counted by `highlightActiveIndex`.

--- a/.changeset/theme-inline-var-token-refs.md
+++ b/.changeset/theme-inline-var-token-refs.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Resolve `$token` references in theme variables declared inline on a `<Theme>`. Previously those values were written to CSS unchanged, so an app-defined variable given a value like `$color-danger-200` reached the DOM as that literal string and computed to nothing — silently, since an invalid custom property raises no error. Theme *definitions* already resolved these; the two paths now share one implementation so they cannot drift again.

--- a/xmlui/src/components-core/theming/ThemeProvider.tsx
+++ b/xmlui/src/components-core/theming/ThemeProvider.tsx
@@ -14,6 +14,7 @@ import { normalizePath } from "../utils/misc";
 import { matchThemeVar } from "../theming/hvar";
 import { ThemeContext, ThemesContext } from "../theming/ThemeContext";
 import themeVars, { getVarKey } from "../theming/themeVars";
+import { replaceThemeVarRefs } from "./transformThemeVars";
 import { EMPTY_ARRAY, EMPTY_OBJECT } from "../constants";
 import { collectThemeChainByExtends } from "../theming/extendThemeUtils";
 import { useComponentRegistry } from "../../components/ComponentRegistryContext";
@@ -632,30 +633,9 @@ function resolveThemeVarsWithCssVars(theme?: Record<string, string>) {
   return ret;
 
   function resolveThemeVarToCssVars(varName: string, theme: Record<string, string>) {
-    const value = theme[varName];
-    if (typeof value === "string" && value.includes("$")) {
-      return replaceThemeVar(value);
-    }
-    return value;
-  }
-
-  function replaceThemeVar(input: string) {
-    const regex = /\$([a-zA-Z0-9_-]+)/gi;
-    const matches = input.matchAll(regex);
-
-    //we go from 1, because result[1] is the whole stuff
-    if (matches) {
-      let ret = input;
-      for (const match of matches) {
-        const varName = match[1];
-        if (varName) {
-          ret = ret.replace(match[0], `var(${getVarKey(varName)})`);
-        }
-      }
-      return ret;
-    }
-
-    return input;
+    // Shared with the inline-<Theme> path in ThemeReact: one definition of how a
+    // `$token` reference becomes a CSS var, so the two cannot diverge again.
+    return replaceThemeVarRefs(theme[varName]);
   }
 }
 

--- a/xmlui/src/components-core/theming/transformThemeVars.ts
+++ b/xmlui/src/components-core/theming/transformThemeVars.ts
@@ -3,9 +3,35 @@ import Color from "color";
 import { type HVar, parseHVar } from "../theming/hvar";
 import { StyleParser } from "../../parsers/style-parser/StyleParser";
 import { toCssVar } from "./layout-resolver";
+import { getVarKey } from "./themeVars";
 
 export function isThemeVarName(varName: any) {
   return typeof varName === "string" && varName?.startsWith("$");
+}
+
+/**
+ * Rewrite `$token` references inside a theme *value* into CSS custom-property
+ * references: `"$color-danger-200"` becomes `"var(--xmlui-color-danger-200)"`.
+ *
+ * Both paths that turn theme declarations into CSS need this, and for a while only
+ * one had it: theme definitions were rewritten while variables declared inline on a
+ * `<Theme>` were written through raw, so an app-defined variable given a `$token`
+ * value landed in the DOM as the literal string and computed to nothing. It lives
+ * here, exported, so the two paths cannot drift apart again.
+ */
+export function replaceThemeVarRefs(input: string): string {
+  if (typeof input !== "string" || !input.includes("$")) {
+    return input;
+  }
+  const regex = /\$([a-zA-Z0-9_-]+)/gi;
+  let ret = input;
+  for (const match of input.matchAll(regex)) {
+    const varName = match[1];
+    if (varName) {
+      ret = ret.replace(match[0], `var(${getVarKey(varName)})`);
+    }
+  }
+  return ret;
 }
 
 export function resolveThemeVar(

--- a/xmlui/src/components/Text/Text.md
+++ b/xmlui/src/components/Text/Text.md
@@ -373,9 +373,33 @@ When `segments` is set it supplies the component's content — `value` and any c
 
 If no segment carries `active`, [`highlightActiveIndex`](#highlightactiveindex) selects which `hit` is active, counting in document order — the same numbering `highlightText` uses, so a find-in-page can step through a list mixing both kinds of row as one sequence.
 
-> [!INFO] `segments` expresses **one kind of span**: whether it matched a search, and whether it is the current match. It is deliberately not a general mechanism for styling arbitrary runs of text. Content that carries other, orthogonal span kinds — added and removed words in a diff, say, which a row may hold *alongside* search hits — needs its own styling and should compose those runs itself. Keeping this property to a single meaning is what lets `hit` and `active` mean the same thing here as they do for `highlightText`.
->
-> The field set — `text`, `hit`, `active` — is **closed for this release**, and that is a decision rather than an oversight. Should a second span kind ever warrant first-class support, a per-segment variant is the intended extension point; until then, content needing more than one kind of span composes it itself.
+> [!INFO] Precedence is `active` > `hit` > `variant`: a segment that is a search hit renders as one, and its `variant` is ignored. Only `hit` segments are counted by [`highlightActiveIndex`](#highlightactiveindex), so variant spans never enter the sequence a find-in-page steps through.
+
+### A second span kind: `variant`
+
+Some content carries spans that have nothing to do with searching — a word that changed on one side of a diff, say — and a row may hold those *alongside* search hits. Give such a segment a `variant` naming its kind:
+
+```xmlui
+<Text segments="{[
+  { text: 'the ', hit: false },
+  { text: 'quick', variant: 'emphasis' },
+  { text: ' brown ', hit: false },
+  { text: 'fox', hit: true, active: true }
+]}" />
+```
+
+Colours come from your theme, keyed by the variant name:
+
+```
+backgroundColor-mark-emphasis-Text
+textColor-mark-emphasis-Text
+```
+
+Declare those for every variant you use. An undeclared variant renders as plain text — the span is still there, just unstyled — and a development build warns once per name so a typo in a data-driven field does not pass silently.
+
+This is deliberately not a general styling channel: exactly those two properties resolve, keyed by a name you declare in the theme, rather than arbitrary CSS travelling in your data.
+
+> [!INFO] Two namespaces here point in opposite directions, deliberately. In the **DOM**, a hit is a `<mark>` and a variant is a `<span data-variant="…">` — they are different kinds of thing, and code that counts or queries marks to find search hits should not also collect diff spans. In the **theme**, both live under `mark-` (`backgroundColor-mark-Text`, `backgroundColor-markActive-Text`, `backgroundColor-mark-emphasis-Text`) — from a theme author's side they are one family of span styling to keep visually coherent.
 
 %-PROP-END
 

--- a/xmlui/src/components/Text/Text.module.scss
+++ b/xmlui/src/components/Text/Text.module.scss
@@ -445,6 +445,13 @@ $textColor-Text-secondary--hover: createThemeVar("textColor-#{$component}-second
     background-color: $backgroundColor-markActive-Text;
   }
 
+  // Segment variants: a non-search span kind. Colours arrive as inline custom-property
+  // references resolved per variant name, so nothing is declared here — this rule only
+  // matches the mark shape, and stays a plain inline run for the same reason marks do.
+  .highlightVariant {
+    border-radius: 2px;
+  }
+
   .noEllipsis {
     text-overflow: clip;
   }

--- a/xmlui/src/components/Text/Text.spec.ts
+++ b/xmlui/src/components/Text/Text.spec.ts
@@ -2549,3 +2549,188 @@ test.describe("segments", () => {
     await expect(page.getByTestId("t").locator("mark")).toHaveCount(0);
   });
 });
+
+// =============================================================================
+// SEGMENT VARIANTS (a second span kind, orthogonal to search hits)
+// =============================================================================
+
+// Mirrors the validation matrix the first consumer committed to running against a
+// real diff surface, so their result and ours speak to the same cases.
+test.describe("segment variants", () => {
+  const devBuild = process.env.PLAYWRIGHT_USE_DEV_SERVER !== "false" && !process.env.CI;
+
+  test("a variant segment renders as a span, not a mark", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Text testId="t" segments="{[
+        {text: 'plain '},
+        {text: 'changed', variant: 'emphasis'},
+        {text: ' tail'}
+      ]}" />
+    `);
+    const t = page.getByTestId("t");
+    await expect(t).toHaveText("plain changed tail");
+    await expect(t.locator("[data-variant='emphasis']")).toHaveText("changed");
+    // The element namespace matters: consumers count marks to find search hits.
+    await expect(t.locator("mark")).toHaveCount(0);
+  });
+
+  test("overlap: a hit that also carries a variant renders as a hit", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Text testId="t" segments="{[
+        {text: 'both', hit: true, active: true, variant: 'emphasis'},
+        {text: ' rest'}
+      ]}" />
+    `);
+    const t = page.getByTestId("t");
+    await expect(t.locator("mark[data-active='true']")).toHaveText("both");
+    await expect(t.locator("[data-variant]")).toHaveCount(0);
+  });
+
+  test("ordinal integrity: variant spans never enter the hit sequence", async ({
+    initTestBed,
+    page,
+  }) => {
+    // Document order is hit(0), variant, hit(1). Index 1 must select the second hit,
+    // not the variant span sitting between them.
+    await initTestBed(`
+      <Text testId="t" highlightActiveIndex="{1}" segments="{[
+        {text: 'one', hit: true},
+        {text: ' mid ', variant: 'emphasis'},
+        {text: 'two', hit: true}
+      ]}" />
+    `);
+    const active = page.getByTestId("t").locator("mark[data-active='true']");
+    await expect(active).toHaveCount(1);
+    await expect(active).toHaveText("two");
+  });
+
+  test("an undeclared variant still renders its text, unstyled", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Text testId="t" segments="{[{text: 'kept', variant: 'nosuchvariant'}]}" />
+    `);
+    await expect(page.getByTestId("t")).toHaveText("kept");
+    await expect(page.getByTestId("t").locator("[data-variant='nosuchvariant']")).toHaveCount(1);
+  });
+
+  // Uses a variant name no other test uses: the warn-once-per-name cache is module
+  // scoped, and the test bed reuses one JS context across tests in a worker, so a
+  // shared name would make this pass or fail depending on test order.
+  test("an undeclared variant warns in dev", async ({ initTestBed, page }) => {
+    test.skip(!devBuild, "The warning is compiled out of production builds");
+    const warnings: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "warning" && msg.text().includes("segment variant")) {
+        warnings.push(msg.text());
+      }
+    });
+    await initTestBed(`
+      <Text testId="t" segments="{[{text: 'kept', variant: 'undeclaredwarncase'}]}" />
+    `);
+    await expect(page.getByTestId("t")).toHaveText("kept");
+    await expect.poll(() => warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("undeclaredwarncase");
+  });
+
+  test("literal brackets in segment text stay literal", async ({ initTestBed, page }) => {
+    // Spans arrive from a server that uses [ ] as its own markers; content containing
+    // real brackets must not be re-interpreted on the way through.
+    await initTestBed(`
+      <Text testId="t" segments="{[
+        {text: 'items: [{ id, feedback }]', hit: false},
+        {text: '[approved]', variant: 'emphasis'}
+      ]}" />
+    `);
+    await expect(page.getByTestId("t")).toHaveText("items: [{ id, feedback }][approved]");
+    await expect(page.getByTestId("t").locator("[data-variant]")).toHaveText("[approved]");
+  });
+
+  test("a variant interior to a word does not split the word", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Text testId="t" width="400px" segments="{[
+        {text: 'anti'},
+        {text: 'tick', variant: 'emphasis'},
+        {text: 'erdisestablish'}
+      ]}" />
+    `);
+    const t = page.getByTestId("t");
+    await expect(t).toHaveText("antitickerdisestablish");
+    const spanBox = await t.locator("[data-variant]").boundingBox();
+    const containerBox = await t.boundingBox();
+    expect(containerBox!.height).toBeLessThan(spanBox!.height * 2);
+  });
+});
+
+
+
+test.describe("segment variant theming", () => {
+  const devBuild = process.env.PLAYWRIGHT_USE_DEV_SERVER !== "false" && !process.env.CI;
+
+  // The case the first consumer hit: a variant token given a `$token` value rendered
+  // flat, because inline <Theme> vars reached the DOM unresolved. A literal worked,
+  // which made it look like the variant feature rather than the theme path.
+  test("a variant themed with a $token reference renders that colour", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <App>
+        <Theme
+          backgroundColor-mark-diffDel-Text="#ff9999"
+          backgroundColor-mark-diffAdd-Text="$color-success-200">
+          <Text testId="t" segments="{[
+            {text: 'del', variant: 'diffDel'},
+            {text: 'add', variant: 'diffAdd'}
+          ]}" />
+        </Theme>
+      </App>
+    `);
+    await expect(page.getByTestId("t")).toHaveText("deladd");
+    const out = await page.evaluate(() => {
+      const read = (v: string) => {
+        const el = document.querySelector(`[data-variant="${v}"]`) as HTMLElement;
+        return getComputedStyle(el).backgroundColor;
+      };
+      return { del: read("diffDel"), add: read("diffAdd") };
+    });
+    expect(out.del).toEqual("rgb(255, 153, 153)");
+    // The whole point: a themed reference must paint, not compute to nothing.
+    expect(out.add).not.toEqual("rgba(0, 0, 0, 0)");
+    expect(out.add).not.toEqual(out.del);
+  });
+
+  // A broken `$token` reference does not reach the component as a broken value: the
+  // theme layer drops the whole declaration, so it looks identical to never declaring
+  // it. One warning covers both, which is why there is only one.
+  test("a variant referencing an undefined theme variable warns in dev", async ({
+    initTestBed,
+    page,
+  }) => {
+    test.skip(!devBuild, "The warning is compiled out of production builds");
+    const warnings: string[] = [];
+    page.on("console", (m) => {
+      if (m.type() === "warning" && m.text().includes("no usable theme value")) {
+        warnings.push(m.text());
+      }
+    });
+    await initTestBed(`
+      <App>
+        <Theme backgroundColor-mark-brokenref-Text="$no-such-token-exists">
+          <Text testId="t" segments="{[{text: 'x', variant: 'brokenref'}]}" />
+        </Theme>
+      </App>
+    `);
+    await expect(page.getByTestId("t")).toHaveText("x");
+    await expect.poll(() => warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("brokenref");
+  });
+});
+

--- a/xmlui/src/components/Text/Text.tsx
+++ b/xmlui/src/components/Text/Text.tsx
@@ -141,8 +141,12 @@ export const TextMd = createMetadata({
         "upstream rather than by matching a search term here — a full-text search snippet, " +
         "for example, whose marks fall on token boundaries that cannot be reproduced by " +
         "substring matching. Segments with `hit` are rendered as highlighted; `active` marks " +
-        `the current occurrence. When set, \`segments\` supplies the \`${COMP}\`'s content and ` +
-        "`highlightText` is ignored.",
+        "the current occurrence. A segment may instead carry `variant`, naming a non-search " +
+        "span kind (such as a changed word in a diff) styled through " +
+        "`backgroundColor-mark-<variant>-" + COMP + "`. Precedence is `active` > `hit` > " +
+        "`variant`, so a segment that is a hit renders as a hit and its variant is ignored, " +
+        `and only \`hit\` segments are counted by \`highlightActiveIndex\`. When set, ` +
+        `\`segments\` supplies the \`${COMP}\`'s content and \`highlightText\` is ignored.`,
       valueType: "any",
     },
   },

--- a/xmlui/src/components/Text/TextReact.tsx
+++ b/xmlui/src/components/Text/TextReact.tsx
@@ -47,6 +47,9 @@ interface CustomVariantCacheEntry {
  */
 const customVariantCache = new Map<string, CustomVariantCacheEntry>();
 
+/** Segment-variant names already warned about, so a long list warns once, not per row. */
+const warnedVariants = new Set<string>();
+
 /**
  * Retrieves a cached custom variant entry if it exists.
  */
@@ -125,6 +128,8 @@ export type HighlightTextSegment = {
   text: string;
   hit?: boolean;
   active?: boolean;
+  /** Names a non-search span kind, styled via `backgroundColor-mark-<variant>-Text`. */
+  variant?: string;
 };
 
 import { defaultProps } from "./Text.defaults";
@@ -215,20 +220,75 @@ export const Text = memo(forwardRef(function Text(
     const callerMarkedActive = validSegments.some((seg) => seg.active);
     let hitOrdinal = 0;
     return validSegments.map((seg, i) => {
-      if (!seg.hit) return <Fragment key={i}>{seg.text}</Fragment>;
-      const ordinal = hitOrdinal++;
-      const isActive = callerMarkedActive ? !!seg.active : ordinal === activeIndex;
-      return (
-        <mark
-          key={i}
-          className={styles.highlightMark}
-          data-active={isActive ? "true" : undefined}
-        >
-          {seg.text}
-        </mark>
-      );
+      // Precedence: active > hit > variant. A segment that is a search hit renders as
+      // one, and its variant is ignored — a span shows one kind at a time.
+      if (seg.hit) {
+        const ordinal = hitOrdinal++;
+        const isActive = callerMarkedActive ? !!seg.active : ordinal === activeIndex;
+        return (
+          <mark
+            key={i}
+            className={styles.highlightMark}
+            data-active={isActive ? "true" : undefined}
+          >
+            {seg.text}
+          </mark>
+        );
+      }
+      // A variant is a different kind of span, not a weaker match, so it is not a
+      // <mark>: consumers count and query marks to find search hits, and putting
+      // variants in that namespace would silently inflate every such count. Note the
+      // ordinal counter is untouched here — variant spans never enter the sequence
+      // highlightActiveIndex walks.
+      if (seg.variant) {
+        return (
+          <span
+            key={i}
+            className={styles.highlightVariant}
+            data-variant={seg.variant}
+            style={{
+              backgroundColor: toCssVar(`$backgroundColor-mark-${seg.variant}-Text`),
+              color: toCssVar(`$textColor-mark-${seg.variant}-Text`),
+            }}
+          >
+            {seg.text}
+          </span>
+        );
+      }
+      return <Fragment key={i}>{seg.text}</Fragment>;
     });
   }, [validSegments, activeIndex]);
+
+  // Dev-only: an undeclared variant renders plain by CSS fallback, which is the right
+  // runtime behavior and a silent one — a typo in a data-driven field looks identical
+  // to a deliberate plain span. Warn once per distinct name rather than per row.
+  useEffect(() => {
+    if (!import.meta.env.DEV || !usingSegments) return;
+    const root = innerRef.current;
+    if (!root) return;
+    const spans = root.querySelectorAll<HTMLElement>("[data-variant]");
+    spans.forEach((el) => {
+      const name = el.dataset.variant;
+      if (!name || warnedVariants.has(name)) return;
+      const token = `--xmlui-backgroundColor-mark-${name}-Text`;
+      // Read from the span itself so scoped theme classes are in scope, not just :root.
+      const declared = getComputedStyle(el).getPropertyValue(token).trim();
+      // Covers both ways a variant renders flat: never declared, and declared with a
+      // reference to an undefined theme variable — the theme layer drops that whole
+      // declaration, so it arrives here as absent rather than as a broken value.
+      if (!declared) {
+        warnedVariants.add(name);
+        console.warn(
+          `Text: segment variant "${name}" has no usable theme value. Define ` +
+            `\`${token.replace("--xmlui-", "")}\` (and optionally ` +
+            `\`textColor-mark-${name}-Text\`) in your theme, or remove the variant. ` +
+            `A declaration that references an undefined theme variable is dropped, so ` +
+            `this fires for a broken \`$token\` reference too. The span renders ` +
+            `unstyled until then.`,
+        );
+      }
+    });
+  }, [usingSegments, segmentChildren]);
 
   const highlightedChildren = useMemo(() => {
     if (needles.length === 0) return children;

--- a/xmlui/src/components/Theme/Theme.spec.ts
+++ b/xmlui/src/components/Theme/Theme.spec.ts
@@ -649,3 +649,39 @@ test.describe("applyIf Edge Cases", () => {
     expect(parentClass).toContain('themeWrapper');
   });
 });
+
+// =============================================================================
+// TOKEN REFERENCES IN INLINE THEME VARS
+// =============================================================================
+
+test.describe("token references in inline theme vars", () => {
+  // Regression: variables declared on a <Theme> were written to CSS raw, so an
+  // app-defined name given a `$token` value landed as that literal string and computed
+  // to nothing. Registered names appeared to work because the theme-definition path
+  // rewrote them separately. Written against a plain variable rather than any one
+  // feature, because every app-defined variable was affected.
+  test("an app-defined variable resolves a $token value", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <App>
+        <Theme app-defined-probe-color="$color-danger-200">
+          <Text testId="t" backgroundColor="$app-defined-probe-color">probe</Text>
+        </Theme>
+      </App>
+    `);
+    await expect(page.getByTestId("t")).toHaveText("probe");
+    const resolved = await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="t"]') as HTMLElement;
+      return {
+        declared: getComputedStyle(el).getPropertyValue("--xmlui-app-defined-probe-color").trim(),
+        bg: getComputedStyle(el).backgroundColor,
+      };
+    });
+    // The contract is that the declaration holds usable CSS, not which form it takes:
+    // a known token may arrive fully resolved to its colour, an indirect one as a
+    // var() reference. What must never survive is the literal "$color-danger-200",
+    // which is what reached the DOM before and computed to nothing.
+    expect(resolved.declared.startsWith("$")).toBe(false);
+    expect(resolved.declared.length).toBeGreaterThan(0);
+    expect(resolved.bg).not.toEqual("rgba(0, 0, 0, 0)");
+  });
+});

--- a/xmlui/src/components/Theme/ThemeReact.tsx
+++ b/xmlui/src/components/Theme/ThemeReact.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../components-core/theming/StyleContext";
 import { useIsomorphicLayoutEffect } from "../../components-core/utils/hooks";
 import { parseHVar } from "../../components-core/theming/hvar";
+import { replaceThemeVarRefs } from "../../components-core/theming/transformThemeVars";
 import { THEME_VAR_PREFIX } from "../../components-core/theming/layout-resolver";
 import { useComponentRegistry } from "../ComponentRegistryContext";
 import baseStyles from "../../index.scss?inline";
@@ -175,7 +176,11 @@ export function Theme({
       if (invalidThemeVarNames.has(key)) {
         return;
       }
-      filteredThemeCssVars[`--${THEME_VAR_PREFIX}-${key}`] = value;
+      // Resolve `$token` references the same way theme definitions do. Without this an
+      // app-defined variable given a `$token` value reaches the DOM as that literal
+      // string and computes to nothing — visible only as the declaration silently
+      // doing nothing, since an invalid custom property raises no error.
+      filteredThemeCssVars[`--${THEME_VAR_PREFIX}-${key}`] = replaceThemeVarRefs(value);
     });
 
     const ret = {

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -19145,7 +19145,7 @@ export default {
         "valueType": "number"
       },
       "segments": {
-        "description": "Pre-computed highlight spans, as an array of `{ text, hit, active }` objects. Use this instead of [`highlightText`](#highlighttext) when the highlights are decided upstream rather than by matching a search term here — a full-text search snippet, for example, whose marks fall on token boundaries that cannot be reproduced by substring matching. Segments with `hit` are rendered as highlighted; `active` marks the current occurrence. When set, `segments` supplies the `Text`'s content and `highlightText` is ignored.",
+        "description": "Pre-computed highlight spans, as an array of `{ text, hit, active }` objects. Use this instead of [`highlightText`](#highlighttext) when the highlights are decided upstream rather than by matching a search term here — a full-text search snippet, for example, whose marks fall on token boundaries that cannot be reproduced by substring matching. Segments with `hit` are rendered as highlighted; `active` marks the current occurrence. A segment may instead carry `variant`, naming a non-search span kind (such as a changed word in a diff) styled through `backgroundColor-mark-<variant>-Text`. Precedence is `active` > `hit` > `variant`, so a segment that is a hit renders as a hit and its variant is ignored, and only `hit` segments are counted by `highlightActiveIndex`. When set, `segments` supplies the `Text`'s content and `highlightText` is ignored.",
         "valueType": "any"
       }
     },


### PR DESCRIPTION
_Jon's Claude speaking from the xmlui project:_

Two changes that ship together because the first is unusable without the second.

## 1. A second span kind for `Text.segments`

`segments` expressed one kind of span: matched, and currently active. Content carrying a second, orthogonal kind — a changed word in a diff, which a row may hold *alongside* search hits — had nowhere to put it. The consequence was that the consumer with the most complex span data was the one that could not adopt the feature, and kept the hand-rolled two-level `inline`/`pre-wrap` construction that `segments` exists to retire.

A segment may now carry `variant`, styled through `backgroundColor-mark-<variant>-Text` and `textColor-mark-<variant>-Text`.

Decisions argued in #3782 rather than assumed:

- **Precedence `active` > `hit` > `variant`**, per segment. A hit renders as a hit and its variant is ignored — one span shows one kind. Composition (background from one, weight from the other) multiplies the theme surface and can produce unreadable combinations.
- **Variant spans are `<span data-variant>`, not `<mark>`.** A mark means a match, and consumers count and query marks to find hits. On a diff row carrying all three kinds, putting variants in that namespace is the difference between "3 hits" and "3 hits plus 31 emphasis spans".
- **Ordinals untouched:** only `hit` segments enter the sequence `highlightActiveIndex` walks, so a variant between two hits cannot desynchronise stepping across row types in a mixed list.
- **Tokens nest under `mark-`** so the three kinds read as siblings of the shipped `mark` / `markActive` variables. Note the element namespace deliberately *separates* variants from marks while the token namespace *unifies* them; `Text.md` names that asymmetry rather than leaving it to be discovered.
- **An undeclared variant renders plain and warns once per name in dev.** A declaration referencing an undefined theme variable is dropped by the theme layer, so it arrives as absent and the same warning covers it — a separate "declared but unresolvable" warning was written and then removed once that shape turned out not to occur.

## 2. Token references in inline theme variables

Found while validating the above. Variables declared inline on a `<Theme>` were written to CSS unchanged, so `"$color-danger-200"` reached the DOM as that literal string and computed to nothing. Silent — an invalid custom property raises no error — so the declaration simply appeared to do nothing.

**This was never specific to variants.** Any app-defined variable declared that way was affected; registered names only appeared to work because they are also carried by the theme-*definition* path, which did run the rewrite. Variants made it unavoidable, since a variant name can never be pre-registered.

The rewrite was private to `ThemeProvider`'s closure. It is now one exported helper both paths call, using `getVarKey` rather than the fixed prefix so `ThemeProvider`'s behaviour is unchanged by construction rather than by coincidence.

> **Release note:** this can change how existing apps look. Declarations that were silently dropped now take effect, so an app that set inline theme variables with `$token` values may see colours it believed it had already set. The reporting app has a live instance: inline Markdown find-mark colours set app-side with a comment asserting the colour was "guaranteed" — which, if those declarations were among the dropped ones, was never true and will now become so.

## Verification

`Text` and `Theme`: **200 passed** dev, **196 passed / 4 skipped** against the production test bed, the skips being exactly the dev-only warnings. `Markdown`, `List`, `Button`: **323 passed**, run because this touched shared theming rather than one component.

Validated downstream on real diffs at scale before merge: both variants resolve distinctly from `$token` values, a hit adjacent to an emphasis renders both kinds on one line, and stepping, counts and reveal are unaffected by variant spans.

**The overlap case** — a hit falling inside an emphasized run, where the match takes the mark and the emphasis survives on the fragments either side — was confirmed as a **human visual judgment on the running build, not an instrument reading**. That is the honest weight to give it, and it is the one question no test on either side can answer.

**Not exercised:** unknown-variant rendering downstream, which would have required deliberately introducing a bogus variant name. Reported as unexercised rather than folded into the pass; it is covered by specs here in both build modes.

One note for anyone verifying candidate bundles from this branch: the two prereleases differed by neither marker counts nor size — the fix is 7 bytes *smaller* than the build it replaced — so only the sha separates them. A marker-plus-size check would have passed on the wrong bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
