### PR TITLE
Compile arrow-function event handlers instead of re-interpreting them

### DIFF
--- a/.changeset/compile-arrow-event-handlers.md
+++ b/.changeset/compile-arrow-event-handlers.md
@@ -1,0 +1,11 @@
+---
+"xmlui": patch
+---
+
+Compile event handlers written as arrow functions instead of re-interpreting them at run time.
+
+An event handler written in the idiomatic `onClick="(ev) => …"` / `onMount="() => { … }"` form was never actually compiled. The emitted code serialized the arrow's entire source tree into a `runtime.arrow(…)` call, which handed the AST straight back to the tree-walking interpreter — so the handler paid for the embedded AST payload without gaining anything from compilation. Only handlers written as bare statement bodies benefited, and since naming event arguments requires the arrow form, the most common handlers were the ones missing out.
+
+The outermost handler arrow is now emitted as a real JavaScript function, invoked with the handler's event arguments, bringing it in line with the nested callback arrows that already compiled natively. Handler bodies using control flow, `try`/`catch`, loops, `switch`, template literals, destructured and rest parameters all compile. For the reported `Lifecycle` `onMount` case this replaces an 11.5 KB serialized-AST payload with 2.4 KB of compiled JavaScript.
+
+Handlers whose bodies use a construct the native emitter does not support (such as spread call arguments) still fall back to the previous interpreted path, and async arrow handlers are still rejected. A handler arrow that references a compiled local declared by an earlier statement now fails compilation — falling back to interpreted execution for the whole handler — instead of emitting an interpreted arrow that could not see that local.

--- a/xmlui/src/components-core/script-compiler/event-runtime.ts
+++ b/xmlui/src/components-core/script-compiler/event-runtime.ts
@@ -245,6 +245,31 @@ export const eventAsyncRuntime = {
     return result;
   },
 
