### PR TITLE
Add rowClick event and opt-in column hover highlight to Table

### DIFF
--- a/.changeset/table-column-hover-styling.md
+++ b/.changeset/table-column-hover-styling.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Add an opt-in `highlightHoveredColumn` prop to Table. When set to `true`, hovering a cell tints its entire column with the `backgroundColor-column-Table--hover` theme variable, using a CSS custom property written directly to the table root on cell hover so a horizontal traverse costs a style write rather than a re-render per cell. The default is `false`: no cell hover handlers are attached and the rendered output is unchanged. Where the hovered row and hovered column intersect, the row highlight wins; pinned columns keep their existing hover background instead of the column tint.

--- a/.changeset/table-row-click-event.md
+++ b/.changeset/table-row-click-event.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Add a `rowClick` event to Table, fired when a table row is clicked. It reports the click without replacing or suppressing selection — pair it with `rowsSelectable` deliberately, and prefer `selectionDidChange` when what you actually care about is the selection. It does not fire for clicks on the selection checkbox or on an interactive control inside a cell.

--- a/xmlui/src/components/Card/Card.md
+++ b/xmlui/src/components/Card/Card.md
@@ -1,4 +1,4 @@
-%-desc-START
+%-DESC-START
 
 **Key features:**
 - **Pre-styled elements**: Built-in support for `title`, `subtitle`, and `avatarUrl` properties

--- a/xmlui/src/components/FormItem/FormItem.md
+++ b/xmlui/src/components/FormItem/FormItem.md
@@ -460,8 +460,6 @@ Note how changing the input in the demo below will result in a slight delay of i
 
 %-PROP-END
 
-%-PROP-END
-
 %-EVENT-START validate
 
 In the demo below, leave the field as is and submit the form or enter an input that is not all capital letters.

--- a/xmlui/src/components/Stack/Stack.md
+++ b/xmlui/src/components/Stack/Stack.md
@@ -46,6 +46,8 @@ Children without a `dock` prop participate as undocked items in the middle row a
   </Stack>
 </App>
 ```
+%-DESC-END
+
 %-PROP-START gap
 
 In the following example we use pixels, characters (shorthand `ch`), and the `em` CSS unit size which is a relative size to the font size of the element (See size values).

--- a/xmlui/src/components/StickyBox/StickyBox.md
+++ b/xmlui/src/components/StickyBox/StickyBox.md
@@ -1,4 +1,4 @@
-%-desc-START
+%-DESC-START
 
 **When to use.** `StickyBox` fits app- and page-level chrome whose scroll
 container is the page itself — a persistent navigation bar, or a "Save changes"

--- a/xmlui/src/components/Table/Table.defaults.ts
+++ b/xmlui/src/components/Table/Table.defaults.ts
@@ -51,4 +51,5 @@ export const defaultProps = {
   },
   alwaysShowHeader: false,
   striped: false,
+  highlightHoveredColumn: false,
 };

--- a/xmlui/src/components/Table/Table.md
+++ b/xmlui/src/components/Table/Table.md
@@ -1733,6 +1733,47 @@ You can use these accelerator key names:
 
 %-PROP-END
 
+%-PROP-START highlightHoveredColumn
+
+Column headers already highlight on hover, but by default hovering a cell in the table body only highlights its row — nothing marks which column you are in. On a wide table this makes it easy to lose track of which field you are reading as your eye travels down a column.
+
+Set `highlightHoveredColumn` to `true` to tint the entire hovered column with the [`backgroundColor-column-Table--hover`](#backgroundcolor-column-table--hover) theme variable. The default is `false`: no cell hover handlers are attached and the table renders exactly as it does today.
+
+Where the hovered row and the hovered column intersect, the row highlight wins — the column tint never competes with or muddies the row's own hover color. Pinned columns keep their existing hover background instead of showing the column tint, since the pointer being elsewhere in the table should not change how a pinned column looks.
+
+```xmlui copy /highlightHoveredColumn="true"/
+<App>
+  <Table data='{[...]}' highlightHoveredColumn="true">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+    <Column bindTo="unit"/>
+  </Table>
+</App>
+```
+
+Hover any cell to see its whole column tinted, and hover a row to see the row highlight take precedence where the two overlap:
+
+```xmlui-pg name="Example: highlightHoveredColumn"
+<App>
+  <Table
+    data='{[
+      { id: 0, name: "Apples", quantity: 5, unit: "pieces", category: "fruits" },
+      { id: 1, name: "Bananas", quantity: 6, unit: "pieces", category: "fruits" },
+      { id: 2, name: "Carrots", quantity: 100, unit: "grams", category: "vegetables" },
+      { id: 3, name: "Spinach", quantity: 1, unit: "bunch", category: "vegetables" },
+      { id: 4, name: "Milk", quantity: 10, unit: "liter", category: "dairy" }
+    ]}'
+    highlightHoveredColumn="true">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+    <Column bindTo="unit"/>
+    <Column bindTo="category"/>
+  </Table>
+</App>
+```
+
+%-PROP-END
+
 %-EVENT-START sortingDidChange
 
 Note the [`canSort`](/docs/reference/components/Column#cansort-default-true) properties on the `Column` components which enable custom ordering.
@@ -1991,6 +2032,23 @@ This event is triggered when a table row is double-clicked. The handler receives
 ```xmlui copy {4}
 <App>
   <Table data='{[...]}' onRowDoubleClick="(item) => console.log(item)">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+  </Table>
