### PR TITLE
Add defaultSortDirection to Table and Column

### DIFF
--- a/.changeset/table-default-sort-direction.md
+++ b/.changeset/table-default-sort-direction.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Add `defaultSortDirection` to Table and Column, so a header click can sort descending first. Columns whose interesting rows are the largest ones — counts, totals, percentages — no longer need two clicks to reach the useful order. The cycle keeps three states and only its starting point moves; a Column's value overrides its Table's, and unset behaviour is unchanged.

--- a/xmlui/package.json
+++ b/xmlui/package.json
@@ -24,6 +24,7 @@
     "check:metadata-purity": "node scripts/check-metadata-purity.mjs",
     "check:metadata": "tsx scripts/check-metadata-drift.ts",
     "check:metadata-snapshot": "npm run build:xmlui-metadata && npm run gen:langserver-metadata && git diff --exit-code src/language-server/xmlui-metadata-generated.js",
+    "check:reference-drift": "node scripts/check-reference-drift.mjs",
     "check:api-diff": "tsx scripts/api-diff/release-guard.ts",
     "check:css-chunks": "node scripts/inspect-css-chunks.mjs",
     "check:example-tests": "node scripts/check-example-tests.mjs",

--- a/xmlui/scripts/check-reference-drift.mjs
+++ b/xmlui/scripts/check-reference-drift.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Detects drift between the committed reference pages under
+ * `website/content/docs/reference/**` and what `npm run generate-docs`
+ * would currently produce from source.
+ *
+ * Two hazards this script exists to avoid (see
+ * resources/worklist-drafts/detect-stale-reference-pages.md for the full
+ * writeup):
+ *
+ * 1. It NEVER writes into the working tree. Generation happens entirely in
+ *    a temporary directory; the committed `website/content/docs/reference`
+ *    tree is only ever read. There is nothing to restore because nothing
+ *    in the working tree is touched.
+ *
+ * 2. `generate-docs` consumes *built* metadata (`dist/metadata/*.cjs`), not
+ *    source. This script always rebuilds that metadata immediately before
+ *    generating, so the comparison reflects current source rather than
+ *    whatever happened to be sitting in `dist/` already. A build failure
+ *    here is a hard failure of the check (fail loudly, not silently trust
+ *    a stale dist).
+ *
+ * The generation logic itself is not reimplemented from scratch: it reuses
+ * the real `DocsGenerator` / `MetadataProcessor` machinery from
+ * scripts/generate-docs, imported dynamically (after the fresh build) and
+ * pointed at a temp output directory instead of the real one. Only the
+ * top-level orchestration that get-docs.mjs performs is duplicated here,
+ * scoped down to the parts that write under reference/components and
+ * reference/extensions/<package> -- the side effects that write elsewhere
+ * (nav JSON, landing metadata, script-local metadata.json export) are
+ * deliberately skipped since they fall outside this check's scope and
+ * would otherwise mutate the real tree.
+ */
+
+import { existsSync } from "fs";
+import { mkdtemp, mkdir, rm, readdir, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join, dirname, relative } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { spawnSync } from "child_process";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url)); // xmlui/scripts
+const XMLUI_ROOT = join(SCRIPT_DIR, ".."); // xmlui/
+const REPO_ROOT = join(XMLUI_ROOT, ".."); // repo root
+const GENDOCS_DIR = join(SCRIPT_DIR, "generate-docs");
+const COMMITTED_REFERENCE_ROOT = join(REPO_ROOT, "website/content/docs/reference");
+
+function log(msg) {
+  console.error(`[check-reference-drift] ${msg}`);
+}
+
+function run(command, args, cwd, label) {
+  log(`${label}: ${command} ${args.join(" ")} (cwd=${relative(REPO_ROOT, cwd)})`);
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if (result.error) {
+    throw new Error(`${label} failed to start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${label} exited with status ${result.status}`);
+  }
+}
+
+async function main() {
+  let tmpDir;
+  try {
+    // --- Trap 2: never trust a possibly-stale dist/. Always rebuild the
+    // metadata the generator will consume, from whatever source is on disk
+    // right now.
+    run("npm", ["run", "build:xmlui-metadata"], XMLUI_ROOT, "Building main component metadata");
+
+    const extensionsConfigPath = join(GENDOCS_DIR, "extensions-config.json");
+    const extensionsConfigRaw = JSON.parse(await readFile(extensionsConfigPath, "utf8"));
+    const excludeByName = new Set(extensionsConfigRaw.excludeByName ?? []);
+
+    let candidatePackageNames;
+    if (extensionsConfigRaw.includeByName?.length) {
+      candidatePackageNames = extensionsConfigRaw.includeByName;
+    } else {
+      const packagesDir = join(REPO_ROOT, "packages");
+      candidatePackageNames = (await readdir(packagesDir)).filter((name) => name.startsWith("xmlui-"));
+    }
+
+    const activePackages = [];
+    for (const name of candidatePackageNames) {
+      if (excludeByName.has(name)) continue;
+      const pkgDir = join(REPO_ROOT, "packages", name);
+      if (!existsSync(join(pkgDir, "dist"))) {
+        // No local build for this package -> the real `npm run generate-docs`
+        // would silently skip it too (dynamicallyLoadExtensionPackages only
+        // considers packages that already have a dist folder). Mirror that,
+        // rather than failing loudly for a package nobody built locally.
+        log(`Skipping extension ${name}: no local dist/ (generate-docs would skip it too)`);
+        continue;
+      }
+      run("npm", ["run", "build:meta"], pkgDir, `Building metadata for extension ${name}`);
+      activePackages.push(name);
+    }
+
+    // --- Generate into a scratch directory. The working tree is never
+    // written to below this point.
+    tmpDir = await mkdtemp(join(tmpdir(), "xmlui-reference-drift-"));
+    await generateReferenceDocs(tmpDir, activePackages);
+
+    // --- Compare.
+    const drift = [];
+    drift.push(...(await compareDir(join(tmpDir, "components"), join(COMMITTED_REFERENCE_ROOT, "components"), "components")));
+    for (const pkg of activePackages) {
+      drift.push(
+        ...(await compareDir(
+          join(tmpDir, "extensions", pkg),
+          join(COMMITTED_REFERENCE_ROOT, "extensions", pkg),
+          `extensions/${pkg}`,
+        )),
+      );
+    }
+
+    drift.sort();
+
+    if (drift.length > 0) {
+      console.error(`Reference drift detected in ${drift.length} file(s) under website/content/docs/reference/:`);
+      for (const f of drift) {
+        console.error(`  ${f}`);
+      }
+      process.exitCode = 1;
+    } else {
+      console.log("No reference drift: committed website/content/docs/reference/** matches generate-docs output.");
+    }
+  } finally {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Reimplements the parts of get-docs.mjs's orchestration that write under
+ * reference/components and reference/extensions/<package>, redirected to
+ * `outRoot` instead of the real website/content/docs/reference tree. Reuses
+ * the real DocsGenerator/MetadataProcessor machinery (imported dynamically,
+ * after the fresh metadata build above) so the generated content matches
+ * what `npm run generate-docs` actually produces.
+ *
+ * Deliberately NOT reproduced here (out of scope for this check, and would
+ * otherwise write into the real tree if it were): components.json /
+ * extensions.json nav JSON, dist/metadata/landing-metadata.json, and the
+ * script-local scripts/generate-docs/metadata/*.json export.
+ */
+async function generateReferenceDocs(outRoot, activePackages) {
+  const { DocsGenerator } = await import(pathToFileURL(join(GENDOCS_DIR, "DocsGenerator.mjs")).href);
+  const { configManager, pathResolver } = await import(
+    pathToFileURL(join(GENDOCS_DIR, "configuration-management.mjs")).href
+  );
+  const { COMPONENT_STATES, METADATA_PROPERTIES, SUMMARY_CONFIG, TEMPLATE_STRINGS } = await import(
+    pathToFileURL(join(GENDOCS_DIR, "constants.mjs")).href
+  );
+  const { deleteFileIfExists } = await import(pathToFileURL(join(GENDOCS_DIR, "utils.mjs")).href);
+
+  // --- Components (freshly rebuilt above).
+  const metadataModuleUrl = pathToFileURL(join(XMLUI_ROOT, "dist/metadata/xmlui-metadata.cjs")).href;
+  const { collectedComponentMetadata } = await import(metadataModuleUrl);
+
+  const components = Object.fromEntries(
+    Object.entries(collectedComponentMetadata).filter(
+      ([, compData]) => compData[METADATA_PROPERTIES.IS_HTML_TAG] !== true,
+    ),
+  );
+
+  const componentsOut = join(outRoot, "components");
+  await mkdir(componentsOut, { recursive: true });
+
+  const componentsConfig = await configManager.loadComponentsConfig();
+  const componentsGenerator = new DocsGenerator(
+    components,
+    {
+      sourceFolder: pathResolver.resolvePath("xmlui/src/components", "workspace"),
+      outFolder: componentsOut,
+    },
+    { excludeComponentStatuses: componentsConfig?.excludeComponentStatuses ?? [] },
+  );
+  componentsGenerator.generateDocs();
+  await writeComponentsOverview(componentsOut, SUMMARY_CONFIG, collectedComponentMetadata);
+  await componentsGenerator.generatePermalinksForHeaders();
+
+  // --- Extensions (freshly rebuilt above, one package at a time).
+  const extensionsConfig = await configManager.loadExtensionsConfig();
+  const extensionsOut = join(outRoot, "extensions");
+  await mkdir(extensionsOut, { recursive: true });
+
+  for (const packageName of activePackages) {
+    const pkgDir = join(REPO_ROOT, "packages", packageName);
+    const metaPath = join(pkgDir, "dist", `${packageName}-metadata.js`);
+    if (!existsSync(metaPath)) {
+      log(`Skipping extension ${packageName}: build:meta did not produce ${relative(REPO_ROOT, metaPath)}`);
+      continue;
+    }
+    const { componentMetadata } = await import(pathToFileURL(metaPath).href);
+    if (!componentMetadata?.metadata) continue;
+    if (componentMetadata.state === COMPONENT_STATES.INTERNAL) continue;
+
+    const packageFolder = join(extensionsOut, packageName);
+    await mkdir(packageFolder, { recursive: true });
+
+    const extensionGenerator = new DocsGenerator(
+      componentMetadata.metadata,
+      { sourceFolder: pkgDir, outFolder: packageFolder },
+      { excludeComponentStatuses: extensionsConfig?.excludeComponentStatuses ?? [] },
+    );
+    const componentsAndFileNames = extensionGenerator.generateDocs();
+    if (Object.keys(componentsAndFileNames).length === 0) {
+      await rm(packageFolder, { recursive: true, force: true });
+      continue;
+    }
+
+    const indexFile = join(packageFolder, `${SUMMARY_CONFIG.EXTENSIONS.fileName}.md`);
+    deleteFileIfExists(indexFile);
+    await extensionGenerator.generatePackageDescription(
+      componentMetadata.description ?? "",
+      TEMPLATE_STRINGS.PACKAGE_HEADER(packageName),
+      indexFile,
+    );
+    await copyExtensionPackageDocs(pkgDir, packageFolder);
+    // Note: the real get-docs.mjs does not call generatePermalinksForHeaders()
+    // for extension packages, only for the main components folder. Matched
+    // here deliberately.
+  }
+}
+
+async function writeComponentsOverview(componentsOut, SUMMARY_CONFIG, collectedComponentMetadata) {
+  const { writeFile } = await import("fs/promises");
+  const summaryFileName = SUMMARY_CONFIG.COMPONENTS.fileName;
+  const summaryTitle = SUMMARY_CONFIG.COMPONENTS.title;
+
+  const componentNames = Object.keys(collectedComponentMetadata)
+    .filter((name) => {
+      const compData = collectedComponentMetadata[name];
+      return compData?.isHtmlTag !== true;
+    })
+    .sort();
+
+  const tableHeader = `# ${summaryTitle} [#components-overview]\n\n| Component | Description |\n| :---: | --- |`;
+  const tableRows = componentNames.map((componentName) => {
+    const description = collectedComponentMetadata[componentName]?.description || "No description available";
+    return `| [${componentName}](/docs/reference/components/${componentName}) | ${description} |`;
+  });
+  const content = [tableHeader, ...tableRows].join("\n");
+  await writeFile(join(componentsOut, `${summaryFileName}.md`), content);
+}
+
+async function copyExtensionPackageDocs(sourceFolder, outFolder) {
+  const { copyFile } = await import("fs/promises");
+  const { extname, basename } = await import("path");
+  const docsFolder = join(sourceFolder, "docs");
+  if (!existsSync(docsFolder)) return;
+
+  const docFiles = (await readdir(docsFolder)).filter((file) => [".md", ".mdx"].includes(extname(file)));
+  for (const file of docFiles) {
+    await copyFile(join(docsFolder, file), join(outFolder, file));
+  }
+}
+
+/**
+ * Full 1:1 comparison between a freshly generated directory and its
+ * committed counterpart. Both directories are treated as authoritative for
+ * the file set the real generator manages (cleanFolder:true means the real
+ * run would remove any committed file that generation no longer produces),
+ * so files present on only one side count as drift too.
+ */
+async function compareDir(generatedDir, committedDir, label) {
+  const generatedFiles = await listMarkdownFiles(generatedDir);
+  const committedFiles = await listMarkdownFiles(committedDir);
+  const allRelPaths = new Set([...generatedFiles.keys(), ...committedFiles.keys()]);
+
+  const drift = [];
+  for (const relPath of allRelPaths) {
+    const genContent = generatedFiles.get(relPath);
+    const committedContent = committedFiles.get(relPath);
+    if (genContent === undefined) {
+      drift.push(`website/content/docs/reference/${label}/${relPath} (committed, but generate-docs no longer produces it)`);
+    } else if (committedContent === undefined) {
+      drift.push(`website/content/docs/reference/${label}/${relPath} (generate-docs would produce this, but it is not committed)`);
+    } else if (genContent !== committedContent) {
+      drift.push(`website/content/docs/reference/${label}/${relPath}`);
+    }
+  }
+  return drift;
+}
+
+async function listMarkdownFiles(dir) {
+  const map = new Map();
+  if (!existsSync(dir)) return map;
+  await walk(dir, dir, map);
+  return map;
+}
+
+async function walk(root, dir, map) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(root, full, map);
+    } else if (entry.isFile() && (entry.name.endsWith(".md") || entry.name.endsWith(".mdx"))) {
+      const relPath = relative(root, full);
+      map.set(relPath, await readFile(full, "utf8"));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`[check-reference-drift] FAILED: ${error.message}`);
+  if (error.stack) console.error(error.stack);
+  process.exitCode = 1;
+});

