### PR TITLE
Regenerate the drifted reference pages

### DIFF
--- a/website/content/docs/reference/components/APICall.md
+++ b/website/content/docs/reference/components/APICall.md
@@ -10,6 +10,7 @@
 
 **Context variables available during execution:**
 
+- `$abortSignal`: AbortSignal for the current request (available in `mockExecute`)
 - `$attempts`: Number of status polls made in deferred mode
 - `$cookies`: Request cookies (available in `mockExecute`)
 - `$elapsed`: Time elapsed since polling started in milliseconds
@@ -381,6 +382,14 @@ This event fires before the request is sent. Returning an explicit boolean`false
 
 **Signature**: `() => boolean | void`
 
+### `cancel` [#cancel]
+
+This event fires when an in-flight request or deferred polling operation is cancelled with `cancel()`.
+
+**Signature**: `(reason?: string) => void`
+
+- `reason`: The optional reason passed to `cancel(reason)`, or `"user"` by default.
+
 ### `error` [#error]
 
 This event fires when a request results in an error.
@@ -486,9 +495,17 @@ Fires if max polling duration is exceeded in deferred mode.
 
 ### `cancel` [#cancel]
 
-Cancel the deferred operation on the server and stop polling. Requires cancelUrl to be configured.
+Cancel an in-flight API request, active deferred polling, and optionally notify the server through `cancelUrl`.
 
-**Signature**: `cancel(): Promise<void>`
+**Signature**: `cancel(reason?: string): Promise<boolean>`
+
+- `reason`: Optional cancellation reason exposed through `onCancel` and `lastCancelReason`.
+
+### `cancelled` [#cancelled]
+
+This property indicates whether the most recent API operation was cancelled.
+
+**Signature**: `get cancelled(): boolean`
 
 ### `execute` [#execute]
 
@@ -515,6 +532,12 @@ Boolean flag indicating whether the API call is currently in progress.
 Check if polling is currently active in deferred mode.
 
 **Signature**: `isPolling(): boolean`
+
+### `lastCancelReason` [#lastcancelreason]
+
+This property returns the reason passed to the most recent `cancel(reason)` call.
+
+**Signature**: `get lastCancelReason(): string | undefined`
 
 ### `lastError` [#lasterror]
 

--- a/website/content/docs/reference/components/Column.md
+++ b/website/content/docs/reference/components/Column.md
@@ -250,6 +250,29 @@ To change the default for all columns in your app, set `columnCanSortDefault` in
 }
 ```
 
