### PR TITLE
Reference-page drift check, the backlog it found, and a Badge example fix

### DIFF
--- a/website/content/docs/reference/components/APICall.md
+++ b/website/content/docs/reference/components/APICall.md
@@ -10,6 +10,7 @@
 
 **Context variables available during execution:**
 
+- `$abortSignal`: AbortSignal for the current request (available in `mockExecute`)
 - `$attempts`: Number of status polls made in deferred mode
 - `$cookies`: Request cookies (available in `mockExecute`)
 - `$elapsed`: Time elapsed since polling started in milliseconds
@@ -381,6 +382,14 @@ This event fires before the request is sent. Returning an explicit boolean`false
 
 **Signature**: `() => boolean | void`
 
+### `cancel` [#cancel]
+
+This event fires when an in-flight request or deferred polling operation is cancelled with `cancel()`.
+
+**Signature**: `(reason?: string) => void`
+
+- `reason`: The optional reason passed to `cancel(reason)`, or `"user"` by default.
+
 ### `error` [#error]
 
 This event fires when a request results in an error.
@@ -486,9 +495,17 @@ Fires if max polling duration is exceeded in deferred mode.
 
 ### `cancel` [#cancel]
 
-Cancel the deferred operation on the server and stop polling. Requires cancelUrl to be configured.
+Cancel an in-flight API request, active deferred polling, and optionally notify the server through `cancelUrl`.
 
-**Signature**: `cancel(): Promise<void>`
+**Signature**: `cancel(reason?: string): Promise<boolean>`
+
+- `reason`: Optional cancellation reason exposed through `onCancel` and `lastCancelReason`.
+
+### `cancelled` [#cancelled]
+
+This property indicates whether the most recent API operation was cancelled.
+
+**Signature**: `get cancelled(): boolean`
 
 ### `execute` [#execute]
 
@@ -515,6 +532,12 @@ Boolean flag indicating whether the API call is currently in progress.
 Check if polling is currently active in deferred mode.
 
 **Signature**: `isPolling(): boolean`
+
+### `lastCancelReason` [#lastcancelreason]
+
+This property returns the reason passed to the most recent `cancel(reason)` call.
+
+**Signature**: `get lastCancelReason(): string | undefined`
 
 ### `lastError` [#lasterror]
 

--- a/website/content/docs/reference/components/DataSource.md
+++ b/website/content/docs/reference/components/DataSource.md
@@ -358,6 +358,14 @@ Set the URL. Required unless `mockData` is provided, in which case the component
 
 ## Events [#events]
 
+### `cancel` [#cancel]
+
+This event fires when an in-flight request is cancelled with the `cancel()` method.
+
+**Signature**: `cancel(reason: string): void`
+
+- `reason`: The cancellation reason. The default value is `user`.
+
 ### `error` [#error]
 
 This event fires when a request results in an error.
@@ -368,7 +376,7 @@ This event fires when a request results in an error.
 
 ### `fetch` [#fetch]
 
-When defined, this event handler replaces the default fetch logic. The handler receives the resolved request properties as context variables: `$url`, `$method`, `$queryParams`, `$requestBody`, `$requestHeaders`, and `$pageParams` (when paging). The return value of the handler becomes the data result. Caching, polling, the `loaded`/`error` events, `resultSelector`, `transformResult`, and the `refetch()` method continue to work normally because the handler runs inside the same query function that powers the default fetch.
+When defined, this event handler replaces the default fetch logic. The handler receives the resolved request properties as context variables: `$url`, `$method`, `$queryParams`, `$requestBody`, `$requestHeaders`, `$pageParams` (when paging), and `$abortSignal`. The return value of the handler becomes the data result. Caching, polling, the `loaded`/`error` events, `resultSelector`, `transformResult`, and the `refetch()` method continue to work normally because the handler runs inside the same query function that powers the default fetch.
 
 **Signature**: `fetch(): any`
 
@@ -428,6 +436,20 @@ The component triggers this event when the fetch operation has been completed an
 
 ## Exposed Methods [#exposed-methods]
 
+### `cancel` [#cancel]
+
+This method cancels the in-flight fetch or refetch operation. It returns `true` when there was an active operation to cancel; otherwise it returns `false`.
+
+**Signature**: `cancel(reason?: string): Promise<boolean>`
+
+- `reason`: Optional reason passed to the `cancel` event. Defaults to `user`.
+
+### `cancelled` [#cancelled]
+
+This property indicates whether the most recent fetch was cancelled.
+
+**Signature**: `get cancelled(): boolean`
+
 ### `inProgress` [#inprogress]
 
 This property indicates if the data is being fetched.
@@ -439,6 +461,12 @@ This property indicates if the data is being fetched.
 This property indicates if the data is being re-fetched.
 
 **Signature**: `get isRefetching(): boolean`
+
+### `lastCancelReason` [#lastcancelreason]
+
+This property returns the reason from the most recent cancellation.
+
+**Signature**: `get lastCancelReason(): string | undefined`
 
 ### `loaded` [#loaded]
 

--- a/website/content/docs/reference/components/ExpandableItem.md
+++ b/website/content/docs/reference/components/ExpandableItem.md
@@ -135,7 +135,7 @@ The `summary` property accepts either a simple text string or a component defini
         <CHStack gap="space-2">
           <Icon name="apps" />
           <Text fontWeight="600">Custom Summary with Icon</Text>
-          <Badge label="New" variant="success" />
+          <Badge value="New" />
         </CHStack>
       </property>
       <Text>

--- a/website/content/docs/reference/components/NavGroup.md
+++ b/website/content/docs/reference/components/NavGroup.md
@@ -121,6 +121,12 @@ Available values:
 | `start` | Display arrow immediately after the label (default) **(default)** |
 | `end` | Push arrow to the right edge of the NavGroup |
 
+### `fitContentWidth` [#fitcontentwidth]
+
+> [!DEF]  default: **false**
+
+This Boolean property controls whether the `NavGroup` sizes itself to fit its widest child item. The resulting width is capped by the `maxWidth-fitContent-NavGroup` theme variable.
+
 ### `icon` [#icon]
 
 This property defines an optional icon to display along with the `NavGroup` label.
@@ -239,6 +245,7 @@ This component does not expose any methods.
 | [marginTop-items-NavGroup](/docs/styles-and-themes/common-units/#size-values) | 0 | 0 |
 | [marginTop-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |
 | [marginVertical-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |
+| [maxWidth-fitContent-NavGroup](/docs/styles-and-themes/common-units/#size-values) | 100vw | 100vw |
 | [minWidth-dropdown-NavGroup](/docs/styles-and-themes/common-units/#size-values) | 11em | 11em |
 | [padding-level1-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |
 | [padding-level2-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |

--- a/website/content/docs/reference/components/Table.md
+++ b/website/content/docs/reference/components/Table.md
@@ -902,6 +902,49 @@ The default value is `false`.
 </App>
 ```
 
