### PR TITLE
Add a how-to for customizing a Select's selected value

### DIFF
--- a/website/content/docs/pages/howto/customize-a-selects-selected-value.md
+++ b/website/content/docs/pages/howto/customize-a-selects-selected-value.md
@@ -1,0 +1,130 @@
+# Customize a Select's selected value
+
+A `Select` whose selected label is long enough to wrap looks off: every
+wrapped line renders **centered**, not left-aligned — and that's true with
+no customization at all. Fixing it takes a `valueTemplate`, and the fix
+needs two props, not one: an explicit width so the label's box fills the
+trigger, and an explicit `textAlign` so the browser's own button default
+doesn't win.
+
+## The problem: a wrapped label centers by default
+
+`Select`'s trigger renders as a real `<button>` element (Radix UI's
+`SelectPrimitive.Trigger`, which xmlui's non-searchable, single-select
+`Select` renders through). Browsers apply `text-align: center` to `<button>`
+by default, and nothing in xmlui's Select styling overrides it — so any
+text that wraps inside the trigger inherits that centering. You don't need
+a `valueTemplate` to see it:
+
+```xmlui-pg copy display name="The default: a long label wraps and centers" height="160px"
+---app display
+<App>
+  <VStack width="260px" gap="$space-2" padding="$space-3" borderWidth="1px" borderColor="$color-surface-300">
+    <Text variant="strong">No customization — still centers</Text>
+    <Select width="100%" label="Priority" initialValue="escalate">
+      <Option value="normal" label="Normal priority" />
+      <Option value="escalate" label="Escalate to the payments team's on-call engineer for urgent review" />
+    </Select>
+  </VStack>
+</App>
+```
+
+The label wraps onto three lines, and each one is centered in the trigger —
+fine for a short, badge-like value, but odd for a sentence-like label.
+
+## The fix: valueTemplate with a full-width, left-aligned Text
+
+There's no theme variable for the selected value's text alignment — the
+`Select` variable families cover color and size, not alignment — so
+`valueTemplate` is the mechanism here, not a workaround. It takes two props
+on the `Text` inside it:
+
+- **`width="100%"`** so the box spans the trigger instead of shrinking to
+  its own content.
+- **`textAlign="start"`** so the browser's centered button default doesn't
+  win.
+
+Both matter, and it's easy to stop after the first one: set only the width
+and the box does fill the trigger, but the wrapped lines are *still*
+centered, because a `<button>`'s inherited `text-align: center` applies to
+anything inside it that doesn't set its own — a full-width box included.
+
+```xmlui-pg copy display name="A valueTemplate with width and textAlign" height="160px"
+---app display
+<App>
+  <VStack width="260px" gap="$space-2" padding="$space-3" borderWidth="1px" borderColor="$color-surface-300">
+    <Text variant="strong">width="100%" + textAlign="start"</Text>
+    <Select width="100%" label="Priority">
+      <property name="valueTemplate">
+        <Text testId="full-value" width="100%" textAlign="start" value="{$item.label}" />
+      </property>
+      <Option value="normal" label="Normal priority" />
+      <Option value="escalate" label="Escalate to the payments team's on-call engineer for urgent review" />
+    </Select>
+  </VStack>
+</App>
+```
+
+Open the select and choose the long option — the label now wraps flush
+against the trigger's left edge.
+
+## `$item` and `$itemContext` inside the template
+
+`valueTemplate` renders once per selected value (once in single-select mode,
+once per chip in multi-select mode). Inside it:
+
+- **`$item.label`** and **`$item.value`** give you the selected option's
+  label and value, exactly as declared on its `<Option>`.
+- **`$itemContext.removeItem()`** removes that value from the current
+  selection — the hook a multi-select badge's close button calls. It's a
+  no-op to reach for in single-select mode, where there's nothing to remove
+  from; it matters once `multiSelect` is `true` and you're rendering your
+  own chip instead of the built-in badge. See the [Select reference's
+  `valueTemplate` example](/docs/reference/components/Select#valuetemplate)
+  for the multi-select badge-with-remove-button recipe this pairs with.
+
+## When to reach for a template instead of a theme variable
+
+Theme variables and `valueTemplate` solve different problems, and reaching
+for the wrong one costs a detour:
+
+- **Theme variables** (`textColor-Select`, `fontSize-Select`,
+  `backgroundColor-Select`, and friends) recolor or resize the *existing*
+  value display without changing what it renders. Use them for anything the
+  variable set already covers — see [Customize Select and AutoComplete
+  menus](/docs/howto/customize-select-and-autocomplete-menus) for the full
+  menu/item/badge variable list.
+- **`valueTemplate`** replaces *what* renders, not just how it looks. Reach
+  for it when the change is structural: an icon beside the label, a
+  multi-line layout, a custom remove control, or — this how-to's case —
+  correcting how a wrapped label fills and aligns inside the trigger. If a
+  theme variable can't express the change, a template is the escape hatch,
+  and it hands you the full markup budget of any other xmlui content.
+
+## Key points
+
+**A wrapped selected value centers by default, template or not.** The
+trigger is a real `<button>`, and the browser's own `text-align: center`
+for buttons is never overridden by xmlui's Select styling.
+
+**The fix needs both `width="100%"` and `textAlign="start"` on the
+template's `Text`.** The width makes the box fill the trigger instead of
+shrinking to its content; the alignment overrides the inherited centering.
+Either one alone leaves the label still off: no width and it doesn't even
+reliably wrap at the trigger's width; width with no alignment override and
+it wraps centered.
+
+**`$item.label` / `$item.value`** read the selected option; **`$itemContext.removeItem()`**
+removes it from the selection, relevant once `multiSelect` is `true`.
+
+**Theme variables restyle; `valueTemplate` restructures.** Start with theme
+variables for color and size. Move to a template only when the change is
+structural — layout, composition, or (as here) how wrapped text aligns.
+
+---
+
+## See also
+
+- [Select component reference](/docs/reference/components/Select#valuetemplate) — full `valueTemplate` API, including the multi-select remove-button recipe
+- [Customize Select and AutoComplete menus](/docs/howto/customize-select-and-autocomplete-menus) — theme variables for the dropdown menu, items, and badges
+- [Wrap long text in a Link](/docs/howto/wrap-long-text-in-a-link) — the same width-and-wrapping mechanics applied to `Link` text

--- a/website/content/docs/pages/howto/customize-a-selects-selected-value.md
+++ b/website/content/docs/pages/howto/customize-a-selects-selected-value.md
@@ -16,7 +16,7 @@ by default, and nothing in xmlui's Select styling overrides it — so any
 text that wraps inside the trigger inherits that centering. You don't need
 a `valueTemplate` to see it:
 
-```xmlui-pg copy display name="The default: a long label wraps and centers" height="160px"
+```xmlui-pg copy display name="The default: a long label wraps and centers" height="320px"
 ---app display
 <App>
   <VStack width="260px" gap="$space-2" padding="$space-3" borderWidth="1px" borderColor="$color-surface-300">
@@ -49,12 +49,12 @@ and the box does fill the trigger, but the wrapped lines are *still*
 centered, because a `<button>`'s inherited `text-align: center` applies to
 anything inside it that doesn't set its own — a full-width box included.
 
-```xmlui-pg copy display name="A valueTemplate with width and textAlign" height="160px"
+```xmlui-pg copy display name="A valueTemplate with width and textAlign" height="320px"
 ---app display
 <App>
   <VStack width="260px" gap="$space-2" padding="$space-3" borderWidth="1px" borderColor="$color-surface-300">
     <Text variant="strong">width="100%" + textAlign="start"</Text>
-    <Select width="100%" label="Priority">
+    <Select width="100%" label="Priority" initialValue="escalate">
       <property name="valueTemplate">
         <Text testId="full-value" width="100%" textAlign="start" value="{$item.label}" />
       </property>
@@ -65,8 +65,9 @@ anything inside it that doesn't set its own — a full-width box included.
 </App>
 ```
 
-Open the select and choose the long option — the label now wraps flush
-against the trigger's left edge.
+The same long label is selected here as in the first playground, and it now
+wraps flush against the trigger's left edge instead of centering. Compare the
+two triggers directly — same option, same width, one prop pair apart.
 
 ## `$item` and `$itemContext` inside the template
 

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -606,6 +606,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Customize a Select's selected value"
+                            to="/docs/howto/customize-a-selects-selected-value"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Present a short list of choices with a RadioGroup"
                             to="/docs/howto/present-choices-with-a-radiogroup"
                         />

--- a/xmlui/tests-e2e/how-to-examples/customize-a-selects-selected-value.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/customize-a-selects-selected-value.spec.ts
@@ -1,0 +1,135 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/customize-a-selects-selected-value.md",
+  ),
+);
+
+test.describe("The default: a long label wraps and centers", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "The default: a long label wraps and centers",
+  );
+
+  // The motivating bug, reproduced with zero customization: a long selected
+  // label wraps inside the trigger, and every wrapped line renders centered
+  // because the trigger is a real <button> and nothing overrides its
+  // inherited text-align: center.
+  test("the default value display wraps the long label centered", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const trigger = page.getByRole("combobox", { name: "Priority" });
+    const valueText = page.getByText(
+      "Escalate to the payments team's on-call engineer for urgent review",
+    );
+    await expect(valueText).toBeVisible();
+
+    const triggerBox = await trigger.boundingBox();
+    const valueBox = await valueText.boundingBox();
+    expect(triggerBox).toBeTruthy();
+    expect(valueBox).toBeTruthy();
+
+    // It wraps onto more than one line...
+    expect(valueBox!.height).toBeGreaterThan(30);
+
+    // ...and it's centered, not left-aligned: the default renderer's value
+    // box already fills the trigger, so this is purely an alignment claim.
+    const align = await valueText.evaluate((el) => getComputedStyle(el).textAlign);
+    expect(align).toBe("center");
+  });
+});
+
+test.describe("A valueTemplate with width and textAlign", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "A valueTemplate with width and textAlign",
+  );
+
+  // The verified fix: width="100%" makes the template's Text fill the
+  // trigger, and textAlign="start" overrides the inherited button
+  // centering, so a chosen long label wraps flush against the left edge.
+  test("choosing the long option renders it full-width and left-aligned", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const trigger = page.getByRole("combobox", { name: "Priority" });
+    await trigger.click();
+    await page
+      .getByRole("option", {
+        name: "Escalate to the payments team's on-call engineer for urgent review",
+      })
+      .click();
+
+    const value = page.getByTestId("full-value");
+    await expect(value).toBeVisible();
+    await expect(value).toHaveText(
+      "Escalate to the payments team's on-call engineer for urgent review",
+    );
+
+    const triggerBox = await trigger.boundingBox();
+    const valueBox = await value.boundingBox();
+    expect(triggerBox).toBeTruthy();
+    expect(valueBox).toBeTruthy();
+
+    // The template's Text spans the trigger's inner width (within a couple
+    // of pixels for border/subpixel rounding), not just its own content...
+    expect(valueBox!.width).toBeGreaterThan(triggerBox!.width - 40);
+
+    // ...wraps onto more than one line...
+    expect(valueBox!.height).toBeGreaterThan(30);
+
+    // ...and is left-aligned rather than inheriting the button's centering.
+    const align = await value.evaluate((el) => getComputedStyle(el).textAlign);
+    expect(["left", "start"]).toContain(align);
+  });
+
+  // The trap the how-to calls out explicitly: width alone isn't enough,
+  // because the inherited centering doesn't come from box sizing. Built as
+  // an independent literal (rather than string surgery on the extracted
+  // example) so the assertion doesn't depend on exact markdown formatting.
+  test("width alone would still leave the label centered (documents the mechanism)", async ({
+    initTestBed,
+    page,
+  }) => {
+    const widthOnlyApp = `
+<App>
+  <VStack width="260px">
+    <Select width="100%" label="Priority">
+      <property name="valueTemplate">
+        <Text testId="full-value" width="100%" value="{$item.label}" />
+      </property>
+      <Option value="normal" label="Normal priority" />
+      <Option value="escalate" label="Escalate to the payments team's on-call engineer for urgent review" />
+    </Select>
+  </VStack>
+</App>`;
+
+    await initTestBed(widthOnlyApp, { components, apiInterceptor });
+
+    const trigger = page.getByRole("combobox", { name: "Priority" });
+    await trigger.click();
+    await page
+      .getByRole("option", {
+        name: "Escalate to the payments team's on-call engineer for urgent review",
+      })
+      .click();
+
+    const value = page.getByTestId("full-value");
+    await expect(value).toBeVisible();
+
+    const align = await value.evaluate((el) => getComputedStyle(el).textAlign);
+    expect(align).toBe("center");
+  });
+});


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Refs #3832.

## What this documents

A long label in a `Select` wraps **and centers** in the closed trigger. The centering is not xmlui styling — the trigger is a real `<button>` (Radix's `Primitive.button`), and the browser's user-agent stylesheet sets `text-align: center` on buttons. Anything inside that doesn't set its own alignment inherits it.

The consequence is a trap worth naming: a `valueTemplate` whose `Text` sets only `width="100%"` **still renders centered**. The box fills the trigger, so it looks like the fix should have worked, but width and alignment are separate properties and only one of them was set. The recipe needs both:

- `width="100%"` — the box spans the trigger instead of shrinking to its content
- `textAlign="start"` — overrides the inherited centering

## On the recipe in the issue

The issue's original recipe specified `width="100%"` alone. That was corrected in-thread on 2026-08-25, and this page independently reproduced the correction before being written — `getComputedStyle` on the rendered label still reported `textAlign: "center"` with width alone. The shipped page teaches the two-prop version, and the accompanying spec pins the width-alone case explicitly so the trap can't silently regress:

```
width alone would still leave the label centered (documents the mechanism)
```

## Structure

Three playground states, in the order a reader hits them: the default (no `valueTemplate` at all — the problem needs no customization to see), then the fix, with prose between them naming the mechanism.

Both playgrounds preselect the same long option, so the two triggers are directly comparable — identical label, identical width, one prop pair apart. An earlier revision left the second one unselected and asked the reader to open the select and choose the option themselves, which put the page's central claim behind an interaction and made the two playgrounds non-comparable at a glance. The second commit here fixes that and gives both playgrounds enough height to show their own trigger, which they previously clipped behind an internal scrollbar.

## Verification

3/3 spec tests pass, at `--workers=1` and `--workers=10`. Both playgrounds were also checked in a running docs server, which is where the sizing and preselection problems were found — they were invisible in the source and in the passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