+### `defaultSortDirection` [#defaultsortdirection]
+
+Sets which direction the *first* click on this column's header sorts. Use `descending` for columns where the largest value is the interesting one (counts, totals, percentages), so a single click gives the useful order. The click cycle keeps three states and only its starting point moves: with `descending` it runs descending, ascending, unsorted. When unset, the column inherits the Table's `defaultSortDirection`, then `ascending`.
+
+Available values: `ascending`, `descending`
+
+Sets which direction the *first* click on this column's header sorts, overriding
+the Table's own [`defaultSortDirection`](/docs/reference/components/Table#defaultsortdirection).
+
+Use it for the odd column that reads the other way round from the rest of its
+table -- a name column in a table of counts, or a single "biggest first" measure
+among otherwise alphabetical fields.
+
+```xmlui copy /defaultSortDirection="ascending"/
+<Table data='{[...]}' defaultSortDirection="descending">
+  <Column bindTo="candidate" canSort="true" defaultSortDirection="ascending"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+When unset, the column inherits the Table's value, then `ascending`. The click
+cycle keeps three states either way; only its starting point moves.
+
 ### `enabled` [#enabled]
 
 > [!DEF]  default: **true**

--- a/website/content/docs/reference/components/DataSource.md
+++ b/website/content/docs/reference/components/DataSource.md
@@ -358,6 +358,14 @@ Set the URL. Required unless `mockData` is provided, in which case the component
 
 ## Events [#events]
 
+### `cancel` [#cancel]
+
+This event fires when an in-flight request is cancelled with the `cancel()` method.
+
+**Signature**: `cancel(reason: string): void`
+
+- `reason`: The cancellation reason. The default value is `user`.
+
 ### `error` [#error]
 
 This event fires when a request results in an error.
@@ -368,7 +376,7 @@ This event fires when a request results in an error.
 
 ### `fetch` [#fetch]
 
-When defined, this event handler replaces the default fetch logic. The handler receives the resolved request properties as context variables: `$url`, `$method`, `$queryParams`, `$requestBody`, `$requestHeaders`, and `$pageParams` (when paging). The return value of the handler becomes the data result. Caching, polling, the `loaded`/`error` events, `resultSelector`, `transformResult`, and the `refetch()` method continue to work normally because the handler runs inside the same query function that powers the default fetch.
+When defined, this event handler replaces the default fetch logic. The handler receives the resolved request properties as context variables: `$url`, `$method`, `$queryParams`, `$requestBody`, `$requestHeaders`, `$pageParams` (when paging), and `$abortSignal`. The return value of the handler becomes the data result. Caching, polling, the `loaded`/`error` events, `resultSelector`, `transformResult`, and the `refetch()` method continue to work normally because the handler runs inside the same query function that powers the default fetch.
 
 **Signature**: `fetch(): any`
 
@@ -428,6 +436,20 @@ The component triggers this event when the fetch operation has been completed an
 
 ## Exposed Methods [#exposed-methods]
 
+### `cancel` [#cancel]
+
+This method cancels the in-flight fetch or refetch operation. It returns `true` when there was an active operation to cancel; otherwise it returns `false`.
+
+**Signature**: `cancel(reason?: string): Promise<boolean>`
+
+- `reason`: Optional reason passed to the `cancel` event. Defaults to `user`.
+
+### `cancelled` [#cancelled]
+
+This property indicates whether the most recent fetch was cancelled.
+
+**Signature**: `get cancelled(): boolean`
+
 ### `inProgress` [#inprogress]
 
 This property indicates if the data is being fetched.
@@ -439,6 +461,12 @@ This property indicates if the data is being fetched.
 This property indicates if the data is being re-fetched.
 
 **Signature**: `get isRefetching(): boolean`
+
+### `lastCancelReason` [#lastcancelreason]
+
+This property returns the reason from the most recent cancellation.
+
+**Signature**: `get lastCancelReason(): string | undefined`
 
 ### `loaded` [#loaded]
 

--- a/website/content/docs/reference/components/NavGroup.md
+++ b/website/content/docs/reference/components/NavGroup.md
@@ -121,6 +121,12 @@ Available values:
 | `start` | Display arrow immediately after the label (default) **(default)** |
 | `end` | Push arrow to the right edge of the NavGroup |
 
+### `fitContentWidth` [#fitcontentwidth]
+
+> [!DEF]  default: **false**
+
+This Boolean property controls whether the `NavGroup` sizes itself to fit its widest child item. The resulting width is capped by the `maxWidth-fitContent-NavGroup` theme variable.
+
 ### `icon` [#icon]
 
 This property defines an optional icon to display along with the `NavGroup` label.
@@ -239,6 +245,7 @@ This component does not expose any methods.
 | [marginTop-items-NavGroup](/docs/styles-and-themes/common-units/#size-values) | 0 | 0 |
 | [marginTop-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |
 | [marginVertical-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |
+| [maxWidth-fitContent-NavGroup](/docs/styles-and-themes/common-units/#size-values) | 100vw | 100vw |
 | [minWidth-dropdown-NavGroup](/docs/styles-and-themes/common-units/#size-values) | 11em | 11em |
 | [padding-level1-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |
 | [padding-level2-NavGroup](/docs/styles-and-themes/common-units/#size-values) | *none* | *none* |

--- a/website/content/docs/reference/components/Table.md
+++ b/website/content/docs/reference/components/Table.md
@@ -570,6 +570,153 @@ For mutation flows where only the next refresh should preserve state, call `pres
 
 Stable, unique `idKey` values are required. If an inserted row is outside the current viewport and is present in the current row model, `operation: "insert"` or `scrollTarget: "first-inserted"` scrolls it into view after reconciliation. For paginated tables, insert targeting does not switch pages.
 