+</App>
+```
+
+%-EVENT-END
+
+%-EVENT-START rowClick
+
+This event is triggered when a table row is clicked. The handler receives the row's data item as its only argument.
+
+`rowClick` reports activation — it does not replace or suppress selection. Row click already runs a selection toggle when `rowsSelectable` is set, and `rowClick` fires alongside that without interfering with it: pair it with `rowsSelectable` deliberately, and prefer [`selectionDidChange`](#selectiondidchange) when what you actually care about is the selection rather than the click itself. `rowClick` does not fire for a click on the selection checkbox, nor for a click on an interactive control (such as a button) inside a cell.
+
+```xmlui copy {4}
+<App>
+  <Table data='{[...]}' onRowClick="(item) => console.log(item)">
     <Column bindTo="name"/>
     <Column bindTo="quantity"/>
   </Table>

--- a/xmlui/src/components/Table/Table.module.scss
+++ b/xmlui/src/components/Table/Table.module.scss
@@ -50,6 +50,7 @@ $borderBottom-last-row-Table: createThemeVar("borderBottom-last-row-Table");
 $borderColor-cell-Table: createThemeVar("borderColor-cell-Table");
 $backgroundColor-pinnedCell-Table: createThemeVar("backgroundColor-pinnedCell-#{$component}");
 $backgroundColor-pinnedCell-Table--hover: createThemeVar("backgroundColor-pinnedCell-#{$component}--hover");
