### PR TITLE
Add how-to: share one DataSource fetch across components

### DIFF
--- a/website/content/docs/pages/howto/share-one-datasource-fetch-across-components.md
+++ b/website/content/docs/pages/howto/share-one-datasource-fetch-across-components.md
@@ -1,0 +1,117 @@
+# Share one DataSource fetch across components
+
+Two `DataSource` instances with the same `url`, `queryParams`, and `body` are one fetch and one cache entry — mount them wherever you need the data and call `refetch()` when it should change.
+
+When two parts of an app need the same server state, the instinct is to fetch once high in the tree and thread the value down, or to hoist it into a global. Neither is necessary. `DataSource` caches by request, not by component, so mounting it twice with the same inputs calls the endpoint once and hands the same result to both consumers — no matter how far apart they sit, and across user-defined component boundaries that ordinary variables cannot cross.
+
+In this example both cards mount their own `DataSource` against the same URL. The server counts how many times it has actually been called, so you can see that two consumers cost one request. **Refresh** calls `refetch()` on one of them and both update, because they share the entry that was invalidated.
+
+```xmlui-pg copy display name="Two consumers, one fetch"
+---app display /url="/api/status"/ /refetch()/
+<App>
+  <HStack gap="$space-4">
+    <Card width="240px">
+      <Text variant="strong">Card A</Text>
+      <DataSource id="statusA" url="/api/status" />
+      <Text value="queue: {statusA.value.queue}" />
+      <Text variant="secondary" value="server calls: {statusA.value.calls}" />
+    </Card>
+    <Card width="240px">
+      <Text variant="strong">Card B</Text>
+      <DataSource id="statusB" url="/api/status" />
+      <Text value="queue: {statusB.value.queue}" />
+      <Text variant="secondary" value="server calls: {statusB.value.calls}" />
+    </Card>
+  </HStack>
+  <Button label="Refresh" onClick="statusA.refetch()" />
+</App>
+---api
+{
+  "apiUrl": "/api",
+  "operations": {
+    "status": {
+      "url": "/status",
+      "method": "get",
+      "handler": "$state.calls = ($state.calls || 0) + 1; return { queue: 40 + $state.calls, calls: $state.calls };"
+    }
+  }
+}
+```
+
+Both cards show `server calls: 1`. Press **Refresh** and both move to `2` together — one request, two consumers, still in step.
+
+## The trap: a cache-busting parameter splits the entry
+
+The sharing is keyed on the request. Anything that makes the requests differ opts you out of it, and the most common way to do that by accident is a per-component refresh tick appended to the URL:
+
+```xmlui
+<!-- Card A, somewhere in the tree -->
+<DataSource id="statusA" url="/api/status?t={tickA}" />
+
+<!-- Card B, somewhere else -->
+<DataSource id="statusB" url="/api/status?t={tickB}" />
+```
+
+This reads like shared state and is not. Query parameters written into the URL are normalized into the cache key — deliberately, so that `?a=1` in the URL and `queryParams="{{ a: 1 }}"` agree — which means the tick is part of the key rather than decoration. Two ticks that advance independently are two cache entries, and they drift apart the moment each component refreshes on its own trigger.
+
+Worse, it **looks correct at first**. Both ticks start at the same value, so the two URLs are identical on load and the cards really do share one fetch. The split happens on the first *independent* refresh — which is exactly the moment nobody is looking, long after the code was reviewed and shipped.
+
+Nothing warns you at any point. Both components render plausible values, and the disagreement only surfaces when someone compares them.
+
+Try it: both cards start in step, then **Refresh A** advances only A's tick and they part company.
+
+```xmlui-pg copy display name="The anti-pattern: per-component ticks"
+---app display /url="/api/status?t={tickA}"/ /url="/api/status?t={tickB}"/
+<App var.tickA="{1}" var.tickB="{1}">
+  <HStack gap="$space-4">
+    <Card width="240px">
+      <Text variant="strong">Card A</Text>
+      <DataSource id="statusA" url="/api/status?t={tickA}" />
+      <Text value="queue: {statusA.value.queue}" />
+      <Text variant="secondary" value="server calls: {statusA.value.calls}" />
+      <Button label="Refresh A" onClick="tickA = tickA + 1" />
+    </Card>
+    <Card width="240px">
+      <Text variant="strong">Card B</Text>
+      <DataSource id="statusB" url="/api/status?t={tickB}" />
+      <Text value="queue: {statusB.value.queue}" />
+      <Text variant="secondary" value="server calls: {statusB.value.calls}" />
+      <Button label="Refresh B" onClick="tickB = tickB + 1" />
+    </Card>
+  </HStack>
+</App>
+---api
+{
+  "apiUrl": "/api",
+  "operations": {
+    "status": {
+      "url": "/status",
+      "method": "get",
+      "handler": "$state.calls = ($state.calls || 0) + 1; return { queue: 40 + $state.calls, calls: $state.calls };"
+    }
+  }
+}
+```
+
+The fix is to delete the tick and call `refetch()` instead — the first example. That is strictly less markup than the version that breaks.
+
+## Key points
+
+**The cache key is the request, not the component**: identical `url`, `queryParams`, and `body` means one entry. Where the `DataSource` sits in the tree is irrelevant, which is what lets two components share server state across a user-defined component boundary without a shared variable.
+
+**`refetch()` refreshes every consumer**: it invalidates the shared entry, so all bound components re-render with the new value. Call it on any one of them.
+
+**A tick, nonce, or timestamp in the URL is a key difference**: URL query parameters are folded into the cache key, so `?t=…` splits the entry as surely as a different path would. If you want a refresh, use `refetch()`; if you want polling, use `pollIntervalInSeconds`.
+
+**Server state does not need a shared variable**: [Communicate between sibling components](/docs/howto/communicate-between-sibling-components) and globals are the right tools for *app* state. When the thing being shared is a server response, `DataSource` already shares it, and adding a variable on top gives you a second copy to keep in sync.
+
+**After a write, prefer invalidation**: an `APICall` that changes the data can refresh readers through [`invalidates`](/docs/howto/control-cache-invalidation) rather than each consumer polling or ticking.
+
+---
+
+## See also
+
+- [Chain a DataSource refetch](/docs/howto/chain-a-refetch) — refetching a reader after a write completes
+- [Invalidate related data after a write](/docs/howto/control-cache-invalidation) — declarative cache control with `invalidates`
+- [Delay a DataSource until another is ready](/docs/howto/delay-a-datasource-until-another-datasource-is-ready) — chaining dependent requests
+- [Communicate between sibling components](/docs/howto/communicate-between-sibling-components) — the shared-variable pattern, for app state rather than server state

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -699,6 +699,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Share one DataSource fetch across components"
+                            to="/docs/howto/share-one-datasource-fetch-across-components"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Update UI optimistically"
                             to="/docs/howto/update-ui-optimistically"
                         />

