### PR TITLE
Use Badge's value prop in documentation examples

### DIFF
--- a/website/content/docs/reference/components/ExpandableItem.md
+++ b/website/content/docs/reference/components/ExpandableItem.md
@@ -135,7 +135,7 @@ The `summary` property accepts either a simple text string or a component defini
         <CHStack gap="space-2">
           <Icon name="apps" />
           <Text fontWeight="600">Custom Summary with Icon</Text>
-          <Badge label="New" variant="success" />
+          <Badge value="New" />
         </CHStack>
       </property>
       <Text>

--- a/xmlui/dev-docs/guide/11-user-defined-components.md
+++ b/xmlui/dev-docs/guide/11-user-defined-components.md
@@ -17,7 +17,7 @@ Understanding UDCs matters for framework developers because the compound renderi
 
 <!-- Main.xmlui — usage: caller's children flow into the Slot -->
 <ContactCard name="Alice" email="alice@example.com">
-  <Badge label="Admin" />
+  <Badge value="Admin" />
 </ContactCard>
 ```
 

--- a/xmlui/dev-docs/guide/15-app-context.md
+++ b/xmlui/dev-docs/guide/15-app-context.md
@@ -221,7 +221,7 @@ You never need to import date-fns directly in component code or markup.
 ### Comparison Functions
 
 ```xml
-<Badge visible="{isToday(event.date)}" label="Today" />
+<Badge visible="{isToday(event.date)}" value="Today" />
 <Text visible="{!isThisYear(doc.createdAt)}">{formatDate(doc.createdAt)}</Text>
 <Text>{differenceInMinutes(endTime, startTime)} min</Text>
 ```

--- a/xmlui/src/components/ExpandableItem/ExpandableItem.md
+++ b/xmlui/src/components/ExpandableItem/ExpandableItem.md
@@ -24,7 +24,7 @@ The `summary` property accepts either a simple text string or a component defini
         <CHStack gap="space-2">
           <Icon name="apps" />
           <Text fontWeight="600">Custom Summary with Icon</Text>
-          <Badge label="New" variant="success" />
+          <Badge value="New" />
         </CHStack>
       </property>
       <Text>


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Refs #3814. Four lines across four files.

The `ExpandableItem` rich-summary example rendered:

```xmlui
<Badge label="New" variant="success" />
```

`Badge` has no `label` prop. `value` is the display text, and without it the component renders a single frame containing a non-breaking space — so anyone copying the example got an **empty badge**. The `variant` was invalid too: `Badge` accepts only `badge` or `pill`, never `success`. Both are dropped in favour of `<Badge value="New" />`.

A repository sweep found the same mistake in two developer-guide examples, corrected the same way:

- `xmlui/dev-docs/guide/11-user-defined-components.md`
- `xmlui/dev-docs/guide/15-app-context.md`

The occurrence in `website/content/docs/pages/behaviors.md` is deliberately left alone — it supplies `value` and uses `label` to demonstrate the generic label behavior, which is the one place the pairing is meaningful.

The generated reference page is updated to match its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