+### `defaultSortDirection` [#defaultsortdirection]
+
+> [!DEF]  default: **"ascending"**
+
+Sets which direction the *first* click on a column header sorts. Use `descending` for tables whose interesting rows are the largest ones (counts, totals, percentages), so one click gives the useful order instead of two. The click cycle keeps three states and only its starting point moves: with `descending` it runs descending, ascending, unsorted. Individual `Column` components override this with their own `defaultSortDirection`. It also supplies the initial direction when [`sortBy`](#sortby) is set without an explicit [`sortDirection`](#sortdirection), so a table declared biggest-first opens that way rather than needing a click.
+
+Available values: `ascending` **(default)**, `descending`
+
+Some columns are only interesting from the top: vote counts, totals, percentages.
+A header click sorts ascending first, so those columns cost an extra click before
+they show anything useful. `defaultSortDirection` moves where the click cycle
+starts.
+
+### The problem [#the-problem]
+
+No configuration here. Click **Votes** once and you get the *smallest* count
+first; click again for the largest.
+
+```xmlui copy
+<Table data='{[...]}'>
+  <Column bindTo="candidate"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: two clicks to see the winner"
+<App>
+  <Table data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'>
+    <Column bindTo="candidate"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Two clicks to answer "who won". On one table that is a shrug; across a screenful
+of count columns it is the difference between a table you read and a table you
+operate.
+
+### One line fixes the click count [#one-line-fixes-the-click-count]
+
+```xmlui copy /defaultSortDirection="descending"/
+<Table data='{[...]}' defaultSortDirection="descending">
+  <Column bindTo="candidate"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: defaultSortDirection on the table" /defaultSortDirection="descending"/
+<App>
+  <Table
+    data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'
+    defaultSortDirection="descending">
+    <Column bindTo="candidate"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Click **Votes** once: biggest first. The cycle still has three states and still
+ends unsorted — descending, ascending, unsorted. Only its starting point moved.
+
+### Opening already sorted [#opening-already-sorted]
+
+The property above says *which direction*. It never says *which column*, so the
+table still opens unsorted until you click. To arrive sorted, name the column
+with [`sortBy`](#sortby):
+
+```xmlui copy /sortBy="votes"/
+<Table data='{[...]}' sortBy="votes" defaultSortDirection="descending">
+  <Column bindTo="candidate"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: sortBy with defaultSortDirection" /sortBy="votes"/
+<App>
+  <Table
+    data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'
+    sortBy="votes"
+    defaultSortDirection="descending">
+    <Column bindTo="candidate"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Zero clicks: biggest first on load. `defaultSortDirection` supplies the opening
+direction because no explicit [`sortDirection`](#sortdirection) was given — set
+that instead when the opening order should differ from what clicking produces.
+
+A seeded table is already **at the first stage of the cycle**, so the first click
+advances to the second stage rather than confirming the first. Clicking **Votes**
+here goes to ascending, then to unsorted. That is worth knowing before it
+surprises you: on a seeded column, the first click looks like it reverses the
+sort.
+
+### One column that reads the other way [#one-column-that-reads-the-other-way]
+
+Names are the case where alphabetical is the natural first read, even in a table
+of counts. A `Column` overrides its table:
+
+```xmlui copy /defaultSortDirection="ascending"/
+<Table data='{[...]}' defaultSortDirection="descending">
+  <Column bindTo="candidate" canSort="true" defaultSortDirection="ascending"/>
+  <Column bindTo="votes" canSort="true"/>
+</Table>
+```
+
+```xmlui-pg name="Example: per-column override" /defaultSortDirection="ascending"/
+<App>
+  <Table
+    data='{[
+      { id: 1, candidate: "Ada", votes: 4820 },
+      { id: 2, candidate: "Grace", votes: 9137 },
+      { id: 3, candidate: "Alan", votes: 2044 },
+      { id: 4, candidate: "Edsger", votes: 6610 }
+    ]}'
+    defaultSortDirection="descending">
+    <Column bindTo="candidate" canSort="true" defaultSortDirection="ascending"/>
+    <Column bindTo="votes" canSort="true"/>
+  </Table>
+</App>
+```
+
+Neither column is sorted on load — there is no `sortBy` here. Click **Votes** and
+it goes largest-first; click **Candidate** and it goes A–Z. Resolution is column
+first, then table, then `ascending`.
+
+Switching columns **restarts the cycle** at the new column's own first direction;
+it does not carry the previous column's stage across. Clicking **Votes** then
+**Candidate** gives descending then ascending, each column's own default.
+
 ### `enableMultiRowSelection` [#enablemultirowselection]
 
 > [!DEF]  default: **true**
@@ -898,6 +1045,49 @@ The default value is `false`.
     <Column bindTo="name"/>
     <Column bindTo="quantity"/>
     <Column bindTo="unit"/>
+  </Table>
+</App>
+```
+
+### `highlightHoveredColumn` [#highlighthoveredcolumn]
+
+> [!DEF]  default: **false**
+
+When set to `true`, hovering a table cell tints its entire column with the [`backgroundColor-column-Table--hover`](#backgroundcolor-column-table--hover) theme variable. The default is `false`: no cell hover handlers are attached and the rendered output is unchanged. Where the hovered row and the hovered column intersect, the row highlight wins. Pinned columns keep their own hover background instead of the column tint.
+
+Column headers already highlight on hover, but by default hovering a cell in the table body only highlights its row — nothing marks which column you are in. On a wide table this makes it easy to lose track of which field you are reading as your eye travels down a column.
+
+Set `highlightHoveredColumn` to `true` to tint the entire hovered column with the [`backgroundColor-column-Table--hover`](#backgroundcolor-column-table--hover) theme variable. The default is `false`: no cell hover handlers are attached and the table renders exactly as it does today.
+
+Where the hovered row and the hovered column intersect, the row highlight wins — the column tint never competes with or muddies the row's own hover color. Pinned columns keep their existing hover background instead of showing the column tint, since the pointer being elsewhere in the table should not change how a pinned column looks.
+
+```xmlui copy /highlightHoveredColumn="true"/
+<App>
+  <Table data='{[...]}' highlightHoveredColumn="true">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+    <Column bindTo="unit"/>
+  </Table>
+</App>
+```
+
+Hover any cell to see its whole column tinted, and hover a row to see the row highlight take precedence where the two overlap:
+
+```xmlui-pg name="Example: highlightHoveredColumn"
+<App>
+  <Table
+    data='{[
+      { id: 0, name: "Apples", quantity: 5, unit: "pieces", category: "fruits" },
+      { id: 1, name: "Bananas", quantity: 6, unit: "pieces", category: "fruits" },
+      { id: 2, name: "Carrots", quantity: 100, unit: "grams", category: "vegetables" },
+      { id: 3, name: "Spinach", quantity: 1, unit: "bunch", category: "vegetables" },
+      { id: 4, name: "Milk", quantity: 10, unit: "liter", category: "dairy" }
+    ]}'
+    highlightHoveredColumn="true">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+    <Column bindTo="unit"/>
+    <Column bindTo="category"/>
   </Table>
 </App>
 ```
@@ -2099,6 +2289,27 @@ This event is triggered when the user presses the paste keyboard shortcut (defau
 - `selectedItems`: Array of selected row items.
 - `selectedIds`: Array of selected row IDs (as strings).
 
+### `rowClick` [#rowclick]
+
+This event is fired when the user clicks a table row. The handler receives the clicked row item as its only argument. It reports the click without replacing or suppressing selection — pair it with `rowsSelectable` deliberately, and prefer `selectionDidChange` when what you actually care about is the selection. The event does not fire for clicks on the selection checkbox or on an interactive control (such as a button) inside a cell.
+
+**Signature**: `rowClick(item: any): void`
+
+- `item`: The clicked table row item.
+
+This event is triggered when a table row is clicked. The handler receives the row's data item as its only argument.
+
+`rowClick` reports activation — it does not replace or suppress selection. Row click already runs a selection toggle when `rowsSelectable` is set, and `rowClick` fires alongside that without interfering with it: pair it with `rowsSelectable` deliberately, and prefer [`selectionDidChange`](#selectiondidchange) when what you actually care about is the selection rather than the click itself. `rowClick` does not fire for a click on the selection checkbox, nor for a click on an interactive control (such as a button) inside a cell.
+
+```xmlui copy {4}
+<App>
+  <Table data='{[...]}' onRowClick="(item) => console.log(item)">
+    <Column bindTo="name"/>
+    <Column bindTo="quantity"/>
+  </Table>
+</App>
+```
+
 ### `rowDoubleClick` [#rowdoubleclick]
 
 This event is fired when the user double-clicks a table row. The handler receives the clicked row item as its only argument.
@@ -2306,6 +2517,12 @@ This event is fired when the table data sorting has changed. It has two argument
 
 - `columnName`: The name of the column being sorted.
 - `sortDirection`: The sort direction: 'asc' for ascending, 'desc' for descending, or null for unsorted.
+
+When the third click clears sorting, the event fires with an empty column name and
+**the direction that was on screen** — the sort the user was just looking at, not
+the direction a fresh click would produce. A column whose
+[`defaultSortDirection`](#defaultsortdirection) is `descending` therefore reports
+`ascending` when cleared from its second stage.
 
 Note the [`canSort`](/docs/reference/components/Column#cansort-default-true) properties on the `Column` components which enable custom ordering.
 
@@ -2720,6 +2937,7 @@ The component has some parts that can be styled through layout properties and th
 
 | Variable | Default Value (Light) | Default Value (Dark) |
 | --- | --- | --- |
+| [backgroundColor-column-Table--hover](/docs/styles-and-themes/common-units/#color) | $color-surface-100 | $color-surface-100 |
 | [backgroundColor-evenRow-Table](/docs/styles-and-themes/common-units/#color) | $backgroundColor-row-Table | $backgroundColor-row-Table |
 | [backgroundColor-heading-Table](/docs/styles-and-themes/common-units/#color) | $color-surface-100 | $color-surface-100 |
 | [backgroundColor-heading-Table--active](/docs/styles-and-themes/common-units/#color) | $color-surface-300 | $color-surface-300 |

--- a/website/content/docs/reference/components/Tree.md
+++ b/website/content/docs/reference/components/Tree.md
@@ -179,7 +179,9 @@ You have several options to style the icons representing the expanded or collaps
 Each tree node is selectable by default, unless the node item's data does not have a `selectable` property (or the one specified in `selectedField`).
 A selectable item can be selected by clicking the mouse or pressing the Enter or Space keys when it has focus.
 
-You can set the `selectedValue` property to define the selected tree item, ot use the `selectNode` exposed method for imperative selection.
+You can set the `selectedValue` property to define the selected tree item, or use the `selectNode` exposed method for imperative selection.
+
+You can also use `selectNodeByIndex(index)` to select a node by its current visible row index. The index is zero-based and follows the tree's physical row order after expansion state is applied. For example, when three root nodes are collapsed, the roots are indexed `0`, `1`, and `2`. If the first root expands and reveals four children, that root remains `0`, its children become `1` through `4`, and the second and third roots become `5` and `6`.
 
 ## Item templates [#item-templates]
 
@@ -1097,6 +1099,14 @@ Replace a node's properties with new data using merge semantics. Properties not 
   </VStack>
 </App>
 ```
+
+### `selectNodeByIndex` [#selectnodebyindex]
+
+Programmatically select a node by its current visible index. The index is 0-based and follows the tree's physical row order after applying the current expanded/collapsed state.
+
+**Signature**: `selectNodeByIndex(index: number): void`
+
+- `index`: The 0-based visible row index to select.
 
 ### `setTreeState` [#settreestate]
 

--- a/website/content/docs/reference/extensions/xmlui-echart/EChart.md
+++ b/website/content/docs/reference/extensions/xmlui-echart/EChart.md
@@ -22,6 +22,10 @@ This component supports the following behaviors:
 
 Height of the chart container.
 
+### `maps`
+
+An object of `name → GeoJSON` map definitions. Each entry is passed to `echarts.registerMap(name, geojson)` before the option is applied, so a `map`-type series can reference the name (e.g. `series: [{ type: 'map', map: 'my-region', ... }]`). Entries whose value is empty are skipped, so binding a not-yet-loaded DataSource value is safe: the map registers (and the chart re-renders) when the data arrives. Omitting the property leaves current behavior unchanged.
+
 ### `option`
 
 The ECharts option object. Accepts any valid ECharts configuration. XMLUI theme colors are automatically injected for palette, text, axes, and tooltip unless explicitly overridden in the option.

--- a/website/content/docs/reference/extensions/xmlui-recharts/AreaChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/AreaChart.md
@@ -2,6 +2,10 @@
 
 Interactive area chart for showing data trends over time with filled areas under the curve
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/website/content/docs/reference/extensions/xmlui-recharts/BarChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/BarChart.md
@@ -2,6 +2,10 @@
 
 `BarChart` displays data as horizontal or vertical bars, supporting both grouped and stacked layouts. It's ideal for comparing values across categories, showing revenue trends, or displaying any quantitative data over time or categories.
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/website/content/docs/reference/extensions/xmlui-recharts/LineChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/LineChart.md
@@ -2,6 +2,10 @@
 
 `LineChart` displays data as connected points over a continuous axis, ideal for showing trends, changes over time, or relationships between variables. Use it time series data, progress tracking, and comparing multiple data series on the same scale.
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:

--- a/website/content/docs/reference/extensions/xmlui-recharts/RadarChart.md
+++ b/website/content/docs/reference/extensions/xmlui-recharts/RadarChart.md
@@ -2,6 +2,10 @@
 
 Interactive radar chart for displaying multivariate data in a two-dimensional chart of three or more quantitative variables
 
+**Context variables available during execution:**
+
+- `$tooltip`: Context variable available inside tooltipTemplate.
+
 ## Behaviors
 
 This component supports the following behaviors:


### PR DESCRIPTION
Jon's Claude speaking from the XMLUI project:

Generated output only — the result of `npm run generate-all-docs` against current `main`. Nothing here is hand-written, so the review question is "should these pages match their metadata," not "is this prose correct."

## What drifted

`website/content/docs/reference/**` is generated from component metadata and the output is committed, but the two had fallen out of step: props documented in metadata were never regenerated into the published pages. Eleven pages, `Column` and `Table` the largest — `Table`'s `highlightHoveredColumn` and `Column`'s `defaultSortDirection` were both documented in source without a regenerated page.

## How it was found

The drift-check script that shipped in #3843 names exactly these pages. After this commit it reports only `_overview.md`, which is a discrepancy in that check's own scoped-down orchestration rather than real drift — `generate-docs` does not produce a different version for that page through this path.

**So the check still exits non-zero**, and that is worth resolving before anyone wires it into CI. A permanently red detector is one people learn to ignore.

## Why it is worth landing rather than leaving

The stale pages are invisible until someone runs the generator for an unrelated reason. Doing so pulls ~160 unrelated insertions into the working tree, belonging to no tracked change, where they are liable to be swept into whatever commit happens to touch a reference page.

That is not hypothetical — it is how this was rediscovered. Regenerating a single page to correct a Badge example (#3854) surfaced ten unrelated pages' worth of backlog alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
