### PR TITLE
Regenerate the language-server metadata snapshot for MenuItem's target property

### DIFF
--- a/.changeset/menuitem-metadata-snapshot.md
+++ b/.changeset/menuitem-metadata-snapshot.md
@@ -1,0 +1,6 @@
+---
+---
+
+chore: regenerate the language-server metadata snapshot for `MenuItem`'s new `target` property.
+
+`src/language-server/xmlui-metadata-generated.js` is a build artifact of the component metadata, checked in and verified by the `check:metadata-snapshot` CI step. Adding `MenuItem.target` (and rewording `MenuItem.to`) left it stale, so that step failed. No behaviour changes — the release note for the change itself is in the accompanying `menuitem-to-renders-a-real-link` changeset, which is still unreleased, so this lands in the same release.

--- a/xmlui/src/language-server/xmlui-metadata-generated.js
+++ b/xmlui/src/language-server/xmlui-metadata-generated.js
@@ -6109,7 +6109,34 @@ export default {
         "valueType": "string"
       },
       "to": {
-        "description": "This property defines the URL of the menu item. If this property is defined (and the `click` event does not have an event handler), clicking the menu item navigates to this link.",
+        "description": "This property defines the URL of the menu item. When it is set, the menu item renders as a real link (an `<a>` element with an `href`), so it can be opened in a new tab, copied, and read as a link by assistive technology. If this property is defined (and the `click` event does not have an event handler), clicking the menu item navigates to this link.",
+        "valueType": "string"
+      },
+      "target": {
+        "description": "This property specifies where to open the link represented by the `MenuItem`. It only has an effect when `to` is defined. This property accepts the following values (in accordance with the HTML standard):",
+        "availableValues": [
+          {
+            "value": "_self",
+            "description": "The link will open in the same frame as it was clicked."
+          },
+          {
+            "value": "_blank",
+            "description": "The link will open in a new window or tab."
+          },
+          {
+            "value": "_parent",
+            "description": "The link will open in the parent frame. If no parent, behaves as _self."
+          },
+          {
+            "value": "_top",
+            "description": "The topmost browsing context. The link will open in the full body of the window. If no ancestors, behaves as _self."
+          },
+          {
+            "value": "_unfencedTop",
+            "description": "Allows embedded fenced frames to navigate the top-level frame, i.e. traversing beyond the root of the fenced frame."
+          }
+        ],
+        "isStrictEnum": true,
         "valueType": "string"
       },
       "active": {


### PR DESCRIPTION
Follow-up to #3873, which failed the **Check metadata snapshot is up to date** CI step.

`xmlui/src/language-server/xmlui-metadata-generated.js` is a checked-in build artifact of the component metadata. #3873 added the `MenuItem.target` property and reworded `MenuItem.to`, but did not regenerate the snapshot, so `npm --prefix xmlui run check:metadata-snapshot` (which rebuilds it and runs `git diff --exit-code`) failed.

Regenerated with `npm run fix:metadata-drift`.

## What changed

Only the `MenuItem` entry, 28 insertions and 1 deletion:

- the new `target` property, with its `availableValues` (`_self`, `_blank`, `_parent`, `_top`, `_unfencedTop`) and `isStrictEnum: true`
- the updated `to` description

No hand-edits, no unrelated churn.

## Verification

| Check | Result |
| --- | --- |
| `npm --prefix xmlui run check:metadata-snapshot` | exit 0 |
| `npm --prefix xmlui run check:metadata` | exit 0 |
| Regeneration is idempotent (a second run leaves the tree clean) | confirmed |

## Changeset

An empty changeset — no version bump. The release note for the underlying change lives in `menuitem-to-renders-a-real-link`, which is still unreleased, so this lands in the same release and should not be documented twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)