### PR TITLE
Handle a null parseExpr() result as literal source text

### DIFF
--- a/.changeset/fix-null-expression-dependency-collection.md
+++ b/.changeset/fix-null-expression-dependency-collection.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Fix a crash on a comment-only (or otherwise content-free) `@{...}` binding expression, e.g. `@{ /* note */ }`. `parseParameterString` now treats a braced section that parses to no expression as literal source text instead of building an expression segment around a `null` AST node, and `collectVariableDependencies` is null-tolerant as a defense-in-depth boundary check. Previously, passing such a segment into dependency collection threw `TypeError: Cannot read properties of null (reading 'type')`, which could take down the surrounding render tree. Refs #3774.

--- a/xmlui/src/components-core/script-runner/ParameterParser.ts
+++ b/xmlui/src/components-core/script-runner/ParameterParser.ts
@@ -86,12 +86,25 @@ export function parseParameterString(
         } else {
           const segmentIndex = result.length;
           const exprText = exprSource.substring(0, exprSource.length - tail.length);
-          // --- Successfully parsed expression
-          result.push({
-            type: "expression",
-            value: expr!,
-            compiled: createCompiledBindingArtifact(expr!, exprText, options, segmentIndex, i),
-          });
+          if (expr === null) {
+            // --- The braced section has no expression to evaluate (e.g. it is
+            // empty, whitespace-only, or comment-only — a comment yields no
+            // tokens once whitespace/comment trivia is stripped). Rather than
+            // fabricating an expression segment around a null AST node, keep
+            // the original source text as a literal so downstream consumers
+            // (dependency collection, evaluation) never see a null `value`.
+            result.push({
+              type: "literal",
+              value: exprText,
+            });
+          } else {
+            // --- Successfully parsed expression
+            result.push({
+              type: "expression",
+              value: expr,
+              compiled: createCompiledBindingArtifact(expr, exprText, options, segmentIndex, i),
+            });
+          }
 
           // --- Skip the parsed part of the expression, and start a new literal section
           i = source.length - tail.length;

--- a/xmlui/src/components-core/script-runner/visitors.ts
+++ b/xmlui/src/components-core/script-runner/visitors.ts
@@ -64,10 +64,19 @@ import { isParsedValue } from "../state/variable-resolution";
  *   provides write targets at runtime.
  */
 export function collectVariableDependencies(
-  program: Expression | Statement[],
+  program: Expression | Statement[] | null | undefined,
   referenceTrackedApis: Record<string, any> = {},
   options: { includeAssignmentTargets?: boolean } = {},
 ): string[] {
+  // --- Defense in depth: a null/undefined program (e.g. a parser producing
+  // no AST for an empty, whitespace-only, or comment-only source) has no
+  // variable dependencies. Guard here so callers never have to null-check
+  // before calling in, and a nullable upstream parser result can't crash
+  // dependency collection.
+  if (program == null) {
+    return [];
+  }
+
   // --- We use these variables to keep track of local variable scopes
   const evalContext: BindingTreeEvaluationContext = {};
   const thread = ensureMainThread(evalContext);

--- a/xmlui/src/components/Markdown/Markdown.spec.ts
+++ b/xmlui/src/components/Markdown/Markdown.spec.ts
@@ -46,6 +46,22 @@ test.describe("smoke tests", { tag: "@smoke" }, () => {
     await expect((await createMarkdownDriver()).component).toHaveText("");
   });
 
+  test("comment-only binding expression does not crash surrounding content (#3774)", async ({
+    initTestBed,
+    createMarkdownDriver,
+  }) => {
+    // --- A braced binding whose body is only a comment parses to no
+    // expression at all. Before the fix, evaluating that segment threw
+    // (`Cannot read properties of null (reading 'type')`); the surrounding
+    // "before " / " after" text must still render, proving the crash does
+    // not take down the render tree.
+    await initTestBed(`<Markdown><![CDATA[before \@{ /* note */ } after]]></Markdown>`);
+    const { component } = await createMarkdownDriver();
+    await expect(component).toBeAttached();
+    await expect(component).toContainText("before");
+    await expect(component).toContainText("after");
+  });
+
   test("handles binding expression", async ({ initTestBed, createMarkdownDriver }) => {
     await initTestBed(`<Markdown><![CDATA[\@{1+1}]]></Markdown>`);
     await expect((await createMarkdownDriver()).component).toHaveText("2");

--- a/xmlui/tests/components-core/script-runner/visitors.test.ts
+++ b/xmlui/tests/components-core/script-runner/visitors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { collectVariableDependencies } from "../../../src/components-core/script-runner/visitors";
+import { Parser } from "../../../src/parsers/scripting/Parser";
+
+// --- https://github.com/xmlui-org/xmlui/issues/3774
+// `collectVariableDependencies` previously dereferenced `program.type`
+// unconditionally, so a null/undefined program (e.g. produced by a parser
+// for an empty, whitespace-only, or comment-only expression source) crashed
+// with `TypeError: Cannot read properties of null (reading 'type')`.
+describe("collectVariableDependencies null-tolerance (issue #3774)", () => {
+  it("returns an empty dependency list for a null program", () => {
+    // --- Act
+    const deps = collectVariableDependencies(null as any);
+
+    // --- Assert
+    expect(deps).toEqual([]);
+  });
+
+  it("returns an empty dependency list for an undefined program", () => {
+    // --- Act
+    const deps = collectVariableDependencies(undefined as any);
+
+    // --- Assert
+    expect(deps).toEqual([]);
+  });
+
+  it("does not throw when given a null program with custom options", () => {
+    // --- Act & Assert
+    expect(() =>
+      collectVariableDependencies(null as any, {}, { includeAssignmentTargets: true }),
+    ).not.toThrow();
+    expect(collectVariableDependencies(null as any, {}, { includeAssignmentTargets: true })).toEqual(
+      [],
+    );
+  });
+
+  it("still collects dependencies normally for a real expression", () => {
+    // --- Arrange
+    const parser = new Parser("a + b");
+    const expr = parser.parseExpr();
+
+    // --- Act
+    const deps = collectVariableDependencies(expr as any);
+
+    // --- Assert
+    expect(deps).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty list for a program that itself parses to null (comment-only source)", () => {
+    // --- Arrange: a comment-only source is trivia-only, so the parser
+    // produces no expression node at all.
+    const parser = new Parser("/* just a comment */");
+    const expr = parser.parseExpr();
+    expect(expr).toBeNull();
+
+    // --- Act
+    const deps = collectVariableDependencies(expr as any);
+
+    // --- Assert
+    expect(deps).toEqual([]);
+  });
+});

--- a/xmlui/tests/parsers/parameter-parser.test.ts
+++ b/xmlui/tests/parsers/parameter-parser.test.ts
@@ -3,6 +3,7 @@ import { parseParameterString } from "../../src/components-core/script-runner/Pa
 import type { Expression } from "../../src/components-core/script-runner/ScriptingSourceTree";
 import { T_BINARY_EXPRESSION, T_LITERAL } from "../../src/parsers/scripting/ScriptingNodeTypes";
 import { UnsupportedCompiledScriptNodeError } from "../../src/components-core/script-compiler";
+import { collectVariableDependencies } from "../../src/components-core/script-runner/visitors";
 
 describe("parseParameterString", () => {
   it("Empty string works", () => {
@@ -155,5 +156,84 @@ describe("parseParameterString", () => {
     expect((result[1].value as Expression).type).toBe(T_LITERAL);
     expect(result[2].type).toBe("literal");
     expect(result[2].value).toBe("$/");
+  });
+
+  // --- https://github.com/xmlui-org/xmlui/issues/3774
+  // A braced section whose content parses to no expression at all (empty,
+  // whitespace-only, or comment-only — comments are lexer trivia, so they
+  // leave no tokens behind) must not produce an expression segment with a
+  // null `value`. It should be treated as literal source text instead.
+  describe("comment-only / empty expression segments (issue #3774)", () => {
+    it("comment-only braces are parsed as a literal segment, not a null expression", () => {
+      // --- Act
+      const result = parseParameterString("before {/* note */} after");
+
+      // --- Assert: no segment has type "expression" with a null value
+      expect(result.every((segment) => segment.type === "literal")).toBe(true);
+      expect(result.map((s) => s.value).join("")).toContain("before ");
+      expect(result.map((s) => s.value).join("")).toContain(" after");
+      // --- No expression segment was fabricated around the null AST node
+      expect(result.some((segment) => segment.type === "expression")).toBe(false);
+    });
+
+    it("whitespace-only braces are also parsed as a literal segment", () => {
+      // --- Act
+      const result = parseParameterString("{   }");
+
+      // --- Assert
+      expect(result.length).toBe(1);
+      expect(result[0].type).toBe("literal");
+      expect(result[0].value).toBe("   ");
+    });
+
+    it("dependency collection never sees a null expression value (interpreted mode)", () => {
+      // --- Act
+      const result = parseParameterString("before @{ /* note */ } after");
+
+      // --- Assert: every segment is safe to feed into collectVariableDependencies
+      for (const segment of result) {
+        if (segment.type === "expression") {
+          expect(() => collectVariableDependencies(segment.value)).not.toThrow();
+        }
+      }
+      // --- The specific crash reported in #3774: no segment carries a null value
+      expect(result.some((segment) => (segment as any).value === null)).toBe(false);
+    });
+
+    it("comment-only braces do not throw when compiled bindings are requested", () => {
+      // --- Act & Assert
+      expect(() =>
+        parseParameterString("before @{ /* note */ } after", {
+          compileBindings: true,
+          sourceId: "Main.xmlui:comment-only",
+        }),
+      ).not.toThrow();
+
+      const result = parseParameterString("before @{ /* note */ } after", {
+        compileBindings: true,
+        sourceId: "Main.xmlui:comment-only",
+      });
+
+      // --- No expression segment (and therefore no compiled artifact) was
+      // built for the comment-only braces.
+      expect(result.every((segment) => segment.type === "literal")).toBe(true);
+    });
+
+    it("a real expression alongside a comment-only one still compiles correctly", () => {
+      // --- Act
+      const result = parseParameterString("{a+b}{/* note */}", {
+        compileBindings: true,
+        sourceId: "Main.xmlui:mixed",
+      });
+
+      // --- Assert
+      expect(result[0].type).toBe("expression");
+      if (result[0].type === "expression") {
+        expect(result[0].compiled).toMatchObject({
+          dependencies: ["a", "b"],
+        });
+      }
+      expect(result[1].type).toBe("literal");
+    });
   });
 });


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Refs #3774.

## The bug

A braced binding whose body is only a comment parses to no expression at all — comments are lexer trivia, so once whitespace and comment tokens are stripped there is nothing left to parse. `ParameterParser` nonetheless asserted the nullable `parseExpr()` result with `expr!` and built an expression segment around the null AST node. `collectVariableDependencies()` then dereferenced `program.type` and threw:

```
TypeError: Cannot read properties of null (reading 'type')
```

Because dependency collection runs while the render tree is being built, a single `@{ /* note */ }` anywhere took down the surrounding content rather than degrading locally.

## The fix, in two halves

**Normalize at the producer.** When `parseExpr()` returns null, emit a **literal** segment carrying the original source text instead of an expression segment, and drop both `expr!` assertions. Downstream consumers never see a null `value`.

**Harden the boundary.** `collectVariableDependencies()` now accepts a null/undefined program and returns no dependencies. This is defense in depth, not the primary fix — it means a nullable parser result can never crash dependency collection again, from any caller.

Doing only the second half would have left an expression segment with a null AST flowing through evaluation; doing only the first would have left the collector as brittle as it was for every other caller.

## Behavior worth knowing

A comment-only binding now renders its comment text, since the fallback keeps the original source as a literal. `@{}` and `@{   }` render empty and whitespace respectively. That is a deliberate choice — preserving the author's bytes rather than silently discarding them — and it is what the tests pin.

## Verification

Unit coverage for comment-only and whitespace-only segments in both interpreted and compiled-binding modes, the defensive collector behavior, and a `Markdown` render regression proving surrounding content stays visible. 22 targeted tests pass.

Beyond the tests, the fix was exercised against the **running engine** rather than only the source diff — the dev server's own modules were imported in the browser and fed the exact call that used to throw:

| input | result |
| --- | --- |
| `before @{ /* note */ } after` | three literals, no nulls, no throw |
| `@{}` / `@{   }` | literal, no throw |
| `@{ /* a */ } and @{ count }` | deps `[count]` |
| `@{ user.name } @{ /* x */ } @{ items.length }` | deps `[user.name, items.length]` |
| `collectVariableDependencies(null / undefined)` | `[]` |

The mixed cases are the ones that matter: the comment is neutralized **without** costing the surrounding expressions their dependency tracking, which is the way a producer-side normalization could most plausibly have gone wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