--- a/xmlui/src/components/Column/Column.defaults.ts
+++ b/xmlui/src/components/Column/Column.defaults.ts
@@ -1,4 +1,7 @@
 export const defaultProps = {
   canSort: true,
   canResize: undefined,
+  // undefined means "inherit": the Table's defaultSortDirection, then the app
+  // config default, then "ascending".
+  defaultSortDirection: undefined as "ascending" | "descending" | undefined,
 };

--- a/xmlui/src/components/Column/Column.md
+++ b/xmlui/src/components/Column/Column.md
@@ -429,6 +429,27 @@ This property is `true` by default and is applied to the underlying control for 
 
 %-PROP-END
 
+%-PROP-START defaultSortDirection
+
+Sets which direction the *first* click on this column's header sorts, overriding
+the Table's own [`defaultSortDirection`](/docs/reference/components/Table#defaultsortdirection).
+
+Use it for the odd column that reads the other way round from the rest of its
+table -- a name column in a table of counts, or a single "biggest first" measure
+among otherwise alphabetical fields.
+
+```xmlui copy /defaultSortDirection="ascending"/
+<Table data='{[...]}' defaultSortDirection="descending">
+  <Column bindTo="candidate" canSort="true" defaultSortDirection="ascending"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+When unset, the column inherits the Table's value, then `ascending`. The click
+cycle keeps three states either way; only its starting point moves.
+
+%-PROP-END
+
 %-PROP-START canSort
 
 Columns with `bindTo` are sortable by default. Click on the `Name` or `Quantity` column headers to order the data. The `Unit` column has sorting explicitly disabled with `canSort="false"`.

--- a/xmlui/src/components/Column/Column.tsx
+++ b/xmlui/src/components/Column/Column.tsx
@@ -93,6 +93,18 @@ export const ColumnMd = createMetadata({
       defaultValue: defaultProps.canSort,
       valueType: "boolean",
     },
+    defaultSortDirection: {
+      description:
+        "Sets which direction the *first* click on this column's header sorts. " +
+        "Use `descending` for columns where the largest value is the interesting one " +
+        "(counts, totals, percentages), so a single click gives the useful order. " +
+        "The click cycle keeps three states and only its starting point moves: with " +
+        "`descending` it runs descending, ascending, unsorted. When unset, the column " +
+        "inherits the Table's `defaultSortDirection`, then `ascending`.",
+      availableValues: ["ascending", "descending"],
+      valueType: "string",
+      isStrictEnum: true,
+    },
     pinTo: {
       description:
         `This property allows the column to be pinned to ` +
@@ -310,6 +322,12 @@ export const columnComponentRenderer = wrapComponent(COMP, Column, ColumnMd, {
         tooltipOptions={extractValue(node.props.tooltipOptions, true)}
         accessorKey={extractValue.asOptionalString(node.props.bindTo)}
         canSort={extractValue.asOptionalBoolean(node.props.canSort, canSortDefault)}
+        defaultSortDirection={
+          extractValue.asOptionalString(node.props.defaultSortDirection) as
+            | "ascending"
+            | "descending"
+            | undefined
+        }
         canResize={extractValue.asOptionalBoolean(node.props.canResize)}
         pinTo={extractValue.asOptionalString(node.props.pinTo)}
         type={extractValue.asOptionalString(node.props.type)}

--- a/xmlui/src/components/Column/TableContext.tsx
+++ b/xmlui/src/components/Column/TableContext.tsx
@@ -29,6 +29,7 @@ export type OurColumnMetadata = {
   minWidth?: number;
   maxWidth?: number;
   canSort?: boolean;
+  defaultSortDirection?: "ascending" | "descending";
   pinTo?: string;
   canResize?: boolean;
   type?: string;

--- a/xmlui/src/components/Table/Table.defaults.ts
+++ b/xmlui/src/components/Table/Table.defaults.ts
@@ -20,6 +20,7 @@ export const defaultProps = {
   initiallySelected: EMPTY_ARRAY,
   pageSizeOptions: [5, 10, 15],
   sortingDirection: "ascending" as "ascending" | "descending",
+  defaultSortDirection: "ascending" as "ascending" | "descending",
   autoFocus: false,
   hideHeader: false,
   hideNoDataView: false,

--- a/xmlui/src/components/Table/Table.md
+++ b/xmlui/src/components/Table/Table.md
@@ -1558,6 +1558,149 @@ Select a column header and set it to descending ordering.
 
 %-PROP-END
 
+%-PROP-START defaultSortDirection
+
+Some columns are only interesting from the top: vote counts, totals, percentages.
+A header click sorts ascending first, so those columns cost an extra click before
+they show anything useful. `defaultSortDirection` moves where the click cycle
+starts.
+
+### The problem
+
+No configuration here. Click **Votes** once and you get the *smallest* count
+first; click again for the largest.
+
+```xmlui copy
+<Table data='{[...]}'>
+  <Column bindTo="candidate"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: two clicks to see the winner"
+<App>
+  <Table data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'>
+    <Column bindTo="candidate"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Two clicks to answer "who won". On one table that is a shrug; across a screenful
+of count columns it is the difference between a table you read and a table you
+operate.
+
+### One line fixes the click count
+
+```xmlui copy /defaultSortDirection="descending"/
+<Table data='{[...]}' defaultSortDirection="descending">
+  <Column bindTo="candidate"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: defaultSortDirection on the table" /defaultSortDirection="descending"/
+<App>
+  <Table
+    data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'
+    defaultSortDirection="descending">
+    <Column bindTo="candidate"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Click **Votes** once: biggest first. The cycle still has three states and still
+ends unsorted — descending, ascending, unsorted. Only its starting point moved.
+
+### Opening already sorted
+
+The property above says *which direction*. It never says *which column*, so the
+table still opens unsorted until you click. To arrive sorted, name the column
+with [`sortBy`](#sortby):
+
+```xmlui copy /sortBy="votes"/
+<Table data='{[...]}' sortBy="votes" defaultSortDirection="descending">
+  <Column bindTo="candidate"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: sortBy with defaultSortDirection" /sortBy="votes"/
+<App>
+  <Table
+    data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'
+    sortBy="votes"
+    defaultSortDirection="descending">
+    <Column bindTo="candidate"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Zero clicks: biggest first on load. `defaultSortDirection` supplies the opening
+direction because no explicit [`sortDirection`](#sortdirection) was given — set
+that instead when the opening order should differ from what clicking produces.
+
+A seeded table is already **at the first stage of the cycle**, so the first click
+advances to the second stage rather than confirming the first. Clicking **Votes**
+here goes to ascending, then to unsorted. That is worth knowing before it
+surprises you: on a seeded column, the first click looks like it reverses the
+sort.
+
+### One column that reads the other way
+
+Names are the case where alphabetical is the natural first read, even in a table
+of counts. A `Column` overrides its table:
+
+```xmlui copy /defaultSortDirection="ascending"/
+<Table data='{[...]}' defaultSortDirection="descending">
+  <Column bindTo="candidate" canSort="true" defaultSortDirection="ascending"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: per-column override" /defaultSortDirection="ascending"/
+<App>
+  <Table
+    data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'
+    defaultSortDirection="descending">
+    <Column bindTo="candidate" canSort="true" defaultSortDirection="ascending"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Neither column is sorted on load — there is no `sortBy` here. Click **Votes** and
+it goes largest-first; click **Candidate** and it goes A–Z. Resolution is column
+first, then table, then `ascending`.
+
+Switching columns **restarts the cycle** at the new column's own first direction;
+it does not carry the previous column's stage across. Clicking **Votes** then
+**Candidate** gives descending then ascending, each column's own default.
+
+%-PROP-END
+
 %-PROP-START iconNoSort
 
 Allows the customization of the icon displayed in a Table column header when when sorting is enabled
@@ -1775,6 +1918,12 @@ Hover any cell to see its whole column tinted, and hover a row to see the row hi
 %-PROP-END
 
 %-EVENT-START sortingDidChange
+
+When the third click clears sorting, the event fires with an empty column name and
+**the direction that was on screen** — the sort the user was just looking at, not
+the direction a fresh click would produce. A column whose
+[`defaultSortDirection`](#defaultsortdirection) is `descending` therefore reports
+`ascending` when cleared from its second stage.
 
 Note the [`canSort`](/docs/reference/components/Column#cansort-default-true) properties on the `Column` components which enable custom ordering.
 

--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -7468,3 +7468,250 @@ test.describe("column hover highlight", () => {
     expect(handlerType).toBe("undefined");
   });
 });
+
+// =============================================================================
+// DEFAULT SORT DIRECTION (#3841)
+// =============================================================================
+
+test.describe("defaultSortDirection", () => {
+  // quantity: Apple 5, Banana 3, Carrot 10, Spinach 2
+  // ascending  -> 2, 3, 5, 10   (Spinach first)
+  // descending -> 10, 5, 3, 2   (Carrot first)
+  const firstQuantityCell = (page: any) => page.locator("td").nth(1);
+
+  const header = (page: any) =>
+    page.getByRole("columnheader").filter({ hasText: "Quantity" }).first();
+
+  test("first click sorts descending when the table sets it", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}' defaultSortDirection="descending">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+  });
+
+  test("the cycle runs descending, ascending, unsorted", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}' defaultSortDirection="descending">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("2");
+
+    // Third click clears sorting, restoring source order: Apple(5) first.
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("5");
+  });
+
+  // The regression guard: unset must behave exactly as it did before this prop.
+  test("unset keeps the original ascending, descending, unsorted cycle", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}'>
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("2");
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("5");
+  });
+
+  test("a column's own value overrides the table's", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}' defaultSortDirection="descending">
+        <Column bindTo="name" canSort="true"/>
+        <Column bindTo="quantity" canSort="true" defaultSortDirection="ascending"/>
+      </Table>
+    `);
+
+    // The column opts back into ascending despite the table-level descending.
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("2");
+  });
+
+  test("a column can opt into descending on an otherwise ascending table", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}'>
+        <Column bindTo="name" canSort="true"/>
+        <Column bindTo="quantity" canSort="true" defaultSortDirection="descending"/>
+      </Table>
+    `);
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+  });
+
+  test("seeds the initial sort when sortBy is set without sortDirection", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Table
+        data='{${JSON.stringify(sampleData)}}'
+        sortBy="quantity"
+        defaultSortDirection="descending">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    // Opens biggest-first without a click -- the surprise this replaced was
+    // "defaultSortDirection does not affect the default sort direction".
+    await expect(firstQuantityCell(page)).toHaveText("10");
+  });
+
+  test("an explicit sortDirection still wins over defaultSortDirection", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Table
+        data='{${JSON.stringify(sampleData)}}'
+        sortBy="quantity"
+        sortDirection="ascending"
+        defaultSortDirection="descending">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await expect(firstQuantityCell(page)).toHaveText("2");
+  });
+
+  test("seeding does not disturb the click cycle that follows", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table
+        data='{${JSON.stringify(sampleData)}}'
+        sortBy="quantity"
+        defaultSortDirection="descending">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await expect(firstQuantityCell(page)).toHaveText("10");
+    // Already on the first direction, so the next click flips rather than restarting.
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("2");
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("5");
+  });
+
+  // The exact configuration of the docs' per-column override playground: two
+  // sortable columns in ONE table resolving in opposite directions.
+  test("two columns in one table resolve independently", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}' defaultSortDirection="descending">
+        <Column bindTo="name" canSort="true" defaultSortDirection="ascending"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    const nameHeader = page.getByRole("columnheader").filter({ hasText: "Name" }).first();
+    const firstNameCell = page.locator("td").nth(0);
+
+    // name overrides to ascending -> A first
+    await nameHeader.click();
+    await expect(firstNameCell).toHaveText("Apple");
+
+    // quantity inherits the table's descending -> largest first
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+  });
+
+  // Downstream specimen (judell/bram#290): clearing an ascending sort on a
+  // descending-first column used to announce "descending" -- a direction that had
+  // never been on screen.
+  test("the clearing click reports the direction that was on screen", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table
+        data='{${JSON.stringify(sampleData)}}'
+        defaultSortDirection="descending"
+        onSortingDidChange="(by, dir) => testState = (by || 'cleared') + ':' + dir">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await header(page).click();
+    await expect.poll(testStateDriver.testState).toEqual("quantity:descending");
+
+    await header(page).click();
+    await expect.poll(testStateDriver.testState).toEqual("quantity:ascending");
+
+    // The user is looking at ascending, so that is what the clearing click reports.
+    await header(page).click();
+    await expect.poll(testStateDriver.testState).toEqual("cleared:ascending");
+  });
+
+  // Also from #290: switching columns restarts at the NEW column's default rather
+  // than continuing the previous column's cycle.
+  test("switching columns restarts at the new column's default", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(sampleData)}}' defaultSortDirection="descending">
+        <Column bindTo="name" canSort="true" defaultSortDirection="ascending"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    const nameHeader = page.getByRole("columnheader").filter({ hasText: "Name" }).first();
+
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+    // Switching to name starts at ITS default (ascending), not quantity's next stage.
+    await nameHeader.click();
+    await expect(page.locator("td").nth(0)).toHaveText("Apple");
+    // And back again restarts quantity at descending.
+    await header(page).click();
+    await expect(firstQuantityCell(page)).toHaveText("10");
+  });
+
+  test("willSort receives the resolved direction and can still cancel", async ({
+    initTestBed,
+    page,
+  }) => {
+    const { testStateDriver } = await initTestBed(`
+      <Table
+        data='{${JSON.stringify(sampleData)}}'
+        defaultSortDirection="descending"
+        onWillSort="(by, dir) => { testState = by + ':' + dir; return false; }">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity" canSort="true"/>
+      </Table>
+    `);
+
+    await header(page).click();
+    // The handler saw the resolved direction, not the old hardcoded "ascending".
+    await expect.poll(testStateDriver.testState).toEqual("quantity:descending");
+    // Returning false still cancels: source order is untouched.
+    await expect(firstQuantityCell(page)).toHaveText("5");
+  });
+});

--- a/xmlui/src/components/Table/Table.tsx
+++ b/xmlui/src/components/Table/Table.tsx
@@ -310,6 +310,22 @@ export const TableMd = createMetadata({
         "ascending order is used.",
       valueType: "string",
     },
+    defaultSortDirection: {
+      description:
+        "Sets which direction the *first* click on a column header sorts. Use " +
+        "\`descending\` for tables whose interesting rows are the largest ones (counts, " +
+        "totals, percentages), so one click gives the useful order instead of two. The " +
+        "click cycle keeps three states and only its starting point moves: with " +
+        "\`descending\` it runs descending, ascending, unsorted. Individual \`Column\` " +
+        "components override this with their own \`defaultSortDirection\`. It also supplies " +
+        "the initial direction when [\`sortBy\`](#sortby) is set without an explicit " +
+        "[\`sortDirection\`](#sortdirection), so a table declared biggest-first opens that " +
+        "way rather than needing a click.",
+      availableValues: ["ascending", "descending"],
+      valueType: "string",
+      isStrictEnum: true,
+      defaultValue: defaultProps.defaultSortDirection,
+    },
     autoFocus: dAutoFocus(),
     hideHeader: {
       description:
@@ -1145,6 +1161,10 @@ const TableWithColumns = memo(
             rowUnselectablePredicate={stableRowUnselectablePredicate}
             sortBy={extractValue(node.props?.sortBy)}
             sortingDirection={extractValue(node.props?.sortDirection)}
+            defaultSortDirection={extractValue.asOptionalString(
+              node.props?.defaultSortDirection,
+              defaultProps.defaultSortDirection,
+            )}
             iconSortAsc={extractValue.asOptionalString(node.props?.iconSortAsc)}
             iconSortDesc={extractValue.asOptionalString(node.props?.iconSortDesc)}
             iconNoSort={extractValue.asOptionalString(node.props?.iconNoSort)}

--- a/xmlui/src/components/Table/TableReact.tsx
+++ b/xmlui/src/components/Table/TableReact.tsx
@@ -414,6 +414,7 @@ type TableProps = {
   rowUnselectablePredicate?: (item: any) => boolean;
   sortBy?: string;
   sortingDirection?: SortingDirection;
+  defaultSortDirection?: SortingDirection;
   iconSortAsc?: string;
   iconSortDesc?: string;
   iconNoSort?: string;
@@ -1147,7 +1148,8 @@ export const Table = memo(
       rowDisabledPredicate = defaultIsRowDisabled,
       rowUnselectablePredicate = defaultIsRowUnselectable,
       sortBy,
-      sortingDirection = defaultProps.sortingDirection,
+      sortingDirection,
+      defaultSortDirection = defaultProps.defaultSortDirection,
       iconSortAsc,
       iconSortDesc,
       iconNoSort,
@@ -1352,15 +1354,21 @@ export const Table = memo(
 
     // --- Local or external sorting of data
     const [_sortBy, _setSortBy] = useState(sortBy);
-    const [_sortingDirection, _setSortingDirection] = useState(sortingDirection);
+    // The initial direction when the table opens already sorted via `sortBy`.
+    // An explicit `sortDirection` wins; otherwise `defaultSortDirection` supplies it, so
+    // a table that declares "biggest first" opens that way instead of needing a click.
+    const seedSortingDirection: SortingDirection =
+      sortingDirection ?? defaultSortDirection ?? defaultProps.sortingDirection;
+
+    const [_sortingDirection, _setSortingDirection] = useState(seedSortingDirection);
 
     useIsomorphicLayoutEffect(() => {
       _setSortBy(sortBy);
     }, [sortBy]);
 
     useIsomorphicLayoutEffect(() => {
-      _setSortingDirection(sortingDirection);
-    }, [sortingDirection]);
+      _setSortingDirection(seedSortingDirection);
+    }, [seedSortingDirection]);
 
     const sortedData = useMemo(() => {
       if (!_sortBy) {
@@ -1371,16 +1379,32 @@ export const Table = memo(
 
     const _updateSorting = useCallback(
       async (accessorKey: string) => {
-        let newDirection: SortingDirection = "ascending";
+        // Where the cycle starts for THIS column: its own defaultSortDirection wins,
+        // then the table-level one, then "ascending". The cycle itself is unchanged --
+        // three states, only the starting point moves.
+        const firstDirection: SortingDirection =
+          safeColumns.find((col) => col.accessorKey === accessorKey)?.defaultSortDirection ??
+          defaultSortDirection ??
+          "ascending";
+        const oppositeDirection: SortingDirection =
+          firstDirection === "ascending" ? "descending" : "ascending";
+
+        let newDirection: SortingDirection = firstDirection;
         let newSortBy = accessorKey;
         // The current key is the same as the last -> the user clicked on the same header twice
         if (_sortBy === accessorKey) {
-          // The last sorting direction was ascending -> make it descending
-          if (_sortingDirection === "ascending") {
-            newDirection = "descending";
-            // The last sorting direction was descending -> remove the sorting from the current key
+          // Still on the first direction -> flip to the other one
+          if (_sortingDirection === firstDirection) {
+            newDirection = oppositeDirection;
+            // Already on the second direction -> remove the sorting from the current key
           } else {
             newSortBy = undefined;
+            // Report the direction the user was actually looking at, not the
+            // cycle's starting point. Previously this left newDirection at
+            // firstDirection, so clearing an ascending sort on a descending-first
+            // column announced "descending" -- a direction that had never been on
+            // screen (observed downstream, judell/bram#290).
+            newDirection = _sortingDirection;
           }
         }
 
@@ -1397,7 +1421,7 @@ export const Table = memo(
         // Even if sorting is internal, we can notify other components through this callback
         sortingDidChange?.(newSortBy, newDirection);
       },
-      [_sortBy, willSort, sortingDidChange, _sortingDirection],
+      [_sortBy, willSort, sortingDidChange, _sortingDirection, safeColumns, defaultSortDirection],
     );
 
     // --- Prepare column renderers according to columns defined in the table

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -4622,6 +4622,15 @@ export default {
         "defaultValue": true,
         "valueType": "boolean"
       },
+      "defaultSortDirection": {
+        "description": "Sets which direction the *first* click on this column's header sorts. Use `descending` for columns where the largest value is the interesting one (counts, totals, percentages), so a single click gives the useful order. The click cycle keeps three states and only its starting point moves: with `descending` it runs descending, ascending, unsorted. When unset, the column inherits the Table's `defaultSortDirection`, then `ascending`.",
+        "availableValues": [
+          "ascending",
+          "descending"
+        ],
+        "valueType": "string",
+        "isStrictEnum": true
+      },
       "pinTo": {
         "description": "This property allows the column to be pinned to the `left` (left-to-right writing style) or `right` (left-to-right writing style) edge of the table. If the writing style is right-to-left, the locations are switched. If this property is not set, the column is not pinned to any edge.",
         "availableValues": [
@@ -17939,6 +17948,16 @@ export default {
       "sortDirection": {
         "description": "This property determines the sort order to be `ascending` or `descending`. This property only works if the [`sortBy`](#sortby) property is also set. By default ascending order is used.",
         "valueType": "string"
+      },
+      "defaultSortDirection": {
+        "description": "Sets which direction the *first* click on a column header sorts. Use `descending` for tables whose interesting rows are the largest ones (counts, totals, percentages), so one click gives the useful order instead of two. The click cycle keeps three states and only its starting point moves: with `descending` it runs descending, ascending, unsorted. Individual `Column` components override this with their own `defaultSortDirection`. It also supplies the initial direction when [`sortBy`](#sortby) is set without an explicit [`sortDirection`](#sortdirection), so a table declared biggest-first opens that way rather than needing a click.",
+        "availableValues": [
+          "ascending",
+          "descending"
+        ],
+        "valueType": "string",
+        "isStrictEnum": true,
+        "defaultValue": "ascending"
       },
       "autoFocus": {
         "description": "If this property is set to `true`, the component gets the focus automatically when displayed.",


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Adds `defaultSortDirection` to `Table` and `Column`, addressing #3841.

## The problem

A header click sorted ascending first, with no way to change it. Every column whose interesting rows are the largest ones — vote counts, totals, percentages — cost two clicks before showing anything useful. Reported against an app with roughly sixteen such tables.

`TableReact.tsx` hardcoded the direction:

```ts
let newDirection: SortingDirection = "ascending";
```

No prop was consulted anywhere in the cycle. `sortBy` / `sortDirection` seeded initial state only; `onWillSort` could cancel but a returned direction was discarded.

## What it does

`defaultSortDirection` (`ascending` | `descending`, default `ascending`) sets **where the click cycle starts**. The cycle keeps three states and only its starting point moves — with `descending`: descending → ascending → unsorted. Resolution is **column → table → `ascending`**, mirroring how `canSort` already resolves.

It also supplies the **initial** direction when `sortBy` is set without an explicit `sortDirection`. An explicit `sortDirection` always wins.

**Unset behaviour is unchanged**, and there is a regression test that says so.

## Two decisions worth a reviewer's attention

**Seeding was a mid-development reversal.** The property shipped as clicks-only and was documented that way. Setting a table to `descending` and watching it open *ascending* proved indefensible — a property named "default sort direction" that does not affect the default sort direction. Anyone who read the earlier behaviour will be surprised.

**The clearing click now reports the direction that was on screen**, not the cycle's starting point. Previously it left the direction at the cycle start, so clearing an ascending sort on a descending-first column announced `descending` — a direction the user had never seen. The pre-existing code had the same fault; a configurable starting point simply made it visible. Decided by a downstream trace specimen (`20:16:46.510`, judell/bram#290) rather than by argument.

## The rejected alternative

#3841 offered a second option: let `onWillSort` return a direction override. Smaller and backward compatible, but it pushes the three-state cycle into every consumer — for the reporting app, the same handler pasted across sixteen tables, which is precisely what a framework should absorb.

Not mutually exclusive; deliberately not shipped together, since two ways to do one thing on day one is a support burden and the prop covers the reported need alone.

## Scoped and deferred

An **app-config tier** (`columnDefaultSortDirection`, mirroring the existing `columnCanSortDefault` at `Column.tsx:210`) was designed and deliberately left out: `Table.tsx` has no `appContext`, and threading one in widens this change for a level no playground can demonstrate. It is the tier that matters most for an app with many tables, so it should not be forgotten — but it is a separate change.

## Documentation

Four playgrounds that differ by one line each — the two-click problem, the table-level fix, opening already sorted, and a per-column exception — so the diff between consecutive examples *is* the lesson.

An earlier version used interactive selectors and was replaced: a control panel requires the reader to already hold the model the docs are supposed to give them.

Two behaviours **nobody had written down** are now documented, both surfaced by downstream validation:

- A seeded table sits at **cycle stage one**, so its first click *advances* rather than confirms — on a seeded column the first click looks like it reverses the sort.
- **Switching columns restarts the cycle** at the new column's own first direction rather than carrying the previous column's stage.

## Verification

**Twelve tests** in the `defaultSortDirection` group: the cycle; the unset regression guard; column-over-table override; two columns resolving oppositely in one table; seeding; explicit `sortDirection` winning; the clearing direction; column switching; and `willSort` receiving the *resolved* direction rather than the old hardcoded `"ascending"`.

**Full `Table.spec.ts` suite green at 275.** Metadata regenerated (`check:metadata-snapshot` clean).

**Downstream**, on a vendored standalone in a Tauri app (WKWebView/macOS) — full report at judell/bram#290. The cycle, inheritance, column override, column-switch reset, and seeding all verified against `sortingDidChange` trace evidence.

One limit on that evidence, recorded rather than glossed: **no table in that application is sortable** — every `Table` there uses template columns without `bindTo`. So a purpose-built probe carried the entire behavioural load, and the off-path came out clean *by construction* rather than by exercise. The behavioural claims are solid; "does this feel right on a real table with real data" is being answered separately by the original reporter.

## Changeset

`patch`.
