### PR TITLE
Add rowEnter and rowLeave events to Table

### DIFF
--- a/.changeset/table-row-hover-events.md
+++ b/.changeset/table-row-hover-events.md
@@ -1,0 +1,5 @@
+---
+"xmlui": minor
+---
+
+Add `rowEnter` and `rowLeave` events to Table, so an app can react to the row hover it already displays — linking a table to a detail panel, chart, or map. Handlers attach only when the event is bound, so unbound tables are unchanged.

--- a/.changeset/table-row-hover-events.md
+++ b/.changeset/table-row-hover-events.md
@@ -1,5 +1,5 @@
 ---
-"xmlui": minor
+"xmlui": patch
 ---
 
 Add `rowEnter` and `rowLeave` events to Table, so an app can react to the row hover it already displays — linking a table to a detail panel, chart, or map. Handlers attach only when the event is bound, so unbound tables are unchanged.

--- a/xmlui/src/components/Table/Table.md
+++ b/xmlui/src/components/Table/Table.md
@@ -1988,27 +1988,11 @@ Click on any of the column headers to trigger a new sorting:
 
 This event is triggered when a table row is double-clicked. The handler receives the row's data item as its only argument.
 
-````xmlui copy {4}
-<App>
-  <Table data='{[...]}' onRowDoubleClick="(item) => console.log(item)">
-    <Column bindTo="name"/>
-
-%-EVENT-START rowDoubleClick
-
-This event is triggered when a table row is double-clicked. The handler receives the row's data item as its only argument.
-
 ```xmlui copy {4}
 <App>
   <Table data='{[...]}' onRowDoubleClick="(item) => console.log(item)">
     <Column bindTo="name"/>
     <Column bindTo="quantity"/>
-  </Table>
-</App>
-````
-
-%-EVENT-END
-<Column bindTo="quantity"/>
-
   </Table>
 </App>
 ```
@@ -2025,6 +2009,67 @@ It is only fired for user-driven scrolls; the table's own programmatic scrolls d
 %-EVENT-START visibleRangeDidChange
 
 This event fires when the visible row range changes. It also fires for non-user-scroll changes, such as initial measurement or programmatic scrolling.
+
+%-EVENT-END
+
+%-EVENT-START rowEnter
+
+This event fires when the pointer enters a table row. The handler receives the row's data item as its only argument.
+
+Use it with `rowLeave` to link the table to another view: the table already highlights the hovered row for the user, and these events let the rest of the app react to the same hover — a detail panel, a matching point on a chart, a pin on a map.
+
+Moving between cells within one row does not re-fire the event; only entering and leaving the row itself does.
+
+```xmlui copy {4-5}
+<App var.hovered="{null}">
+  <Table
+    data='{[...]}'
+    onRowEnter="(item) => hovered = item"
+    onRowLeave="() => hovered = null">
+    <Column bindTo="name"/>
+  </Table>
+</App>
+```
+
+Hover a row to see the panel follow it:
+
+```xmlui-pg name="Example: rowEnter and rowLeave"
+<App var.hovered="{null}">
+  <HStack gap="$space-4">
+    <Table
+      width="60%"
+      data='{[
+        { id: 0, name: "Apples", quantity: 5, unit: "pieces", category: "fruits" },
+        { id: 1, name: "Bananas", quantity: 6, unit: "pieces", category: "fruits" },
+        { id: 2, name: "Carrots", quantity: 100, unit: "grams", category: "vegetables" },
+        { id: 3, name: "Spinach", quantity: 1, unit: "bunch", category: "vegetables" },
+        { id: 4, name: "Milk", quantity: 10, unit: "liter", category: "dairy" },
+      ]}'
+      onRowEnter="(item) => hovered = item"
+      onRowLeave="() => hovered = null">
+      <Column bindTo="name"/>
+      <Column bindTo="quantity"/>
+      <Column bindTo="unit"/>
+    </Table>
+    <Card width="40%">
+      <Text when="{!hovered}" variant="secondary" value="Hover a row." />
+      <Fragment when="{hovered}">
+        <Text variant="strong" value="{hovered.name}" />
+        <Text value="{hovered.quantity} {hovered.unit}" />
+        <Text variant="secondary" value="{hovered.category}" />
+      </Fragment>
+    </Card>
+  </HStack>
+</App>
+```
+
+%-EVENT-END
+
+%-EVENT-START rowLeave
+
+This event fires when the pointer leaves a table row. The handler receives the row's data item as its only argument — the row being left, not the one being entered.
+
+Pair it with `rowEnter` to clear whatever that event set. See the [`rowEnter`](#rowenter) example.
 
 %-EVENT-END
 

--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -6972,3 +6972,91 @@ test.describe("Table in HStack layout", () => {
     expect(vs1Box!.width + vs2Box!.width).toBeGreaterThan(hstackBox!.width * 0.8);
   });
 });