--- a/xmlui/tests-e2e/how-to-examples/share-one-datasource-fetch-across-components.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/share-one-datasource-fetch-across-components.spec.ts
@@ -1,0 +1,73 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/share-one-datasource-fetch-across-components.md",
+  ),
+);
+
+test.describe("Two consumers, one fetch", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Two consumers, one fetch",
+  );
+
+  // The claim the whole how-to rests on, and the one a reader cannot see without
+  // the server-side counter: two mounted DataSources against the same URL cost
+  // one request, not two.
+  test("two DataSources against the same url produce a single fetch", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    await expect(page.getByText("server calls: 1")).toHaveCount(2);
+    await expect(page.getByText("queue: 41")).toHaveCount(2);
+  });
+
+  test("refetch on one consumer updates both", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    await expect(page.getByText("server calls: 1")).toHaveCount(2);
+
+    await page.getByRole("button", { name: "Refresh" }).click();
+
+    // Both move together because refetch() invalidates the shared entry rather
+    // than the calling component's private copy.
+    await expect(page.getByText("server calls: 2")).toHaveCount(2);
+    await expect(page.getByText("queue: 42")).toHaveCount(2);
+  });
+});
+
+test.describe("The anti-pattern: per-component ticks", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "The anti-pattern: per-component ticks",
+  );
+
+  // The counterpart claim: a per-component tick in the URL splits the cache, so
+  // the consumers drift. If this ever starts behaving as "shared", the
+  // anti-pattern section has stopped being true and the how-to needs rewriting.
+  test("independent ticks split the cache and the consumers diverge", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    // Both ticks start equal, so the URLs are identical and the cards DO share at
+    // first. This is what makes the bug survive review: it looks correct on load.
+    await expect(page.getByText("server calls: 1")).toHaveCount(2);
+
+    await page.getByRole("button", { name: "Refresh A" }).click();
+
+    // The first independent refresh changes one URL, splitting the cache. Only A
+    // moves, and nothing warns — the two cards simply disagree from here on.
+    await expect(page.getByText("server calls: 2")).toHaveCount(1);
+    await expect(page.getByText("server calls: 1")).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Adds `website/content/docs/pages/howto/share-one-datasource-fetch-across-components.md` for #3809.

## What it documents

The rule: two `DataSource` instances with the same `url`, `queryParams`, and `body` are **one fetch and one cache entry**. Mount them wherever the data is needed and call `refetch()` when it should change — no prop threading, no shared variable, and it works across user-defined component boundaries that ordinary variables cannot cross.

The trap: a per-component tick/nonce/timestamp appended to the URL splits the entry. `normalizeUrlAndParams` deliberately folds URL-embedded query params into `mergedParams`, which is part of the cache key (`xmlui/src/components-core/utils/DataLoaderQueryKeyGenerator.ts:84-100`), so `?t={tick}` is a key difference rather than decoration.

## Two playgrounds, both counting server calls

The mock API handler counts its own invocations and both cards display the count. That counter carries the whole pedagogical load: without it the broken version renders identically to the working one, which is exactly why the bug survives review.

- **Two consumers, one fetch** — two cards, one request; `refetch()` on either moves both.
- **The anti-pattern: per-component ticks** — the same two cards with independent ticks. They **start in step**, because equal ticks make equal URLs, and split on the first *independent* refresh.

## The anti-pattern is worse than the filing described — the fix is not

The filing has the mechanism right and the remedy right. Delete the tick, call `refetch()`. Nothing here changes that.

What changes is the failure's *detectability*. The filing reads as though two ticks produce visible drift from the start. They don't. Both ticks initialize to the same value, so the two URLs are byte-identical and the cache hands both consumers the same entry — **the sharing is genuinely real on mount.** The bug is latent, not present.

That inverts every gate that would catch it:

- **Code review passes.** The reviewer sees two `DataSource`s, runs the app, both cards agree. That *confirms* the "they share" reading rather than challenging it.
- **A smoke test asserting the two agree passes.** So does manual QA on load.
- The split arrives at the first *asymmetric* refresh — user-triggered, arbitrary, possibly long after ship.

And when it surfaces, the symptom is two panels disagreeing about a number, which points at staleness or a race, not at a cache key. The instinctive fix at that point is *more* cache-busting, which entrenches it.

The consequence for this PR is a documentation one rather than an engineering one: **you cannot find this by looking.** If the broken version rendered wrong on load, the how-to would be a nice-to-have — people would hit it, see it, and go digging. Because it renders correctly on load, the doc has to arrive *before* the mistake. Hence the rule stated first, and hence the server-call counter in both playgrounds: the two versions are visually identical at the exact moment anyone would check them, and the counter is the only thing that tells them apart.

## Verification from this side

`xmlui/tests-e2e/how-to-examples/share-one-datasource-fetch-across-components.spec.ts`, 3 passing:

- two `DataSource`s against the same URL produce a single fetch (`server calls: 1` on both cards)
- `refetch()` on one consumer updates both (both to `2`)
- independent ticks split the cache — shared on mount, then only card A advances after **Refresh A**

The spec's third test initially failed because I asserted divergence on mount. The test was wrong, not the doc; the corrected assertion is what the doc now describes.

## Also in this PR

Nav entry in `website/src/Main.xmlui` under **Data Loading & APIs**, beside `chain-a-refetch` and `delay-a-datasource-until-another-datasource-is-ready` — the two documents the failing how-to search actually returns.

## Not in scope

A change to `reference/components/DataSource.md`. The paragraph there states the rule correctly; its problem is location, which a how-to plus cross-links addresses without touching a reference page whose wording is fine.

Refs #3809.