+### `highlightHoveredColumn` [#highlighthoveredcolumn]
+
+> [!DEF]  default: **false**
+
+When set to `true`, hovering a table cell tints its entire column with the [`backgroundColor-column-Table--hover`](#backgroundcolor-column-table--hover) theme variable. The default is `false`: no cell hover handlers are attached and the rendered output is unchanged. Where the hovered row and the hovered column intersect, the row highlight wins. Pinned columns keep their own hover background instead of the column tint.
+
+Column headers already highlight on hover, but by default hovering a cell in the table body only highlights its row — nothing marks which column you are in. On a wide table this makes it easy to lose track of which field you are reading as your eye travels down a column.
+
+Set `highlightHoveredColumn` to `true` to tint the entire hovered column with the [`backgroundColor-column-Table--hover`](#backgroundcolor-column-table--hover) theme variable. The default is `false`: no cell hover handlers are attached and the table renders exactly as it does today.
+
+Where the hovered row and the hovered column intersect, the row highlight wins — the column tint never competes with or muddies the row's own hover color. Pinned columns keep their existing hover background instead of showing the column tint, since the pointer being elsewhere in the table should not change how a pinned column looks.
+
+```xmlui copy /highlightHoveredColumn="true"/
+<App>
+  <Table data='{[...]}' highlightHoveredColumn="true">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+    <Column bindTo="unit"/>
+  </Table>
+</App>
+```
+
+Hover any cell to see its whole column tinted, and hover a row to see the row highlight take precedence where the two overlap:
+
+```xmlui-pg name="Example: highlightHoveredColumn"
+<App>
+  <Table
+    data='{[
+      { id: 0, name: "Apples", quantity: 5, unit: "pieces", category: "fruits" },
+      { id: 1, name: "Bananas", quantity: 6, unit: "pieces", category: "fruits" },
+      { id: 2, name: "Carrots", quantity: 100, unit: "grams", category: "vegetables" },
+      { id: 3, name: "Spinach", quantity: 1, unit: "bunch", category: "vegetables" },
+      { id: 4, name: "Milk", quantity: 10, unit: "liter", category: "dairy" }
+    ]}'
+    highlightHoveredColumn="true">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+    <Column bindTo="unit"/>
+    <Column bindTo="category"/>
+  </Table>
+</App>
+```
+
 ### `iconNoSort` [#iconnosort]
 
 Allows setting an alternate icon displayed in the Table column header when sorting is enabled, but the column remains unsorted. You can change the default icon for all Table instances with the "icon.nosort:Table" declaration in the app configuration file.
@@ -2099,6 +2142,27 @@ This event is triggered when the user presses the paste keyboard shortcut (defau
 - `selectedItems`: Array of selected row items.
 - `selectedIds`: Array of selected row IDs (as strings).
 
+### `rowClick` [#rowclick]
+
+This event is fired when the user clicks a table row. The handler receives the clicked row item as its only argument. It reports the click without replacing or suppressing selection — pair it with `rowsSelectable` deliberately, and prefer `selectionDidChange` when what you actually care about is the selection. The event does not fire for clicks on the selection checkbox or on an interactive control (such as a button) inside a cell.
+
+**Signature**: `rowClick(item: any): void`
+
+- `item`: The clicked table row item.
+
+This event is triggered when a table row is clicked. The handler receives the row's data item as its only argument.
+
+`rowClick` reports activation — it does not replace or suppress selection. Row click already runs a selection toggle when `rowsSelectable` is set, and `rowClick` fires alongside that without interfering with it: pair it with `rowsSelectable` deliberately, and prefer [`selectionDidChange`](#selectiondidchange) when what you actually care about is the selection rather than the click itself. `rowClick` does not fire for a click on the selection checkbox, nor for a click on an interactive control (such as a button) inside a cell.
+
+```xmlui copy {4}
+<App>
+  <Table data='{[...]}' onRowClick="(item) => console.log(item)">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+  </Table>
+</App>
+```
+
 ### `rowDoubleClick` [#rowdoubleclick]
 
 This event is fired when the user double-clicks a table row. The handler receives the clicked row item as its only argument.
@@ -2720,6 +2784,7 @@ The component has some parts that can be styled through layout properties and th
 
 | Variable | Default Value (Light) | Default Value (Dark) |
 | --- | --- | --- |
+| [backgroundColor-column-Table--hover](/docs/styles-and-themes/common-units/#color) | $color-surface-100 | $color-surface-100 |
 | [backgroundColor-evenRow-Table](/docs/styles-and-themes/common-units/#color) | $backgroundColor-row-Table | $backgroundColor-row-Table |
 | [backgroundColor-heading-Table](/docs/styles-and-themes/common-units/#color) | $color-surface-100 | $color-surface-100 |
 | [backgroundColor-heading-Table--active](/docs/styles-and-themes/common-units/#color) | $color-surface-300 | $color-surface-300 |

--- a/website/content/docs/reference/components/Tree.md
+++ b/website/content/docs/reference/components/Tree.md
@@ -179,7 +179,9 @@ You have several options to style the icons representing the expanded or collaps
 Each tree node is selectable by default, unless the node item's data does not have a `selectable` property (or the one specified in `selectedField`).
 A selectable item can be selected by clicking the mouse or pressing the Enter or Space keys when it has focus.
 
-You can set the `selectedValue` property to define the selected tree item, ot use the `selectNode` exposed method for imperative selection.
+You can set the `selectedValue` property to define the selected tree item, or use the `selectNode` exposed method for imperative selection.
+
+You can also use `selectNodeByIndex(index)` to select a node by its current visible row index. The index is zero-based and follows the tree's physical row order after expansion state is applied. For example, when three root nodes are collapsed, the roots are indexed `0`, `1`, and `2`. If the first root expands and reveals four children, that root remains `0`, its children become `1` through `4`, and the second and third roots become `5` and `6`.
 
 ## Item templates [#item-templates]
 
@@ -1097,6 +1099,14 @@ Replace a node's properties with new data using merge semantics. Properties not 
   </VStack>
 </App>
 ```
+
+### `selectNodeByIndex` [#selectnodebyindex]
+
+Programmatically select a node by its current visible index. The index is 0-based and follows the tree's physical row order after applying the current expanded/collapsed state.
+
+**Signature**: `selectNodeByIndex(index: number): void`
+
+- `index`: The 0-based visible row index to select.
 
 ### `setTreeState` [#settreestate]
 

--- a/website/content/docs/reference/extensions/xmlui-echart/EChart.md
+++ b/website/content/docs/reference/extensions/xmlui-echart/EChart.md
@@ -22,6 +22,10 @@ This component supports the following behaviors:
 
 Height of the chart container.
 
+### `maps`
+
+An object of `name → GeoJSON` map definitions. Each entry is passed to `echarts.registerMap(name, geojson)` before the option is applied, so a `map`-type series can reference the name (e.g. `series: [{ type: 'map', map: 'my-region', ... }]`). Entries whose value is empty are skipped, so binding a not-yet-loaded DataSource value is safe: the map registers (and the chart re-renders) when the data arrives. Omitting the property leaves current behavior unchanged.
+
 ### `option`
 
 The ECharts option object. Accepts any valid ECharts configuration. XMLUI theme colors are automatically injected for palette, text, axes, and tooltip unless explicitly overridden in the option.

--- a/website/content/docs/reference/extensions/xmlui-recharts/AreaChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/AreaChart.md
@@ -2,6 +2,10 @@
 
 Interactive area chart for showing data trends over time with filled areas under the curve
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/website/content/docs/reference/extensions/xmlui-recharts/BarChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/BarChart.md
@@ -2,6 +2,10 @@
 
 `BarChart` displays data as horizontal or vertical bars, supporting both grouped and stacked layouts. It's ideal for comparing values across categories, showing revenue trends, or displaying any quantitative data over time or categories.
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/website/content/docs/reference/extensions/xmlui-recharts/LineChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/LineChart.md
@@ -2,6 +2,10 @@
 
 `LineChart` displays data as connected points over a continuous axis, ideal for showing trends, changes over time, or relationships between variables. Use it time series data, progress tracking, and comparing multiple data series on the same scale.
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/website/content/docs/reference/extensions/xmlui-recharts/RadarChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/RadarChart.md
@@ -2,6 +2,10 @@
 
 Interactive radar chart for displaying multivariate data in a two-dimensional chart of three or more quantitative variables
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/xmlui/dev-docs/guide/11-user-defined-components.md
+++ b/xmlui/dev-docs/guide/11-user-defined-components.md
@@ -17,7 +17,7 @@ Understanding UDCs matters for framework developers because the compound renderi
 
 <!-- Main.xmlui — usage: caller's children flow into the Slot -->
 <ContactCard name="Alice" email="alice@example.com">
-  <Badge label="Admin" />
+  <Badge value="Admin" />
 </ContactCard>
 ```
 

--- a/xmlui/dev-docs/guide/15-app-context.md
+++ b/xmlui/dev-docs/guide/15-app-context.md
@@ -221,7 +221,7 @@ You never need to import date-fns directly in component code or markup.
 ### Comparison Functions
 
 ```xml
-<Badge visible="{isToday(event.date)}" label="Today" />
+<Badge visible="{isToday(event.date)}" value="Today" />
 <Text visible="{!isThisYear(doc.createdAt)}">{formatDate(doc.createdAt)}</Text>
 <Text>{differenceInMinutes(endTime, startTime)} min</Text>
 ```

--- a/xmlui/package.json
+++ b/xmlui/package.json
@@ -24,6 +24,7 @@
     "check:metadata-purity": "node scripts/check-metadata-purity.mjs",
     "check:metadata": "tsx scripts/check-metadata-drift.ts",
     "check:metadata-snapshot": "npm run build:xmlui-metadata && npm run gen:langserver-metadata && git diff --exit-code src/language-server/xmlui-metadata-generated.js",
+    "check:reference-drift": "node scripts/check-reference-drift.mjs",
     "check:api-diff": "tsx scripts/api-diff/release-guard.ts",
     "check:css-chunks": "node scripts/inspect-css-chunks.mjs",
     "check:example-tests": "node scripts/check-example-tests.mjs",

--- a/xmlui/scripts/check-reference-drift.mjs
+++ b/xmlui/scripts/check-reference-drift.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Detects drift between the committed reference pages under
+ * `website/content/docs/reference/**` and what `npm run generate-docs`
+ * would currently produce from source.
+ *
+ * Two hazards this script exists to avoid (see
+ * resources/worklist-drafts/detect-stale-reference-pages.md for the full
+ * writeup):
+ *
+ * 1. It NEVER writes into the working tree. Generation happens entirely in
+ *    a temporary directory; the committed `website/content/docs/reference`
+ *    tree is only ever read. There is nothing to restore because nothing
+ *    in the working tree is touched.
+ *
+ * 2. `generate-docs` consumes *built* metadata (`dist/metadata/*.cjs`), not
+ *    source. This script always rebuilds that metadata immediately before
+ *    generating, so the comparison reflects current source rather than
+ *    whatever happened to be sitting in `dist/` already. A build failure
+ *    here is a hard failure of the check (fail loudly, not silently trust
+ *    a stale dist).
+ *
+ * The generation logic itself is not reimplemented from scratch: it reuses
+ * the real `DocsGenerator` / `MetadataProcessor` machinery from
+ * scripts/generate-docs, imported dynamically (after the fresh build) and
+ * pointed at a temp output directory instead of the real one. Only the
+ * top-level orchestration that get-docs.mjs performs is duplicated here,
+ * scoped down to the parts that write under reference/components and
+ * reference/extensions/<package> -- the side effects that write elsewhere
+ * (nav JSON, landing metadata, script-local metadata.json export) are
+ * deliberately skipped since they fall outside this check's scope and
+ * would otherwise mutate the real tree.
+ */
+
+import { existsSync } from "fs";
+import { mkdtemp, mkdir, rm, readdir, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join, dirname, relative } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { spawnSync } from "child_process";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url)); // xmlui/scripts
+const XMLUI_ROOT = join(SCRIPT_DIR, ".."); // xmlui/
+const REPO_ROOT = join(XMLUI_ROOT, ".."); // repo root
+const GENDOCS_DIR = join(SCRIPT_DIR, "generate-docs");
+const COMMITTED_REFERENCE_ROOT = join(REPO_ROOT, "website/content/docs/reference");
+
+function log(msg) {
+  console.error(`[check-reference-drift] ${msg}`);
+}
+
+function run(command, args, cwd, label) {
+  log(`${label}: ${command} ${args.join(" ")} (cwd=${relative(REPO_ROOT, cwd)})`);
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if (result.error) {
+    throw new Error(`${label} failed to start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${label} exited with status ${result.status}`);
+  }
+}
+
+async function main() {
+  let tmpDir;
+  try {
+    // --- Trap 2: never trust a possibly-stale dist/. Always rebuild the
+    // metadata the generator will consume, from whatever source is on disk
+    // right now.
+    run("npm", ["run", "build:xmlui-metadata"], XMLUI_ROOT, "Building main component metadata");
+
+    const extensionsConfigPath = join(GENDOCS_DIR, "extensions-config.json");
+    const extensionsConfigRaw = JSON.parse(await readFile(extensionsConfigPath, "utf8"));
+    const excludeByName = new Set(extensionsConfigRaw.excludeByName ?? []);
+
+    let candidatePackageNames;
+    if (extensionsConfigRaw.includeByName?.length) {
+      candidatePackageNames = extensionsConfigRaw.includeByName;
+    } else {
+      const packagesDir = join(REPO_ROOT, "packages");
+      candidatePackageNames = (await readdir(packagesDir)).filter((name) => name.startsWith("xmlui-"));
+    }
+
+    const activePackages = [];
+    for (const name of candidatePackageNames) {
+      if (excludeByName.has(name)) continue;
+      const pkgDir = join(REPO_ROOT, "packages", name);
+      if (!existsSync(join(pkgDir, "dist"))) {
+        // No local build for this package -> the real `npm run generate-docs`
+        // would silently skip it too (dynamicallyLoadExtensionPackages only
+        // considers packages that already have a dist folder). Mirror that,
+        // rather than failing loudly for a package nobody built locally.
+        log(`Skipping extension ${name}: no local dist/ (generate-docs would skip it too)`);
+        continue;
+      }
+      run("npm", ["run", "build:meta"], pkgDir, `Building metadata for extension ${name}`);
+      activePackages.push(name);
+    }
+
+    // --- Generate into a scratch directory. The working tree is never
+    // written to below this point.
+    tmpDir = await mkdtemp(join(tmpdir(), "xmlui-reference-drift-"));
+    await generateReferenceDocs(tmpDir, activePackages);
+
+    // --- Compare.
+    const drift = [];
+    drift.push(...(await compareDir(join(tmpDir, "components"), join(COMMITTED_REFERENCE_ROOT, "components"), "components")));
+    for (const pkg of activePackages) {
+      drift.push(
+        ...(await compareDir(
+          join(tmpDir, "extensions", pkg),
+          join(COMMITTED_REFERENCE_ROOT, "extensions", pkg),
+          `extensions/${pkg}`,
+        )),
+      );
+    }
+
+    drift.sort();
+
+    if (drift.length > 0) {
+      console.error(`Reference drift detected in ${drift.length} file(s) under website/content/docs/reference/:`);
+      for (const f of drift) {
+        console.error(`  ${f}`);
+      }
+      process.exitCode = 1;
+    } else {
+      console.log("No reference drift: committed website/content/docs/reference/** matches generate-docs output.");
+    }
+  } finally {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Reimplements the parts of get-docs.mjs's orchestration that write under
+ * reference/components and reference/extensions/<package>, redirected to
+ * `outRoot` instead of the real website/content/docs/reference tree. Reuses
+ * the real DocsGenerator/MetadataProcessor machinery (imported dynamically,
+ * after the fresh metadata build above) so the generated content matches
+ * what `npm run generate-docs` actually produces.
+ *
+ * Deliberately NOT reproduced here (out of scope for this check, and would
+ * otherwise write into the real tree if it were): components.json /
+ * extensions.json nav JSON, dist/metadata/landing-metadata.json, and the
+ * script-local scripts/generate-docs/metadata/*.json export.
+ */
+async function generateReferenceDocs(outRoot, activePackages) {
+  const { DocsGenerator } = await import(pathToFileURL(join(GENDOCS_DIR, "DocsGenerator.mjs")).href);
+  const { configManager, pathResolver } = await import(
+    pathToFileURL(join(GENDOCS_DIR, "configuration-management.mjs")).href
+  );
+  const { COMPONENT_STATES, METADATA_PROPERTIES, SUMMARY_CONFIG, TEMPLATE_STRINGS } = await import(
+    pathToFileURL(join(GENDOCS_DIR, "constants.mjs")).href
+  );
+  const { deleteFileIfExists } = await import(pathToFileURL(join(GENDOCS_DIR, "utils.mjs")).href);
+
+  // --- Components (freshly rebuilt above).
+  const metadataModuleUrl = pathToFileURL(join(XMLUI_ROOT, "dist/metadata/xmlui-metadata.cjs")).href;
+  const { collectedComponentMetadata } = await import(metadataModuleUrl);
+
+  const components = Object.fromEntries(
+    Object.entries(collectedComponentMetadata).filter(
+      ([, compData]) => compData[METADATA_PROPERTIES.IS_HTML_TAG] !== true,
+    ),
+  );
+
+  const componentsOut = join(outRoot, "components");
+  await mkdir(componentsOut, { recursive: true });
+
+  const componentsConfig = await configManager.loadComponentsConfig();
+  const componentsGenerator = new DocsGenerator(
+    components,
+    {
+      sourceFolder: pathResolver.resolvePath("xmlui/src/components", "workspace"),
+      outFolder: componentsOut,
+    },
+    { excludeComponentStatuses: componentsConfig?.excludeComponentStatuses ?? [] },
+  );
+  componentsGenerator.generateDocs();
+  await writeComponentsOverview(componentsOut, SUMMARY_CONFIG, collectedComponentMetadata);
+  await componentsGenerator.generatePermalinksForHeaders();
+
+  // --- Extensions (freshly rebuilt above, one package at a time).
+  const extensionsConfig = await configManager.loadExtensionsConfig();
+  const extensionsOut = join(outRoot, "extensions");
+  await mkdir(extensionsOut, { recursive: true });
+
+  for (const packageName of activePackages) {
+    const pkgDir = join(REPO_ROOT, "packages", packageName);
+    const metaPath = join(pkgDir, "dist", `${packageName}-metadata.js`);
+    if (!existsSync(metaPath)) {
+      log(`Skipping extension ${packageName}: build:meta did not produce ${relative(REPO_ROOT, metaPath)}`);
+      continue;
+    }
+    const { componentMetadata } = await import(pathToFileURL(metaPath).href);
+    if (!componentMetadata?.metadata) continue;
+    if (componentMetadata.state === COMPONENT_STATES.INTERNAL) continue;
+
+    const packageFolder = join(extensionsOut, packageName);
+    await mkdir(packageFolder, { recursive: true });
+
+    const extensionGenerator = new DocsGenerator(
+      componentMetadata.metadata,
+      { sourceFolder: pkgDir, outFolder: packageFolder },
+      { excludeComponentStatuses: extensionsConfig?.excludeComponentStatuses ?? [] },
+    );
+    const componentsAndFileNames = extensionGenerator.generateDocs();
+    if (Object.keys(componentsAndFileNames).length === 0) {
+      await rm(packageFolder, { recursive: true, force: true });
+      continue;
+    }
+
+    const indexFile = join(packageFolder, `${SUMMARY_CONFIG.EXTENSIONS.fileName}.md`);
+    deleteFileIfExists(indexFile);
+    await extensionGenerator.generatePackageDescription(
+      componentMetadata.description ?? "",
+      TEMPLATE_STRINGS.PACKAGE_HEADER(packageName),
+      indexFile,
+    );
+    await copyExtensionPackageDocs(pkgDir, packageFolder);
+    // Note: the real get-docs.mjs does not call generatePermalinksForHeaders()
+    // for extension packages, only for the main components folder. Matched
+    // here deliberately.
+  }
+}
+
+async function writeComponentsOverview(componentsOut, SUMMARY_CONFIG, collectedComponentMetadata) {
+  const { writeFile } = await import("fs/promises");
+  const summaryFileName = SUMMARY_CONFIG.COMPONENTS.fileName;
+  const summaryTitle = SUMMARY_CONFIG.COMPONENTS.title;
+
+  const componentNames = Object.keys(collectedComponentMetadata)
+    .filter((name) => {
+      const compData = collectedComponentMetadata[name];
+      return compData?.isHtmlTag !== true;
+    })
+    .sort();
+
+  const tableHeader = `# ${summaryTitle} [#components-overview]\n\n| Component | Description |\n| :---: | --- |`;
+  const tableRows = componentNames.map((componentName) => {
+    const description = collectedComponentMetadata[componentName]?.description || "No description available";
+    return `| [${componentName}](/docs/reference/components/${componentName}) | ${description} |`;
+  });
+  const content = [tableHeader, ...tableRows].join("\n");
+  await writeFile(join(componentsOut, `${summaryFileName}.md`), content);
+}
+
+async function copyExtensionPackageDocs(sourceFolder, outFolder) {
+  const { copyFile } = await import("fs/promises");
+  const { extname, basename } = await import("path");
+  const docsFolder = join(sourceFolder, "docs");
+  if (!existsSync(docsFolder)) return;
+
+  const docFiles = (await readdir(docsFolder)).filter((file) => [".md", ".mdx"].includes(extname(file)));
+  for (const file of docFiles) {
+    await copyFile(join(docsFolder, file), join(outFolder, file));
+  }
+}
+
+/**
+ * Full 1:1 comparison between a freshly generated directory and its
+ * committed counterpart. Both directories are treated as authoritative for
+ * the file set the real generator manages (cleanFolder:true means the real
+ * run would remove any committed file that generation no longer produces),
+ * so files present on only one side count as drift too.
+ */
+async function compareDir(generatedDir, committedDir, label) {
+  const generatedFiles = await listMarkdownFiles(generatedDir);
+  const committedFiles = await listMarkdownFiles(committedDir);
+  const allRelPaths = new Set([...generatedFiles.keys(), ...committedFiles.keys()]);
+
+  const drift = [];
+  for (const relPath of allRelPaths) {
+    const genContent = generatedFiles.get(relPath);
+    const committedContent = committedFiles.get(relPath);
+    if (genContent === undefined) {
+      drift.push(`website/content/docs/reference/${label}/${relPath} (committed, but generate-docs no longer produces it)`);
+    } else if (committedContent === undefined) {
+      drift.push(`website/content/docs/reference/${label}/${relPath} (generate-docs would produce this, but it is not committed)`);
+    } else if (genContent !== committedContent) {
+      drift.push(`website/content/docs/reference/${label}/${relPath}`);
+    }
+  }
+  return drift;
+}
+
+async function listMarkdownFiles(dir) {
+  const map = new Map();
+  if (!existsSync(dir)) return map;
+  await walk(dir, dir, map);
+  return map;
+}
+
+async function walk(root, dir, map) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(root, full, map);
+    } else if (entry.isFile() && (entry.name.endsWith(".md") || entry.name.endsWith(".mdx"))) {
+      const relPath = relative(root, full);
+      map.set(relPath, await readFile(full, "utf8"));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`[check-reference-drift] FAILED: ${error.message}`);
+  if (error.stack) console.error(error.stack);
+  process.exitCode = 1;
+});

--- a/xmlui/src/components/ExpandableItem/ExpandableItem.md
+++ b/xmlui/src/components/ExpandableItem/ExpandableItem.md
@@ -24,7 +24,7 @@ The `summary` property accepts either a simple text string or a component defini
         <CHStack gap="space-2">
           <Icon name="apps" />
           <Text fontWeight="600">Custom Summary with Icon</Text>
-          <Badge label="New" variant="success" />
+          <Badge value="New" />
         </CHStack>
       </property>
       <Text>


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Refs #3814. Three commits, in dependency order — an instrument, the backlog it found, and the fix that rediscovered it.

## `7b4681b` — a drift check for the committed reference pages

`website/content/docs/reference/**` is generated from component metadata and the output is committed, but nothing verified the committed output still matched what `generate-docs` would produce. Ten pages had already drifted.

The check never writes into the working tree — generation happens in a temp directory and the committed tree is only read. It also rebuilds metadata first, because `generate-docs` consumes *built* metadata (`dist/metadata/*.cjs`) rather than source, so a stale `dist/` would otherwise make the comparison meaningless.

## `795103b3c` — regenerate the ten pages it named

Generator output, not hand-written. The largest addition is Table's `highlightHoveredColumn`, whose metadata landed in `db1ada0` without a regenerated page.

**Why now rather than continuing to soak.** The staleness is not only cosmetic — it is a trap for unrelated work, because the stale pages are invisible until someone runs the generator for another reason. Doing so pulls 158 unrelated insertions into the working tree belonging to no tracked change, where they are liable to be swept into whatever commit happens to touch a reference page. That is exactly how this was rediscovered: running `generate-all-docs` to regenerate one page for the Badge fix below.

After this commit the check reports **one** file instead of eleven — `_overview.md`, the known false positive recorded when the instrument was added. It is excluded here rather than papered over: `generate-docs` does not produce a different version for it through this path, so it is a discrepancy in the check's own scoped-down orchestration, not real drift. **The check therefore still exits non-zero**, which is worth fixing before anyone wires it into CI — a permanently red detector trains people to ignore it.

## `fbc803316` — use Badge's `value` prop in documentation examples

The `ExpandableItem` rich-summary example rendered:

```xmlui
<Badge label="New" variant="success" />
```

`Badge` has no `label` prop. `value` is the display text, and without it the component renders a single frame containing a non-breaking space — so anyone copying the example got an **empty badge**. The `variant` was invalid too: `Badge` accepts only `badge` or `pill`, never `success`. Both are dropped in favour of `<Badge value="New" />`.

A repository sweep found the same mistake in two developer-guide examples, corrected the same way. The occurrence in `behaviors.md` is deliberately left alone — it supplies `value` and uses `label` to demonstrate the generic label behavior, which is the one place the pairing is meaningful.

## Note on scope

`7b4681b` was originally committed to soak rather than ship. It is included because `795103b3c` is its direct consequence and would be strange to land without it, and because keeping the SHAs intact is what lets the queued close for #3814 bind correctly. Happy to split it back out if you would rather it kept soaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