+
+// =============================================================================
+// ROW HOVER EVENTS
+// =============================================================================
+
+test.describe("row hover events", () => {
+  const DATA = `{[
+    { id: 0, name: "Apples", quantity: 5 },
+    { id: 1, name: "Bananas", quantity: 6 }
+  ]}`;
+
+  test("rowEnter fires with the hovered row item", async ({ initTestBed, page }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table data='${DATA}' onRowEnter="(item) => testState = item.name">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await page.getByRole("cell", { name: "Bananas" }).hover();
+    await expect.poll(testStateDriver.testState).toEqual("Bananas");
+  });
+
+  test("rowLeave fires with the row that was left", async ({ initTestBed, page }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table data='${DATA}' onRowLeave="(item) => testState = 'left:' + item.name">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await page.getByRole("cell", { name: "Apples" }).hover();
+    await page.getByRole("cell", { name: "Bananas" }).hover();
+    await expect.poll(testStateDriver.testState).toEqual("left:Apples");
+  });
+
+  // The obvious way to get this wrong is to put the handlers on cells rather
+  // than the row, which turns every horizontal move into a leave/enter pair.
+  test("moving between cells of the same row does not re-fire", async ({ initTestBed, page }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Fragment var.enters="{0}">
+        <Table data='${DATA}' onRowEnter="() => { enters = enters + 1; testState = enters; }">
+          <Column bindTo="name"/>
+          <Column bindTo="quantity"/>
+        </Table>
+      </Fragment>
+    `);
+
+    await page.getByRole("cell", { name: "Apples" }).hover();
+    await expect.poll(testStateDriver.testState).toEqual(1);
+
+    // Same row, different cell — no second enter, and no leave in between.
+    await page.getByRole("cell", { name: "5", exact: true }).hover();
+    await expect.poll(testStateDriver.testState).toEqual(1);
+  });
+
+  // The zero-cost claim, asserted rather than assumed: row hover fires on every
+  // traverse of a virtualized list, so an unbound table must register no
+  // listener at all rather than attaching one that returns early.
+  test("no hover listener is attached when the events are unbound", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Table data='${DATA}'>
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    const row = page.getByRole("row").filter({ hasText: "Apples" });
+    await expect(row).toBeVisible();
+
+    // React records its handlers on the DOM node's internal props bag; an
+    // unattached event is absent from it entirely.
+    const handlers = await row.evaluate((el) => {
+      const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"));
+      const props: any = key ? (el as any)[key] : {};
+      return {
+        onMouseEnter: typeof props?.onMouseEnter,
+        onMouseLeave: typeof props?.onMouseLeave,
+      };
+    });
+
+    expect(handlers.onMouseEnter).toBe("undefined");
+    expect(handlers.onMouseLeave).toBe("undefined");
+  });
+});

--- a/xmlui/src/components/Table/Table.tsx
+++ b/xmlui/src/components/Table/Table.tsx
@@ -536,6 +536,26 @@ export const TableMd = createMetadata({
         item: "The clicked table row item.",
       },
     },
+    rowEnter: {
+      description:
+        `This event is fired when the pointer enters a table row. The handler receives the ` +
+        `row item as its only argument. Use it with \`rowLeave\` to link the table to another ` +
+        `view — highlighting the matching point on a chart, or showing the hovered record in a ` +
+        `detail panel. Moving between cells of the same row does not re-fire it.`,
+      signature: "rowEnter(item: any): void",
+      parameters: {
+        item: "The hovered table row item.",
+      },
+    },
+    rowLeave: {
+      description:
+        `This event is fired when the pointer leaves a table row. The handler receives the row ` +
+        `item as its only argument. Pair it with \`rowEnter\` to clear whatever that event set.`,
+      signature: "rowLeave(item: any): void",
+      parameters: {
+        item: "The table row item the pointer left.",
+      },
+    },
     scroll: {
       description:
         `This event fires as the user scrolls the table. The handler receives an object ` +
@@ -835,6 +855,12 @@ const TableWithColumns = memo(
       const stableRowDoubleClick = useEvent((...args: any[]) =>
         lookupEventHandler("rowDoubleClick")?.(...args),
       );
+      const stableRowEnter = useEvent((...args: any[]) =>
+        lookupEventHandler("rowEnter")?.(...args),
+      );
+      const stableRowLeave = useEvent((...args: any[]) =>
+        lookupEventHandler("rowLeave")?.(...args),
+      );
       const stableScroll = useEvent((...args: any[]) => lookupEventHandler("scroll")?.(...args));
       const stableVisibleRangeDidChange = useEvent((...args: any[]) =>
         lookupEventHandler("visibleRangeDidChange")?.(...args),
@@ -1100,6 +1126,8 @@ const TableWithColumns = memo(
             onSelectionDidChange={stableSelectionDidChange}
             willSort={stableWillSort}
             rowDoubleClick={node.events?.rowDoubleClick ? stableRowDoubleClick : undefined}
+            rowEnter={node.events?.rowEnter ? stableRowEnter : undefined}
+            rowLeave={node.events?.rowLeave ? stableRowLeave : undefined}
             onScroll={node.events?.scroll ? stableScroll : undefined}
             onVisibleRangeDidChange={
               node.events?.visibleRangeDidChange ? stableVisibleRangeDidChange : undefined

--- a/xmlui/src/components/Table/TableReact.tsx
+++ b/xmlui/src/components/Table/TableReact.tsx
@@ -451,6 +451,8 @@ type TableProps = {
   checkboxTolerance?: CheckboxTolerance;
   rowHeight?: number;
   rowDoubleClick?: (item: any) => void;
+  rowEnter?: (item: any) => void;
+  rowLeave?: (item: any) => void;
   headerUserSelect?: string;
   cellUserSelect?: string;
   userSelectCell?: string;
@@ -1181,6 +1183,8 @@ export const Table = memo(
       checkboxTolerance = defaultProps.checkboxTolerance,
       rowHeight = defaultProps.rowHeight,
       rowDoubleClick,
+      rowEnter,
+      rowLeave,
       headerUserSelect,
       cellUserSelect,
       userSelectCell,
@@ -1989,6 +1993,8 @@ export const Table = memo(
       enableMultiRowSelection,
       lookupEventHandler,
       rowDoubleClick,
+      rowEnter,
+      rowLeave,
       striped,
       rowHeight,
       renderVersion: rowRenderVersion,
@@ -2261,6 +2267,38 @@ export const Table = memo(
                   }
                 }
               }}
+              // Hover handlers attach only when the app binds the event. An
+              // unbound table registers no listener at all: row hover fires on
+              // every traverse of a virtualized list, so the unused case must
+              // cost nothing rather than merely returning early.
+              onMouseEnter={
+                rowStateRef.current.rowEnter
+                  ? () => {
+                      const { rowEnter: enter } = rowStateRef.current;
+                      if (enter && typeof enter === "function") {
+                        try {
+                          enter(row.original);
+                        } catch (e) {
+                          console.error("Error in rowEnter handler:", e);
+                        }
+                      }
+                    }
+                  : undefined
+              }
+              onMouseLeave={
+                rowStateRef.current.rowLeave
+                  ? () => {
+                      const { rowLeave: leave } = rowStateRef.current;
+                      if (leave && typeof leave === "function") {
+                        try {
+                          leave(row.original);
+                        } catch (e) {
+                          console.error("Error in rowLeave handler:", e);
+                        }
+                      }
+                    }
+                  : undefined
+              }
               onContextMenu={
                 rowStateRef.current.lookupEventHandler
                   ? (event) => {

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -18086,6 +18086,20 @@ export default {
           "item": "The clicked table row item."
         }
       },
+      "rowEnter": {
+        "description": "This event is fired when the pointer enters a table row. The handler receives the row item as its only argument. Use it with `rowLeave` to link the table to another view — highlighting the matching point on a chart, or showing the hovered record in a detail panel. Moving between cells of the same row does not re-fire it.",
+        "signature": "rowEnter(item: any): void",
+        "parameters": {
+          "item": "The hovered table row item."
+        }
+      },
+      "rowLeave": {
+        "description": "This event is fired when the pointer leaves a table row. The handler receives the row item as its only argument. Pair it with `rowEnter` to clear whatever that event set.",
+        "signature": "rowLeave(item: any): void",
+        "parameters": {
+          "item": "The table row item the pointer left."
+        }
+      },
       "scroll": {
         "description": "This event fires as the user scrolls the table. The handler receives an object describing the current scroll state. It is only fired for user-driven scrolls; the table's own programmatic scrolls do not trigger it. Use it together with the `atEnd` flag and the `scrollToBottom()` method to implement follow-newest and read-pause behavior, or with `visibleRange` and `itemCount` to display a visible row range.",
         "signature": "scroll(event: { scrollTop: number, scrollHeight: number, viewportSize: number, atEnd: boolean, visibleRange: { startIndex: number, endIndex: number }, itemCount: number }): void",


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Adds `rowEnter` and `rowLeave` events to `Table`.

## The gap

`Table` already had hover **styling** — `backgroundColor-row-Table--hover` and its siblings for pinned cells, selected rows, and the selection cell — but no hover **events**. All of it is CSS-only (`Table.module.scss`), with no JS mouse handling anywhere in the component; the declared event list went `contextMenu`, `sortingDidChange`, `willSort`, `rowDoubleClick`, `scroll`, `visibleRangeDidChange`, `selectionDidChange` plus the clipboard actions, and nothing hover-shaped.

So the hover was visible to the user and unobservable by the app. Linking a table to another view — a detail panel, the matching point on a chart, a pin on a map — was not expressible. `ReactFlowCanvas` gained exactly this pairing recently (`onNodeEnter` / `onNodeLeave` / `onNodeClick` with controlled emphasis); `Table` is the more common half of that pattern and could not participate.

## What this adds

- `rowEnter(item: any)` — pointer enters a row.
- `rowLeave(item: any)` — pointer leaves it, receiving the row being *left*.

Both receive the row's data item, matching `rowDoubleClick` so the three read as a family. Moving between cells within one row fires neither, since the handlers sit on the row element.

`rowEnter` / `rowLeave` was chosen over `rowMouseEnter` / `rowMouseLeave` to match the `nodeEnter` / `nodeLeave` naming already in the tree for the same use case, and because the literal-device spelling would be wrong-footed if focus-driven highlighting is ever added.

## The design constraint, and how it is verified

Row hover fires on every traverse, and `Table` is virtualized. Routing that into the scripting engine unconditionally would be a real cost on a wide table.

So handlers attach **only when the app binds the event**, following the conditional shape of `onContextMenu` rather than `onDoubleClick` — the latter attaches unconditionally and checks inside, which is fine for a rare event and wrong for hover. An unbound table registers no listener at all.

That claim is asserted rather than written: one test reads the row element's React props bag and requires both `onMouseEnter` and `onMouseLeave` to be literally absent when the events are unbound.

## Verification

- Full `Table.spec.ts` suite green: **259 passed**.
- Four new tests: `rowEnter` fires with the right item; `rowLeave` fires with the row left; moving between cells of one row does not re-fire; no listener attached when unbound.
- Built as a standalone bundle and **vendored into a downstream application, where it has been exercised end to end** — the events drive a real feature there, not just a playground.

## Also in this PR

**Repairs the adjacent `rowDoubleClick` docs block.** `Table.md` carried a duplicated `%-EVENT-START rowDoubleClick` nested inside the first, with mismatched code fences and orphaned markup trailing the inner `%-EVENT-END` — which is why that event's published reference page renders garbled. Collapsed to one correct block; markers now balance 8/8 with no duplicate names. Pre-existing, noticed only because this change put new event sections in the same file.

**Regenerates `xmlui-metadata-generated.js`** for the two new events. `check:metadata-snapshot` verifies this file, so omitting it would land a red build.

Docs include a playground showing the linking pattern the events exist for: a table beside a card that follows the hovered row.

## Changeset

`minor`, not `patch` — this is new public event surface on a core component.

## Noted in passing, not addressed here

`npm run check:metadata` reports `Metadata drift check passed (0 component metadata exports checked)`. It inspected nothing, so its green proves nothing; `check:metadata-snapshot` is the check with teeth. Unrelated to this change and left alone, but worth someone's attention.

Two pre-existing TypeScript errors surface during the standalone build, in `src/components-core/rendering/reducer.ts` and `src/components/DataSource/DataSource.spec.ts`. Neither is touched by this PR and the build succeeds regardless.