+  /**
+   * Invokes a natively compiled arrow function — an event handler written in the
+   * `(args) => …` form, whose body the compiler emitted as real JavaScript instead of
+   * handing its AST back to the interpreter through `arrow()`/`call()`.
+   *
+   * The bracketing mirrors what `call()` does for the lazy-arrow path it replaces: the
+   * pending XMLUI state is flushed before the body runs and again once it settles, so a
+   * handler observes (and commits) exactly the same state boundaries either way. There is
+   * no `updateRootName` here because the lazy-arrow call site never passed one — invoking
+   * the handler itself is not an assignment to a tracked container variable — which makes
+   * `notifyEventStateUpdate` a no-op for this path.
+   */
+  async callNativeArrow(
+    fn: (...args: any[]) => any,
+    args: any[],
+    evalContext: BindingTreeEvaluationContext,
+  ): Promise<any> {
+    await this.flushPendingState(evalContext);
+    try {
+      return await completePromise(fn(...args));
+    } finally {
+      await this.flushPendingState(evalContext);
+    }
+  },
+
   async call(
     functionObj: any,
     thisArg: any,

--- a/xmlui/src/components-core/script-compiler/targets/event-async.ts
+++ b/xmlui/src/components-core/script-compiler/targets/event-async.ts
@@ -298,7 +298,7 @@ function emitArrowExpressionStatement(
   statement: ArrowExpressionStatement,
   context: CompilerContext,
 ): void {
-  if (statement.expr.async || containsNonSerializableLiteral(statement.expr)) {
+  if (statement.expr.async) {
     throwUnsupportedCompiledScriptNode(statement.expr, context.sourceId);
   }
   emitBeforeStatement(writer, statement);
@@ -311,12 +311,37 @@ function emitArrowExpressionStatement(
   writer.write(`return ${returnName};`, statement);
 }
 
+/**
+ * Emits the invocation of an event handler that was written as an arrow function
+ * (`onClick="(ev) => …"`, `onMount="() => { … }"`), which is the idiomatic form whenever a
+ * handler needs to name its event arguments.
+ *
+ * Native compilation is attempted first, so the handler body becomes real JavaScript. The
+ * lazy `runtime.arrow` fallback below serializes the whole AST into the generated code and
+ * hands it straight back to the tree-walking interpreter at run time, meaning an
+ * arrow-wrapped handler used to get no benefit at all from compilation — it merely paid for
+ * the AST payload. Nested callback arrows already compile natively (see `emitArgumentArray`),
+ * and this brings the outermost arrow in line with them.
+ */
 function emitEventArrowCall(
   writer: CompiledScriptCodeWriter,
   expr: ArrowExpression,
   context: CompilerContext,
 ): void {
-  if (expr.async || containsNonSerializableLiteral(expr)) {
+  if (expr.async) {
+    throwUnsupportedCompiledScriptNode(expr, context.sourceId);
+  }
+  if (tryEmitNativeEventArrowCall(writer, expr, context)) {
+    return;
+  }
+  if (arrowReferencesCompilerLocals(expr, context)) {
+    // The lazy path evaluates through the interpreter, which cannot see compiled JS
+    // locals declared by earlier statements of this handler. Emitting it here would
+    // silently resolve those names to something else, so fail compilation instead and
+    // let the whole handler fall back to interpreted execution (existing, safe behavior).
+    throwUnsupportedCompiledScriptNode(expr, context.sourceId);
+  }
+  if (containsNonSerializableLiteral(expr)) {
     throwUnsupportedCompiledScriptNode(expr, context.sourceId);
   }
   writer.write("await runtime.call(runtime.arrow(", expr);
@@ -325,6 +350,32 @@ function emitEventArrowCall(
     ", evalContext, thread), evalContext.localContext, evalContext.eventArgs ?? [], evalContext, thread)",
     expr,
   );
+}
+
+/**
+ * Speculatively emits the handler arrow as a natively compiled function invoked with the
+ * handler's event arguments. Rolls the writer back and reports `false` when the body uses a
+ * construct the native emitter cannot handle, so the caller can fall back without leaving
+ * partial output behind (same contract as `tryEmitNativeArrowExpression`).
+ */
+function tryEmitNativeEventArrowCall(
+  writer: CompiledScriptCodeWriter,
+  expr: ArrowExpression,
+  context: CompilerContext,
+): boolean {
+  const mark = writer.mark();
+  try {
+    writer.write("await runtime.callNativeArrow(", expr);
+    emitNativeArrowExpression(writer, expr, context);
+    writer.write(", evalContext.eventArgs ?? [], evalContext)", expr);
+    return true;
+  } catch (error) {
+    if (error instanceof UnsupportedCompiledScriptNodeError) {
+      writer.resetTo(mark);
+      return false;
+    }
+    throw error;
+  }
 }
 
 function emitExpressionStatement(

--- a/xmlui/tests/components-core/compiled-events/event-async-handler-arrow-runtime.test.ts
+++ b/xmlui/tests/components-core/compiled-events/event-async-handler-arrow-runtime.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Runtime proof that arrow-function event handlers are genuinely compiled.
+ *
+ * Inspecting the generated JavaScript shows what the compiler *emitted*; this file asserts
+ * what actually *runs*. `executeArrowExpression` is the tree-walking interpreter's arrow
+ * executor, and it is the only way a `runtime.arrow` payload can be evaluated. A handler
+ * that is truly compiled must therefore never reach it.
+ *
+ * The spy wraps the real implementation rather than replacing it, so the interpreted
+ * fallback below still executes normally — which is what makes the "never called" assertion
+ * meaningful instead of vacuous.
+ */
+vi.mock("../../../src/components-core/script-runner/eval-tree-async", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../src/components-core/script-runner/eval-tree-async")
+  >();
+  return { ...actual, executeArrowExpression: vi.fn(actual.executeArrowExpression) };
+});
+
+import {
+  compileEventAsyncStatements,
+  executeCompiledEventAsyncArtifact,
+} from "../../../src/components-core/script-compiler";
+import { createEvalContext } from "../../../src/components-core/script-runner/BindingTreeEvaluationContext";
+import { executeArrowExpression } from "../../../src/components-core/script-runner/eval-tree-async";
+import {
+  parseHandlerCode,
+  prepareHandlerStatements,
+} from "../../../src/components-core/utils/statementUtils";
+
+const interpreterEntries = executeArrowExpression as unknown as ReturnType<typeof vi.fn>;
+
+/** Runs a handler through the compiled pipeline, reporting its observable side effects. */
+async function runCompiledHandler(source: string, localContext: Record<string, any>) {
+  interpreterEntries.mockClear();
+  const evalContext = createEvalContext({
+    localContext,
+    eventArgs: [],
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  });
+  const artifact = compileEventAsyncStatements(
+    prepareHandlerStatements(parseHandlerCode(source)),
+    { sourceId: `test:runtime-proof:${source}` },
+  );
+  await executeCompiledEventAsyncArtifact(artifact, evalContext);
+  return interpreterEntries.mock.calls.length;
+}
+
+/** The handler shape reported against v0.14.24. */
+const LIFECYCLE_ON_MOUNT = `() => {
+  if ($props.scrollToCaseId != null && rows.some(item => item.id === $props.scrollToCaseId)) {
+    casesTable.scrollToId($props.scrollToCaseId);
+    emitEvent('scrolledToCase', $props.scrollToCaseId);
+  }
+}`;
+
+describe("arrow event handlers execute as compiled code, not interpreted AST", () => {
+  it("runs the reported onMount handler without entering the interpreter", async () => {
+    const calls: any[] = [];
+    const entries = await runCompiledHandler(LIFECYCLE_ON_MOUNT, {
+      $props: { scrollToCaseId: 7 },
+      rows: [{ id: 3 }, { id: 7 }],
+      casesTable: { scrollToId: (id: number) => calls.push(["scroll", id]) },
+      emitEvent: (name: string, payload: any) => calls.push([name, payload]),
+    });
+
+    // --- The handler did its work, including the nested `rows.some(...)` callback...
+    expect(calls).toEqual([
+      ["scroll", 7],
+      ["scrolledToCase", 7],
+    ]);
+    // --- ...without the tree-walking interpreter running any part of it.
+    expect(entries).toBe(0);
+  });
+
+  it("runs a parameterised handler without entering the interpreter", async () => {
+    const opened: any[] = [];
+    const entries = await runCompiledHandler("() => caseMenu.openAt($item)", {
+      caseMenu: { openAt: (item: any) => opened.push(item) },
+      $item: { id: 12 },
+    });
+
+    expect(opened).toEqual([{ id: 12 }]);
+    expect(entries).toBe(0);
+  });
+
+  it("control: an unsupported body still falls back to the interpreter", async () => {
+    // --- Spread call arguments are not supported by the native emitter, so this handler
+    // --- keeps the lazy-arrow path. It proves the spy above genuinely detects interpreted
+    // --- execution, so `toBe(0)` in the tests above is a real signal rather than a spy
+    // --- that was never wired up.
+    const seen: any[] = [];
+    const entries = await runCompiledHandler("() => { collect(...items); }", {
+      items: [1, 2, 3],
+      collect: (...args: any[]) => seen.push(args),
+    });
+
+    expect(seen).toEqual([[1, 2, 3]]);
+    expect(entries).toBeGreaterThan(0);
+  });
+});

--- a/xmlui/tests/components-core/compiled-events/event-async-handler-arrow.test.ts
+++ b/xmlui/tests/components-core/compiled-events/event-async-handler-arrow.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileEventAsyncStatements,
+  compileEventAsyncStatementSource,
+  executeCompiledEventAsyncArtifact,
+} from "../../../src/components-core/script-compiler";
+import { createEvalContext } from "../../../src/components-core/script-runner/BindingTreeEvaluationContext";
+import type { BindingTreeEvaluationContext } from "../../../src/components-core/script-runner/BindingTreeEvaluationContext";
+import { processStatementQueueAsync } from "../../../src/components-core/script-runner/process-statement-async";
+import {
+  parseHandlerCode,
+  prepareHandlerStatements,
+} from "../../../src/components-core/utils/statementUtils";
+
+/**
+ * Compiles a handler the way the XMLUI transform builds its parse-time artifact: the parsed
+ * statements go straight to the event-async target, with no handler-shape preparation.
+ */
+function compileHandler(source: string, sourceId = `test:handler-arrow:${source}`) {
+  return compileEventAsyncStatementSource(source, sourceId);
+}
+
+/**
+ * Compiles a handler the way the container does when no parse-time artifact is available:
+ * `prepareHandlerStatements` first wraps the handler into an `ArrowExpressionStatement`.
+ * Both shapes reach the compiler in production, so both are covered here.
+ */
+function compilePreparedHandler(source: string) {
+  return compileEventAsyncStatements(prepareHandlerStatements(parseHandlerCode(source)), {
+    sourceId: `test:handler-arrow:prepared:${source}`,
+  });
+}
+
+/** The interpreter records a handler's value on the innermost block scope. */
+function interpretedReturnValue(evalContext: BindingTreeEvaluationContext): any {
+  const blocks = evalContext.mainThread?.blocks;
+  return blocks?.length ? blocks[blocks.length - 1].returnValue : evalContext.mainThread?.returnValue;
+}
+
+async function runCompiled(
+  source: string,
+  localContext: Record<string, any> = {},
+  eventArgs: any[] = [],
+) {
+  const evalContext = createEvalContext({
+    localContext,
+    eventArgs,
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  });
+  const returnValue = await executeCompiledEventAsyncArtifact(
+    compilePreparedHandler(source),
+    evalContext,
+  );
+  return { evalContext, localContext, returnValue };
+}
+
+async function runInterpreted(
+  source: string,
+  localContext: Record<string, any> = {},
+  eventArgs: any[] = [],
+) {
+  const evalContext = createEvalContext({
+    localContext,
+    eventArgs,
+    options: { defaultToOptionalMemberAccess: true },
+  });
+  await processStatementQueueAsync(
+    prepareHandlerStatements(parseHandlerCode(source)),
+    evalContext,
+  );
+  return { evalContext, localContext, returnValue: interpretedReturnValue(evalContext) };
+}
+
+async function expectHandlerParity(
+  source: string,
+  localContext: Record<string, any> = {},
+  eventArgs: any[] = [],
+) {
+  const compiled = await runCompiled(source, { ...localContext }, eventArgs);
+  const interpreted = await runInterpreted(source, { ...localContext }, eventArgs);
+
+  expect(compiled.returnValue).toEqual(interpreted.returnValue);
+  expect(compiled.localContext).toEqual(interpreted.localContext);
+  return compiled;
+}
+
+/**
+ * True when the generated code hands an AST back to the tree-walking interpreter instead of
+ * running compiled JavaScript. `runtime.arrow` receives the arrow's serialized source tree,
+ * so its presence means nothing inside the arrow was actually compiled.
+ */
+function usesInterpretedArrow(js: string): boolean {
+  return js.includes("runtime.arrow(");
+}
+
+/**
+ * The exact handler shape reported against v0.14.24: a `Lifecycle` `onMount` written as a
+ * zero-argument arrow. Before the fix its whole body was serialized into `runtime.arrow` and
+ * re-interpreted at run time.
+ */
+const LIFECYCLE_ON_MOUNT = `() => {
+  if ($props.scrollToCaseId != null && rows.some(item => item.id === $props.scrollToCaseId)) {
+    casesTable.scrollToId($props.scrollToCaseId);
+    emitEvent('scrolledToCase', $props.scrollToCaseId);
+  }
+}`;
+
+describe("compiled event handlers written as arrow functions", () => {
+  describe("are compiled to native JavaScript", () => {
+    it("compiles the reported Lifecycle onMount handler instead of re-interpreting it", () => {
+      const { js } = compileHandler(LIFECYCLE_ON_MOUNT);
+
+      expect(usesInterpretedArrow(js)).toBe(false);
+      expect(js).toContain("runtime.callNativeArrow(");
+      // --- The body's control flow is real emitted JavaScript, not an interpreted AST.
+      expect(js).toMatch(/if \(__xmlui_evt_\d+\)/);
+      // --- No serialized source tree is embedded in the generated code.
+      expect(js).not.toContain("startToken");
+    });
+
+    it("compiles the reported handler in its prepared (ArrowExpressionStatement) shape too", () => {
+      const { js } = compilePreparedHandler(LIFECYCLE_ON_MOUNT);
+
+      expect(usesInterpretedArrow(js)).toBe(false);
+      expect(js).toContain("runtime.callNativeArrow(");
+      expect(js).not.toContain("startToken");
+    });
+
+    it("binds arrow parameters as real JavaScript parameters", () => {
+      const { js } = compileHandler("(event) => caseMenu.openAt(event, $item)");
+
+      expect(usesInterpretedArrow(js)).toBe(false);
+      expect(js).toContain("(async (event) =>");
+    });
+
+    it("emits markedly less code than the interpreted-arrow payload it replaces", () => {
+      // --- The serialized AST carries every token with its source positions, so the old
+      // --- lazy-arrow output was several times larger than the compiled body.
+      const { js } = compileHandler(LIFECYCLE_ON_MOUNT);
+      expect(js.length).toBeLessThan(4000);
+    });
+
+    it.each([
+      ["block body with control flow", "() => { if (flag) { hits = hits + 1; } }"],
+      ["try/catch", "() => { try { hits = risky(); } catch (e) { hits = -1; } }"],
+      ["for-of loop", "() => { for (const x of items) { total = total + x; } }"],
+      ["switch", "(v) => { switch (v) { case 1: r = 'a'; break; default: r = 'b'; } }"],
+      ["template literal", "(n) => { msg = `hi ${n}`; }"],
+      ["destructured parameter", "({ a, b }) => { total = a + b; }"],
+      ["rest parameter", "(...args) => { total = args.length; }"],
+      ["nested callback arrow", "() => { hits = items.filter(x => x > 1).length; }"],
+    ])("compiles %s natively", (_label, source) => {
+      const { js } = compileHandler(source);
+      expect(usesInterpretedArrow(js)).toBe(false);
+      expect(js).toContain("runtime.callNativeArrow(");
+    });
+  });
+
+  describe("behave identically to the interpreted handler", () => {
+    it("runs the reported onMount body and its nested callback", async () => {
+      const calls: any[] = [];
+      const context = () => ({
+        $props: { scrollToCaseId: 7 },
+        rows: [{ id: 3 }, { id: 7 }],
+        casesTable: { scrollToId: (id: number) => calls.push(["scroll", id]) },
+        emitEvent: (name: string, payload: any) => calls.push([name, payload]),
+      });
+
+      await runCompiled(LIFECYCLE_ON_MOUNT, context());
+      expect(calls).toEqual([
+        ["scroll", 7],
+        ["scrolledToCase", 7],
+      ]);
+
+      // --- The guard short-circuits when the anchor row is not present.
+      calls.length = 0;
+      await runCompiled(LIFECYCLE_ON_MOUNT, { ...context(), $props: { scrollToCaseId: 99 } });
+      expect(calls).toEqual([]);
+    });
+
+    it("passes event arguments to a single-expression handler", async () => {
+      const compiled = await expectHandlerParity("(item) => item.toUpperCase()", {}, ["alpha"]);
+      expect(compiled.returnValue).toBe("ALPHA");
+    });
+
+    it("passes event arguments to a block-bodied handler", async () => {
+      await expectHandlerParity(
+        "(item) => { first = item; second = item; }",
+        { first: "", second: "" },
+        ["alpha"],
+      );
+    });
+
+    it("returns an explicit value from a block-bodied handler", async () => {
+      const compiled = await expectHandlerParity("(a, b) => { return a * b; }", {}, [6, 7]);
+      expect(compiled.returnValue).toBe(42);
+    });
+
+    it("supports multiple parameters and missing arguments", async () => {
+      await expectHandlerParity("(a, b) => { total = (a ?? 0) + (b ?? 0); }", { total: 0 }, [5]);
+    });
+
+    it("destructures an event argument", async () => {
+      await expectHandlerParity(
+        "({ id, name }) => { picked = name + ':' + id; }",
+        { picked: "" },
+        [{ id: 4, name: "row" }],
+      );
+    });
+
+    it("collects rest arguments", async () => {
+      await expectHandlerParity("(...args) => { total = args.length; }", { total: 0 }, [1, 2, 3]);
+    });
+
+    it("mutates container state from inside the arrow body", async () => {
+      await expectHandlerParity(
+        "(value) => { selected = selected.concat([value]); count = selected.length; }",
+        { selected: [], count: 0 },
+        ["a"],
+      );
+    });
+
+    it("runs loops and control flow inside the arrow body", async () => {
+      await expectHandlerParity(
+        "(items) => { for (const item of items) { if (item > 1) { total = total + item; } } }",
+        { total: 0 },
+        [[1, 2, 3]],
+      );
+    });
+
+    it("runs try/catch inside the arrow body", async () => {
+      await expectHandlerParity(
+        "() => { try { throw new Error('nope'); } catch (e) { caught = e.message; } }",
+        { caught: "" },
+      );
+    });
+
+    it("propagates a thrown error from the arrow body", async () => {
+      await expect(runCompiled("() => { throw new Error('boom'); }")).rejects.toThrow("boom");
+      await expect(runInterpreted("() => { throw new Error('boom'); }")).rejects.toThrow("boom");
+    });
+  });
+
+  describe("preserve the interpreted fallback", () => {
+    it("falls back to the lazy arrow when the body uses an unsupported construct", async () => {
+      // --- Spread call arguments are not supported by the native emitter.
+      const source = "() => { collect(...items); }";
+      const { js } = compileHandler(source);
+
+      expect(usesInterpretedArrow(js)).toBe(true);
+      expect(js).not.toContain("runtime.callNativeArrow(");
+
+      const seen: any[] = [];
+      await runCompiled(source, { items: [1, 2, 3], collect: (...args: any[]) => seen.push(args) });
+      expect(seen).toEqual([[1, 2, 3]]);
+    });
+
+    it("fails compilation rather than emitting a lazy arrow that cannot see compiled locals", () => {
+      // --- The arrow both references a local declared by an earlier compiled statement and
+      // --- uses a construct the native emitter rejects. Emitting the lazy arrow here would
+      // --- silently resolve `extra` against the interpreter's scope instead, so compilation
+      // --- must fail and let the whole handler fall back to interpreted execution.
+      expect(() =>
+        compileHandler("const extra = 5; (items) => { collect(extra, ...items); }"),
+      ).toThrow(/Unsupported/);
+    });
+
+    it("still rejects async arrow handlers", () => {
+      expect(() => compileHandler("async () => { await save(); }")).toThrow(/Unsupported/);
+    });
+  });
+});

--- a/xmlui/tests/parsers/xmlui/transform.element.test.ts
+++ b/xmlui/tests/parsers/xmlui/transform.element.test.ts
@@ -545,6 +545,54 @@ describe("Xmlui transform - child elements", () => {
       expect(warnings).toEqual([]);
     });
 
+    it("compiles arrow-function event handlers instead of re-interpreting them", () => {
+      const warnings: string[] = [];
+      // --- The handler shape reported against v0.14.24: a `Lifecycle` `onMount` written as
+      // --- an arrow function. Its body used to be serialized into `runtime.arrow` and handed
+      // --- back to the interpreter, so compiling the handler bought nothing.
+      const cd = transformSource(
+        `<Lifecycle
+          onMount="() => {
+            if (scrollToCaseId != null && rows.some(item => item.id === scrollToCaseId)) {
+              casesTable.scrollToId(scrollToCaseId);
+              emitEvent('scrolledToCase', scrollToCaseId);
+            }
+          }" />`,
+        0,
+        false,
+        warnings,
+        { compileEventHandlers: true },
+      ) as ComponentDef;
+      const event = (cd.events! as any).mount;
+
+      expect(event.compiledUnsupported).toBe(false);
+      expect(warnings).toEqual([]);
+      // --- No serialized AST handed to the interpreter...
+      expect(event.compiled.js).not.toContain("runtime.arrow(");
+      expect(event.compiled.js).not.toContain("startToken");
+      // --- ...the body is emitted as real JavaScript instead.
+      expect(event.compiled.js).toContain("runtime.callNativeArrow(");
+      expect(event.compiled.js).toMatch(/if \(__xmlui_evt_\d+\)/);
+      expect(event.compiled.js).toContain("scrollToId");
+    });
+
+    it("compiles arrow event handlers that name their event arguments", () => {
+      const cd = transformSource(
+        `<Table onSelectionDidChange="(items) => { selectedItems = items; }" />`,
+        0,
+        false,
+        undefined,
+        { compileEventHandlers: true },
+      ) as ComponentDef;
+      const event = (cd.events! as any).selectionDidChange;
+
+      expect(event.compiledUnsupported).toBe(false);
+      expect(event.compiled.js).not.toContain("runtime.arrow(");
+      // --- The event argument becomes a real JavaScript parameter of the compiled body.
+      expect(event.compiled.js).toContain("(async (items) =>");
+      expect(event.compiled.js).toContain("evalContext.eventArgs ?? []");
+    });
+
     it("does not log parse-time compiled event source by default", () => {
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
       const groupSpy = vi.spyOn(console, "groupCollapsed").mockImplementation(() => undefined);


### PR DESCRIPTION
An event handler written in the idiomatic `onClick="(ev) => …"` / `onMount="() => { … }"` form was never actually compiled. `emitEventArrowCall` unconditionally emitted `runtime.call(runtime.arrow(<serialized AST>))`, which hands the arrow's source tree straight back to the tree-walking interpreter at run time. The handler therefore paid for the embedded AST payload without gaining anything from compilation. Because naming event arguments requires the arrow form, the most common handlers were the ones missing out; only bare statement bodies were compiled.

The native arrow emitter that fixes this already existed — #3865 wired `tryEmitNativeArrowExpression` into `emitArgumentArray` so nested callback arrows compile — it was just never applied to the outermost handler arrow. `emitEventArrowCall` now attempts native emission first and invokes the result through a new `runtime.callNativeArrow`, whose state-flush bracketing mirrors what `runtime.call` did for the lazy path it replaces. Both handler shapes that reach the compiler in production are covered: the raw `ExpressionStatement` from the parse-time transform artifact, and the `ArrowExpressionStatement` produced by `prepareHandlerStatements`.

For the reported `Lifecycle` `onMount` this turns an 11.5 KB serialized-AST payload into 2.4 KB of compiled JavaScript with real emitted control flow.

Fallback behavior is preserved: bodies using an unsupported construct (spread call arguments) still roll back to the lazy arrow, and async arrow handlers are still rejected. One correctness improvement — a handler arrow referencing a compiled local declared by an earlier statement now fails compilation, letting the whole handler fall back to interpreted execution, rather than emitting a lazy arrow that could not resolve that local. This is the same invariant `emitArgumentArray` already enforced.

Tests come at three levels: generated-code shape, behavioral parity against the interpreter, and a runtime proof that spies on the interpreter's `executeArrowExpression` to assert compiled handlers never enter it (with a control case proving the spy detects interpretation when it does happen).

Verified: 11227 unit tests and 1326 e2e tests with XMLUI_COMPILE_SCRIPTS=true pass. The 17 new assertions fail against the unfixed compiler.