+$backgroundColor-column-Table--hover: createThemeVar("backgroundColor-column-#{$component}--hover");
 $borderColor-Checkbox--hover: createThemeVar("Input:borderColor-Checkbox--hover");
 
 @layer components {
@@ -178,6 +179,31 @@ $borderColor-Checkbox--hover: createThemeVar("Input:borderColor-Checkbox--hover"
   // last column is resized narrower than the table.
   .columnCell {
     border-bottom: $borderBottom-cell-Table;
+  }
+
+  // Column hover highlight (opt-in via highlightHoveredColumn, off by default).
+  // TableReact writes --xmlui-hovered-col-index to the table wrapper on cell
+  // mouseenter, outside React state; each non-pinned cell carries its own static
+  // --xmlui-col-index. Neither is written when the prop is off, so the diff below
+  // falls back to values far enough apart that the mix amount is always 0 and this
+  // rule paints nothing extra. This is a plain, low-specificity `.cell` rule on
+  // purpose: the existing row-hover and selected-row rules below already select
+  // `.cell` through a more specific ancestor chain (e.g. `.row:hover .cell`), so
+  // they already win over this rule at the intersection through specificity alone,
+  // and a pinned cell's own inline `background-color` (see getCommonPinningStyles)
+  // wins over any class rule regardless.
+  .cell {
+    --xmlui-col-diff: calc(var(--xmlui-hovered-col-index, -9999) - var(--xmlui-col-index, -8888));
+    --xmlui-col-diff-abs: max(var(--xmlui-col-diff), calc(var(--xmlui-col-diff) * -1));
+    // 1 when this cell's column is the hovered column, 0 otherwise (never
+    // fractional, since both indexes are integers), consumed as an alpha
+    // channel below rather than blended with color-mix() — a plain alpha on
+    // the theme color keeps the same underlying rgb() triplet regardless of
+    // match state, which matters for anyone reading the computed style.
+    --xmlui-col-hover-amount: clamp(0, calc(1 - var(--xmlui-col-diff-abs)), 1);
+    background-color: rgb(
+      from $backgroundColor-column-Table--hover r g b / var(--xmlui-col-hover-amount, 0)
+    );
   }
 
   .table {

--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -7154,3 +7154,256 @@ test.describe("row hover events", () => {
     expect(handlers.onMouseLeave).toBe("undefined");
   });
 });
+
+// =============================================================================
+// ROW CLICK EVENT
+// =============================================================================
+
+test.describe("rowClick event", () => {
+  const DATA = `{[
+    { id: 0, name: "Apples", quantity: 5 },
+    { id: 1, name: "Bananas", quantity: 6 }
+  ]}`;
+
+  test("fires with the correct row item on a plain click", async ({ initTestBed, page }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table data='${DATA}' onRowClick="(item) => testState = item.name">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await page.getByRole("cell", { name: "Bananas" }).click();
+    await expect.poll(testStateDriver.testState).toEqual("Bananas");
+  });
+
+  // Row click already runs a selection toggle when the click lands on the selection
+  // checkbox; rowClick must not fire for that click, only report it.
+  test("does not fire when the click lands on the selection checkbox", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table
+        data='${DATA}'
+        rowsSelectable="true"
+        alwaysShowSelectionCheckboxes="true"
+        onRowClick="(item) => testState = item.name">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    // nth(0) is the header select-all checkbox; nth(1) is the first data row's.
+    const firstCheckbox = page.locator("input[type='checkbox']").nth(1);
+    await firstCheckbox.click();
+
+    // The click did land on the row and toggled selection...
+    await expect(firstCheckbox).toBeChecked();
+    // ...but rowClick did not fire for it.
+    expect(await testStateDriver.testState()).toBeNull();
+  });
+
+  test("does not fire when the click lands on an interactive cell control", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table data='${DATA}' onRowClick="(item) => testState = item.name">
+        <Column bindTo="name">
+          <Button testId="{'button' + $itemIndex}" label="{$cell}" />
+        </Column>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await page.getByTestId("button0").click();
+    expect(await testStateDriver.testState()).toBeNull();
+  });
+
+  test("selection still toggles normally with the event bound", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table
+        data='${DATA}'
+        rowsSelectable="true"
+        toggleSelectionOnClick="true"
+        onRowClick="(item) => testState = item.name">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    const firstRow = page.locator("tbody tr").first();
+    await firstRow.click();
+
+    const firstCheckbox = page.locator("input[type='checkbox']").nth(1);
+    await expect(firstCheckbox).toBeChecked();
+    await expect.poll(testStateDriver.testState).toEqual("Apples");
+  });
+
+  // Unlike rowEnter/rowLeave (which attach onMouseEnter/onMouseLeave only when bound,
+  // since hover fires on every traverse of a virtualized list), the row's onClick handler
+  // is always attached for double-click detection and selection. What's conditional is
+  // whether it invokes a rowClick callback — verified here by confirming no handler runs
+  // when the event isn't bound.
+  test("no rowClick handler is invoked when the event is unbound", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table data='${DATA}'>
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await page.getByRole("cell", { name: "Apples" }).click();
+    expect(await testStateDriver.testState()).toBeNull();
+  });
+});
+
+// =============================================================================
+// COLUMN HOVER HIGHLIGHT (highlightHoveredColumn)
+// =============================================================================
+
+test.describe("column hover highlight", () => {
+  const DATA = `{[
+    { id: 0, name: "Apples", quantity: 5 },
+    { id: 1, name: "Bananas", quantity: 6 }
+  ]}`;
+
+  // The column tint composites the theme color through a CSS alpha function
+  // (see Table.module.scss) — 0% alpha where the column is not the hovered
+  // one, 100% where it is — so a match can compute-serialize as either legacy
+  // `rgb(r, g, b)` or modern `color(srgb r g b [/ a])` depending on the
+  // browser, and a non-match keeps the same r/g/b channel values with alpha 0
+  // rather than switching to a different color. Parse either form into an
+  // [r, g, b, a] tuple (0-255 channels, 0-1 alpha) so the assertions below
+  // check the actual visible color, not one particular serialization of it.
+  async function backgroundRgba(locator: Locator): Promise<[number, number, number, number]> {
+    const raw = await locator.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const legacy = raw.match(
+      /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/,
+    );
+    if (legacy) {
+      return [
+        Number(legacy[1]),
+        Number(legacy[2]),
+        Number(legacy[3]),
+        legacy[4] !== undefined ? Number(legacy[4]) : 1,
+      ];
+    }
+    const modern = raw.match(
+      /^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)$/,
+    );
+    if (modern) {
+      return [
+        Math.round(Number(modern[1]) * 255),
+        Math.round(Number(modern[2]) * 255),
+        Math.round(Number(modern[3]) * 255),
+        modern[4] !== undefined ? Number(modern[4]) : 1,
+      ];
+    }
+    throw new Error(`Unrecognized computed background-color: ${raw}`);
+  }
+
+  test("hovering a cell tints every cell in its column when enabled", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(
+      `
+        <Table data='${DATA}' highlightHoveredColumn="true">
+          <Column bindTo="name"/>
+          <Column bindTo="quantity"/>
+        </Table>
+      `,
+      {
+        testThemeVars: { "backgroundColor-column-Table--hover": "rgb(10, 20, 30)" },
+      },
+    );
+
+    // Hover the "quantity" cell in the first row.
+    await page.getByRole("cell", { name: "5", exact: true }).hover();
+
+    // The other row's cell in the SAME column is tinted too...
+    const sameColumnOtherRow = page.getByRole("cell", { name: "6", exact: true });
+    await expect.poll(() => backgroundRgba(sameColumnOtherRow)).toEqual([10, 20, 30, 1]);
+
+    // ...while a cell in a DIFFERENT column is not.
+    const differentColumnCell = page.getByRole("cell", { name: "Apples" });
+    await expect(differentColumnCell).not.toHaveCSS("background-color", "rgb(10, 20, 30)");
+    expect(await backgroundRgba(differentColumnCell)).not.toEqual([10, 20, 30, 1]);
+  });
+
+  test("the row highlight wins where the hovered row and column intersect", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(
+      `
+        <Table data='${DATA}' highlightHoveredColumn="true">
+          <Column bindTo="name"/>
+          <Column bindTo="quantity"/>
+        </Table>
+      `,
+      {
+        testThemeVars: {
+          "backgroundColor-column-Table--hover": "rgb(10, 20, 30)",
+          "backgroundColor-row-Table--hover": "rgb(200, 100, 50)",
+        },
+      },
+    );
+
+    const hoveredCell = page.getByRole("cell", { name: "5", exact: true });
+    await hoveredCell.hover();
+
+    // The intersecting cell — the one actually under the pointer, whose row AND
+    // column are both hovered — shows the row hover color, not the column tint.
+    // This declaration is untouched by the column-tint alpha function, so it
+    // always serializes as the plain legacy value the theme var was set to.
+    await expect(hoveredCell).toHaveCSS("background-color", "rgb(200, 100, 50)");
+
+    // A cell further down the SAME column, in a row that is not hovered, still
+    // shows the column tint plainly.
+    const sameColumnOtherRow = page.getByRole("cell", { name: "6", exact: true });
+    await expect.poll(() => backgroundRgba(sameColumnOtherRow)).toEqual([10, 20, 30, 1]);
+  });
+
+  // Off by default: rendered output must be unchanged from a table that never
+  // opted in — no cell hover handler attached, and no visible column tint.
+  test("is off by default: no handler attached and no highlight on hover", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(
+      `
+        <Table data='${DATA}'>
+          <Column bindTo="name"/>
+          <Column bindTo="quantity"/>
+        </Table>
+      `,
+      {
+        testThemeVars: { "backgroundColor-column-Table--hover": "rgb(10, 20, 30)" },
+      },
+    );
+
+    const hoveredCell = page.getByRole("cell", { name: "5", exact: true });
+    await hoveredCell.hover();
+
+    const sameColumnOtherRow = page.getByRole("cell", { name: "6", exact: true });
+    expect(await backgroundRgba(sameColumnOtherRow)).not.toEqual([10, 20, 30, 1]);
+
+    // React records its handlers on the DOM node's internal props bag; an
+    // unattached event is absent from it entirely.
+    const handlerType = await hoveredCell.evaluate((el) => {
+      const key = Object.keys(el).find((k) => k.startsWith("__reactProps$"));
+      const props: any = key ? (el as any)[key] : {};
+      return typeof props?.onMouseEnter;
+    });
+    expect(handlerType).toBe("undefined");
+  });
+});

