### PR TITLE
Repair component doc section markers, restoring the lost Stack description

### DIFF
--- a/website/content/docs/reference/components/Stack.md
+++ b/website/content/docs/reference/components/Stack.md
@@ -2,6 +2,53 @@
 
 `Stack` is the fundamental layout container that organizes child elements in configurable horizontal or vertical arrangements. As the most versatile building block in XMLUI's layout system, it provides comprehensive alignment, spacing, and flow control options that serve as the foundation for all specialized stack variants.
 
+**Key features:**
+- **Dynamic orientation**: Switch between horizontal and vertical layouts programmatically
+- **Comprehensive alignment**: Precise control over both horizontal and vertical child positioning
+- **Flexible spacing**: Configurable gaps between elements with theme-aware sizing
+- **Content wrapping**: Automatic wrapping when space constraints require it
+- **Order control**: Reverse child element order with the reverse property
+- **Dock layout**: Anchor children to edges or fill remaining space using the `dock` prop
+- **Foundation for variants**: Powers HStack, VStack, CHStack, and CVStack specialized components
+
+For common scenarios, consider the specialized variants: [HStack](/docs/reference/components/HStack) (horizontal), [VStack](/docs/reference/components/VStack) (vertical), [CHStack](/docs/reference/components/CHStack) (centered horizontal), and [CVStack](/docs/reference/components/CVStack) (centered vertical).
+
+## Dock Layout [#dock-layout]
+
+Setting the `dock` prop on any direct child of a `Stack` switches the parent into **DockPanel layout mode**. Children are anchored to the edges of the parent in declaration order, with the remainder of the space filled by the `stretch` child.
+
+| `dock` value | Behavior |
+|---|---|
+| `"top"` | Anchored to the top edge, full width, respects its own `height` |
+| `"bottom"` | Anchored to the bottom edge, full width, respects its own `height` |
+| `"left"` | Anchored to the left of the middle row, respects its own `width` |
+| `"right"` | Anchored to the right of the middle row, respects its own `width` |
+| `"stretch"` | Fills all remaining space in the middle row; its `width` and `height` are ignored |
+
+Children without a `dock` prop participate as undocked items in the middle row alongside any `stretch` child.
+
+> [!NOTE]
+> The parent `Stack` must have a defined `height` for `dock="bottom"` children to anchor to the bottom edge. Without a bounded height the outer flex column has no fixed size and bottom items follow immediately after top items.
+
+```xmlui-pg copy display name="Example: dock layout"
+<App>
+  <Stack height="300px" width="400px" gap="0">
+    <Stack dock="top" height="50px" backgroundColor="coral">
+      <Text>Top</Text>
+    </Stack>
+    <Stack dock="bottom" height="50px" backgroundColor="cornflowerblue">
+      <Text>Bottom</Text>
+    </Stack>
+    <Stack dock="left" width="30%" backgroundColor="lightgreen">
+      <Text>Left</Text>
+    </Stack>
+    <Stack dock="stretch" backgroundColor="lightyellow">
+      <Text>Stretch</Text>
+    </Stack>
+  </Stack>
+</App>
+```
+
 ## Behaviors [#behaviors]
 
 This component supports the following behaviors:

--- a/xmlui/src/components/Card/Card.md
+++ b/xmlui/src/components/Card/Card.md
@@ -1,4 +1,4 @@
-%-desc-START
+%-DESC-START
 
 **Key features:**
 - **Pre-styled elements**: Built-in support for `title`, `subtitle`, and `avatarUrl` properties

--- a/xmlui/src/components/FormItem/FormItem.md
+++ b/xmlui/src/components/FormItem/FormItem.md
@@ -460,8 +460,6 @@ Note how changing the input in the demo below will result in a slight delay of i
 
 %-PROP-END
 
-%-PROP-END
-
 %-EVENT-START validate
 
 In the demo below, leave the field as is and submit the form or enter an input that is not all capital letters.