--- a/xmlui/src/components/Table/Table.tsx
+++ b/xmlui/src/components/Table/Table.tsx
@@ -500,6 +500,16 @@ export const TableMd = createMetadata({
       valueType: "boolean",
       defaultValue: defaultProps.striped,
     },
+    highlightHoveredColumn: {
+      description:
+        `When set to \`true\`, hovering a table cell tints its entire column with the ` +
+        `[\`backgroundColor-column-${COMP}--hover\`](#backgroundcolor-column-table--hover) theme ` +
+        `variable. The default is \`false\`: no cell hover handlers are attached and the rendered ` +
+        `output is unchanged. Where the hovered row and the hovered column intersect, the row ` +
+        `highlight wins. Pinned columns keep their own hover background instead of the column tint.`,
+      valueType: "boolean",
+      defaultValue: defaultProps.highlightHoveredColumn,
+    },
   },
   events: {
     contextMenu: {
@@ -532,6 +542,19 @@ export const TableMd = createMetadata({
     rowDoubleClick: {
       description: `This event is fired when the user double-clicks a table row. The handler receives the clicked row item as its only argument.`,
       signature: "rowDoubleClick(item: any): void",
+      parameters: {
+        item: "The clicked table row item.",
+      },
+    },
+    rowClick: {
+      description:
+        `This event is fired when the user clicks a table row. The handler receives the ` +
+        `clicked row item as its only argument. It reports the click without replacing or ` +
+        `suppressing selection — pair it with \`rowsSelectable\` deliberately, and prefer ` +
+        `\`selectionDidChange\` when what you actually care about is the selection. The event ` +
+        `does not fire for clicks on the selection checkbox or on an interactive control ` +
+        `(such as a button) inside a cell.`,
+      signature: "rowClick(item: any): void",
       parameters: {
         item: "The clicked table row item.",
       },
@@ -785,6 +808,7 @@ export const TableMd = createMetadata({
     [`backgroundColor-pinnedCell-${COMP}--hover`]: `$backgroundColor-row-${COMP}--hover`,
     [`backgroundColor-selectionCell-${COMP}`]: "$backgroundColor-pinnedCell-Table",
     [`backgroundColor-selectionCell-${COMP}--hover`]: `$backgroundColor-row-${COMP}--hover`,
+    [`backgroundColor-column-${COMP}--hover`]: "$color-surface-100",
   },
 });
 
@@ -854,6 +878,9 @@ const TableWithColumns = memo(
       );
       const stableRowDoubleClick = useEvent((...args: any[]) =>
         lookupEventHandler("rowDoubleClick")?.(...args),
+      );
+      const stableRowClick = useEvent((...args: any[]) =>
+        lookupEventHandler("rowClick")?.(...args),
       );
       const stableRowEnter = useEvent((...args: any[]) =>
         lookupEventHandler("rowEnter")?.(...args),
@@ -1126,6 +1153,7 @@ const TableWithColumns = memo(
             onSelectionDidChange={stableSelectionDidChange}
             willSort={stableWillSort}
             rowDoubleClick={node.events?.rowDoubleClick ? stableRowDoubleClick : undefined}
+            rowClick={node.events?.rowClick ? stableRowClick : undefined}
             rowEnter={node.events?.rowEnter ? stableRowEnter : undefined}
             rowLeave={node.events?.rowLeave ? stableRowLeave : undefined}
             onScroll={node.events?.scroll ? stableScroll : undefined}
@@ -1187,6 +1215,9 @@ const TableWithColumns = memo(
             keyBindings={extractValue(node.props.keyBindings)}
             alwaysShowHeader={extractValue.asOptionalBoolean(node.props.alwaysShowHeader)}
             striped={extractValue.asOptionalBoolean(node.props.striped)}
+            highlightHoveredColumn={extractValue.asOptionalBoolean(
+              node.props.highlightHoveredColumn,
+            )}
           />
         </>
       );

--- a/xmlui/src/components/Table/TableReact.tsx
+++ b/xmlui/src/components/Table/TableReact.tsx
@@ -451,6 +451,7 @@ type TableProps = {
   checkboxTolerance?: CheckboxTolerance;
   rowHeight?: number;
   rowDoubleClick?: (item: any) => void;
+  rowClick?: (item: any) => void;
   rowEnter?: (item: any) => void;
   rowLeave?: (item: any) => void;
   headerUserSelect?: string;
@@ -475,6 +476,7 @@ type TableProps = {
   onDeleteAction?: AsyncFunction;
   alwaysShowHeader?: boolean;
   striped?: boolean;
+  highlightHoveredColumn?: boolean;
 };
 
 type PendingDataRefresh = {
@@ -1183,6 +1185,7 @@ export const Table = memo(
       checkboxTolerance = defaultProps.checkboxTolerance,
       rowHeight = defaultProps.rowHeight,
       rowDoubleClick,
+      rowClick,
       rowEnter,
       rowLeave,
       headerUserSelect,
@@ -1200,6 +1203,7 @@ export const Table = memo(
       onDeleteAction,
       alwaysShowHeader = defaultProps.alwaysShowHeader,
       striped = defaultProps.striped,
+      highlightHoveredColumn = defaultProps.highlightHoveredColumn,
       ...rest
       // cols
     }: TableProps,
@@ -1993,6 +1997,7 @@ export const Table = memo(
       enableMultiRowSelection,
       lookupEventHandler,
       rowDoubleClick,
+      rowClick,
       rowEnter,
       rowLeave,
       striped,
@@ -2011,12 +2016,14 @@ export const Table = memo(
       cellVerticalAlign,
       localeProfile,
       localeRenderKey,
+      highlightHoveredColumn,
     });
     cellRenderStateRef.current = {
       effectiveUserSelectCell,
       cellVerticalAlign,
       localeProfile,
       localeRenderKey,
+      highlightHoveredColumn,
     };
 
     // TableMemoizedCells — analogous to TileGridMemoizedItem.
@@ -2045,6 +2052,7 @@ export const Table = memo(
             effectiveUserSelectCell: userSelectCell,
             cellVerticalAlign: vertAlign,
             localeProfile: currentLocaleProfile,
+            highlightHoveredColumn: columnHoverEnabled,
           } = cellRenderStateRef.current;
           return (
             <>
@@ -2138,6 +2146,17 @@ export const Table = memo(
                   </div>
                 );
                 const tooltipTemplate = tooltipRenderer?.(sourceRow, rowIndex, i, liveCellValue);
+                // Column hover highlight: opt-in, off by default. When enabled, a non-pinned
+                // cell's mouseenter writes the hovered column's positional index directly to a
+                // CSS custom property on the table wrapper (outside React state), so a
+                // horizontal traverse costs a style write rather than a per-cell re-render.
+                // Table.module.scss reads --xmlui-hovered-col-index against each cell's own
+                // static --xmlui-col-index and paints the tint via a color-mix() background,
+                // which the existing higher-specificity row-hover/selected rules already
+                // override at the intersection — no extra selector or !important needed.
+                // Pinned cells are excluded so they keep their own hover precedence.
+                const isPinnedColumn = !!cell.column.getIsPinned();
+                const columnHoverActive = columnHoverEnabled && !isPinnedColumn;
                 return (
                   <td
                     className={classnames(styles.cell, alignmentClass, columnClassName)}
@@ -2150,7 +2169,18 @@ export const Table = memo(
                         flexShrink: 0,
                         ...getCommonPinningStyles(cell.column),
                         ...styleWithoutWidth,
+                        ...(columnHoverActive ? { "--xmlui-col-index": i } : undefined),
                       } as React.CSSProperties
+                    }
+                    onMouseEnter={
+                      columnHoverActive
+                        ? () => {
+                            wrapperRef.current?.style.setProperty(
+                              "--xmlui-hovered-col-index",
+                              String(i),
+                            );
+                          }
+                        : undefined
                     }
                   >
                     {tooltipTemplate ? (
@@ -2217,9 +2247,6 @@ export const Table = memo(
                 if (event.detail >= 2) {
                   return;
                 }
-                if (!row.getCanSelect()) {
-                  return;
-                }
                 if (event?.defaultPrevented) {
                   return;
                 }
@@ -2235,23 +2262,44 @@ export const Table = memo(
                   return;
                 }
 
-                // Focus the table wrapper to enable keyboard shortcuts (after checking input/button)
-                wrapperRef.current?.focus();
-
                 const isSelectColumn =
                   target.closest("td")?.getAttribute("data-column-id") === "select";
 
-                if (isSelectColumn) {
-                  const rs = rowStateRef.current;
-                  if (!rs.enableMultiRowSelection && row.getIsSelected()) {
-                    rs.checkAllRows(false); // Deselect all (which is just this one row)
-                  } else {
-                    rs.toggleRow(row.original, { metaKey: true });
+                // Selection is gated on getCanSelect() (rowsSelectable + the unselectable
+                // predicate); rowClick below is not — it must fire even when the table isn't
+                // selectable at all, which is its main use case ("click a row to open it").
+                if (row.getCanSelect()) {
+                  // Focus the table wrapper to enable keyboard shortcuts (after checking input/button)
+                  wrapperRef.current?.focus();
+
+                  if (isSelectColumn) {
+                    const rs = rowStateRef.current;
+                    if (!rs.enableMultiRowSelection && row.getIsSelected()) {
+                      rs.checkAllRows(false); // Deselect all (which is just this one row)
+                    } else {
+                      rs.toggleRow(row.original, { metaKey: true });
+                    }
+                    return;
                   }
-                  return;
+
+                  rowStateRef.current.toggleRow(row.original, event);
                 }
 
-                rowStateRef.current.toggleRow(row.original, event);
+                // rowClick is additive: it reports the click without suppressing or replacing
+                // selection above, and it does not fire for clicks the code already treats as
+                // belonging to something else (the selection checkbox, or the input/button
+                // guards above).
+                if (isSelectColumn) {
+                  return;
+                }
+                const { rowClick } = rowStateRef.current;
+                if (rowClick && typeof rowClick === "function") {
+                  try {
+                    rowClick(row.original);
+                  } catch (e) {
+                    console.error("Error in rowClick handler:", e);
+                  }
+                }
               }}
               onDoubleClick={(event) => {
                 // Prevent browser text selection on double-click
@@ -2967,6 +3015,15 @@ export const Table = memo(
         onPointerDown={clearPreservedScrollPaddingEnd}
         onTouchStart={clearPreservedScrollPaddingEnd}
         onWheel={clearPreservedScrollPaddingEnd}
+        // Clears the column hover highlight when the pointer leaves the whole table rather
+        // than on each cell's mouseleave, so moving between adjacent cells does not flicker.
+        onMouseLeave={
+          highlightHoveredColumn
+            ? () => {
+                wrapperRef.current?.style.removeProperty("--xmlui-hovered-col-index");
+              }
+            : undefined
+        }
         onClick={(e) => {
           const target = e.target as HTMLElement;
 

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -18189,6 +18189,11 @@ export default {
         "description": "When set to `true`, the table rows alternate between the `backgroundColor-evenRow-Table` and `backgroundColor-oddRow-Table` theme variables, creating a striped appearance.",
         "valueType": "boolean",
         "defaultValue": false
+      },
+      "highlightHoveredColumn": {
+        "description": "When set to `true`, hovering a table cell tints its entire column with the [`backgroundColor-column-Table--hover`](#backgroundcolor-column-table--hover) theme variable. The default is `false`: no cell hover handlers are attached and the rendered output is unchanged. Where the hovered row and the hovered column intersect, the row highlight wins. Pinned columns keep their own hover background instead of the column tint.",
+        "valueType": "boolean",
+        "defaultValue": false
       }
     },
     "events": {
@@ -18224,6 +18229,13 @@ export default {
       "rowDoubleClick": {
         "description": "This event is fired when the user double-clicks a table row. The handler receives the clicked row item as its only argument.",
         "signature": "rowDoubleClick(item: any): void",
+        "parameters": {
+          "item": "The clicked table row item."
+        }
+      },
+      "rowClick": {
+        "description": "This event is fired when the user clicks a table row. The handler receives the clicked row item as its only argument. It reports the click without replacing or suppressing selection — pair it with `rowsSelectable` deliberately, and prefer `selectionDidChange` when what you actually care about is the selection. The event does not fire for clicks on the selection checkbox or on an interactive control (such as a button) inside a cell.",
+        "signature": "rowClick(item: any): void",
         "parameters": {
           "item": "The clicked table row item."
         }
@@ -18479,6 +18491,7 @@ export default {
       "borderBottom-last-row-Table": "var(--xmlui-borderBottom-last-row-Table)",
       "backgroundColor-pinnedCell-Table": "var(--xmlui-backgroundColor-pinnedCell-Table)",
       "backgroundColor-pinnedCell-Table--hover": "var(--xmlui-backgroundColor-pinnedCell-Table--hover)",
+      "backgroundColor-column-Table--hover": "var(--xmlui-backgroundColor-column-Table--hover)",
       "Input:borderColor-Checkbox--hover": "var(--xmlui-borderColor-Checkbox--hover)"
     },
     "defaultThemeVars": {
@@ -18516,7 +18529,8 @@ export default {
       "backgroundColor-pinnedCell-Table": "$color-surface-50",
       "backgroundColor-pinnedCell-Table--hover": "$backgroundColor-row-Table--hover",
       "backgroundColor-selectionCell-Table": "$backgroundColor-pinnedCell-Table",
-      "backgroundColor-selectionCell-Table--hover": "$backgroundColor-row-Table--hover"
+      "backgroundColor-selectionCell-Table--hover": "$backgroundColor-row-Table--hover",
+      "backgroundColor-column-Table--hover": "$color-surface-100"
     },
     "isImplicitContainerByDefault": true
   },


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Two Table capabilities: a `rowClick` event, and an opt-in column hover highlight.

## Why one commit

They share four source files, and they were validated downstream as a **single vendored artifact** — neither has ever existed on disk in isolation. Splitting them would produce two commits whose individual states were never built or run, which is worse for bisect than one state that was actually tested.

## `rowClick(item)`

`Table` had `rowDoubleClick`, and since `270b661` also `rowEnter` / `rowLeave` — but no single-click counterpart. `rowClick` reports row *activation*: it does not replace or suppress selection, does not fire for clicks on the selection checkbox or on an interactive control inside a cell, and suppresses the trailing click of a double-click.

**One non-obvious change, worth a reviewer's attention.** The previous row `onClick` opened with:

```js
if (!row.getCanSelect()) { return; }
```

which early-returned the *entire* handler whenever `rowsSelectable` was off — the common case, and precisely the scenario `rowClick` exists for ("click a row to open it"). Firing the event after that guard would have shipped an event that never fires for its own motivating use case.

The gate now wraps only the selection mutation (focus + `toggleRow` / `checkAllRows`). Selection behaviour is unchanged when `rowsSelectable` is on; `rowClick` additionally works when it is off. This is the riskiest edit in the PR and the one the regression sweep and downstream probe were aimed at.

## `highlightHoveredColumn`

Boolean, default `false`. Hovering a cell tints its entire column via a new `backgroundColor-column-Table--hover` theme variable (defaults to `$color-surface-100` — neutral, deliberately quieter than the saturated row hover).

A table column is not a DOM element, so there is no selector for "every cell in the hovered cell's column". Per-column-index rules were considered and **rejected**: they do not survive dynamic column counts, resizing, sorting or pinning. Instead:

- the hovered index is written to a CSS custom property on the table root, **outside React state**, so a horizontal traverse costs one style write rather than a re-render per cell;
- each non-pinned cell carries its own static index;
- one low-specificity rule derives a 0/1 alpha from the difference:

```scss
--xmlui-col-hover-amount: clamp(0, calc(1 - var(--xmlui-col-diff-abs)), 1);
background-color: rgb(from $backgroundColor-column-Table--hover r g b / var(--xmlui-col-hover-amount, 0));
```

Unset fallbacks are chosen so the difference can never be zero when the feature is off. Intersection precedence falls out of the existing `.row:hover .cell` chain being more specific — **no `!important`**. Pinned cells keep their own inline background. Off by default means no handlers attached and no custom properties written.

## Verification

**Upstream:** full `Table.spec.ts` green at **262 passed / 0 failed**, including both features' tests and a regression sweep over `rowsSelectable`, `toggleSelectionOnClick`, and the double-click path.

**Downstream** — the part the test suite structurally could not answer. Built as a standalone (sha256 `7d4060b38b0d10ec660dea9e2db454eda97e29e7628e5fd3dc05bfe22162b8ae`) and vendored into a Tauri application on macOS: **WKWebView, Safari's engine, not the Chromium Playwright exercises.** Exercised on a purpose-built 40×9 probe table with a pinned column, resizable and sortable columns, and selectable rows.

- **Layout robustness** — the property that justified the design and had *no* test coverage. The highlight tracks the pointer correctly after sorting, after a column-resize drag, under horizontal scroll, and across the pinned boundary, where a column occluded to a sliver still tints exactly itself. No off-by-one drift in any manipulation.
- **Cross-engine** — the relative-color syntax renders in WKWebView. This is its only use in the codebase and it has no fallback, so this was the finding that could have redirected the implementation.
- **Selection interaction** — row-body click fires `rowClick`; checkbox click does not; in-cell button click does not; N double-clicks produce exactly N `rowClick` entries.
- **Performance** — horizontal sweeps are instrument-invisible: zero heartbeat drift spikes, zero ResizeObserver activity, no attributable long-tasks. The "one style write, not a re-render" claim holds under measurement rather than assertion.
- **Off-path** — every pre-existing table in the host application renders and behaves unchanged.

Full report with numbers: https://github.com/judell/bram/issues/288

## Known and not addressed here

Double-clicking a row leaves a native text-selection artifact in WebKit. The existing `preventDefault` on `dblclick` fires too late — selection happens on the second `mousedown`. This **predates both features** (it belongs to `rowDoubleClick`) and reproduces independently of this branch, so folding a WebKit-specific selection fix in here would widen the diff into an unrelated mechanism. Filed separately.

## Changeset

`patch` for both, matching the convention the sibling `table-row-hover-events` changeset settled on.