--- a/xmlui/src/components/Stack/Stack.md
+++ b/xmlui/src/components/Stack/Stack.md
@@ -46,6 +46,8 @@ Children without a `dock` prop participate as undocked items in the middle row a
   </Stack>
 </App>
 ```
+%-DESC-END
+
 %-PROP-START gap
 
 In the following example we use pixels, characters (shorthand `ch`), and the `em` CSS unit size which is a relative size to the font size of the element (See size values).

--- a/xmlui/src/components/StickyBox/StickyBox.md
+++ b/xmlui/src/components/StickyBox/StickyBox.md
@@ -1,4 +1,4 @@
-%-desc-START
+%-DESC-START
 
 **When to use.** `StickyBox` fits app- and page-level chrome whose scroll
 container is the page itself — a persistent navigation bar, or a "Save changes"


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Two commits: a marker repair across four component docs, and the regenerated page that repair turned out to actually fix — plus a correction to what the first commit claimed.

## The user-visible bug

The published **Stack** reference page was missing its entire "Key features" block — dynamic orientation, comprehensive alignment, flexible spacing, content wrapping, order control, dock layout. 47 lines, absent from the page.

Cause: `Stack.md` was missing the `%-DESC-END` that closes its description. `resolveSection` matches lazily between START and END, so with no END the section never resolves and returns empty. The docs build does not treat an unbalanced marker as an error, so it failed silently.

## The correction

`ec44db7`'s message says the consequential faults were in `Card.md` and `StickyBox.md` — that a lowercase `%-desc-START` never matched its uppercase `%-DESC-END`, dropping both descriptions from their published pages.

**That is wrong.** `resolveSection` compiles its matcher with the `"i"` flag:

```js
const match = data.match(new RegExp(`${startDirective}([\\s\\S]*?)${endDirective}`, "i"));
```

Marker casing has never mattered. The earlier analysis traced how the directive is *built* (`MetadataProcessor.mjs:587`, `constants.mjs:129`) and never reached the fifteen lines below where it is *used* — and the published Card page carried its description throughout, which would have contradicted the claim at any point.

Regenerating the docs settles it empirically. Of the four files `ec44db7` touched, exactly one changed the published output:

| file | verdict |
| --- | --- |
| **Stack.md** | **real** — missing `%-DESC-END`, section never resolved, 47 lines lost |
| Card.md | cosmetic — case-insensitive match, nothing was broken |
| StickyBox.md | cosmetic — same |
| FormItem.md | cosmetic — the orphaned `%-PROP-END` changed no output |

So `ec44db7` remains a correct repair and all four files are now consistent; only its explanation was inverted. The true marker faults were `FormItem.md` and `Stack.md`, and Stack's was the only one that cost a reader anything.

`ec44db7` is left as-is rather than amended — it is recorded in worklist history by SHA, and rewriting it would orphan that reference permanently. The correction belongs in a follow-up, which is what this is.

## Scope

Deliberately narrow. Running `generate-docs` also rewrote ten other reference pages — unrelated pre-existing drift between committed output and current metadata, plus `Table.md` picking up in-progress work that is not committed. None of that belongs here, and those files were restored rather than swept in.

## Verification

Docs server, all four routes 200, and the Stack page now renders the restored block:

- `/docs/reference/components/Stack`
- `/docs/reference/components/Card`
- `/docs/reference/components/StickyBox`
- `/docs/reference/components/FormItem`

## Two follow-ups, not addressed here

**Nothing validates these markers at build time.** Five files had drifted — the four here plus `Table.md`, repaired separately in `270b661` where a duplicated `%-EVENT-START rowDoubleClick` had been pasted inside the first with mismatched fences. All five went unnoticed until a manual audit. A balance check over `xmlui/src/components/**/*.md` would be a few lines and would catch every one at authoring time.

**Nothing flags that committed reference pages have drifted from what `generate-docs` would produce.** Ten pages changed on a routine regeneration, unrelated to any change in this PR. That drift is invisible until someone happens to run the generator.
