### PR TITLE
fix: honor appGlobals/xmluiConfig compileScripts at build time (#3876)

### DIFF
--- a/.ai/xmlui/build-system.md
+++ b/.ai/xmlui/build-system.md
@@ -252,6 +252,29 @@ export default defineConfig({
 });
 ```
 
+### Where the CLI reads plugin options from
+
+`loadXmluiPluginOptions()` (`src/nodejs/bin/xmluiPluginOptions.ts`) feeds `xmlui start`,
+`xmlui build`, and `xmlui build-lib`. It merges two sources:
+
+1. the app description — the first of `src/config.{ts,tsx,mts,js,mjs,json}` or `config.json`
+   that exists — reading its `xmluiConfig` and `appGlobals` records;
+2. `xmlui.config.json` at the project root.
+
+Per key, an explicit top-level `xmlui.config.json` entry wins over `xmluiConfig`, which wins
+over `appGlobals` — the same precedence the browser runtime applies (`mergeXmluiConfig` in
+`AppContent`). This is what makes `compileScripts` declared in the app description reach the
+build-time compiler; without it the flag only ever enabled runtime compilation.
+
+App descriptions are ES modules and may import assets Node cannot evaluate (SCSS,
+`import.meta.glob`). A failed load is not fatal: the build continues with `xmlui.config.json`
+alone, and the CLI warns only when the unreadable file mentions a script-compilation key.
+
+The plugin counts the artifacts it emits and reports them (`[xmlui] Script compilation: …`) at
+`buildEnd`, or shortly after the dev server settles. When compilation is enabled but no artifact
+is produced, it warns instead — "requested but never ran" is otherwise indistinguishable from
+"compiled successfully" in the emitted modules.
+
 ---
 
 ## Build Outputs

--- a/.changeset/compile-scripts-app-description.md
+++ b/.changeset/compile-scripts-app-description.md
@@ -1,0 +1,14 @@
+---
+"xmlui": patch
+---
+
+Honor `compileScripts` (and its `compileBindings` / `compileEventHandlers` aliases) declared in
+the app description when building. `xmlui start` and `xmlui build` previously read script
+compilation settings from `xmlui.config.json` only, so an app that set
+`appGlobals.compileScripts: true` or `xmluiConfig.compileScripts: true` in `src/config.ts` or
+`config.json` — the documented place for it — got no compiled artifacts in its modules, silently.
+The CLI now reads the app description as well, with `xmlui.config.json` taking precedence per key.
+
+The build also reports what compilation produced (`[xmlui] Script compilation: N compiled
+artifact(s) …`) and warns when compilation was requested but produced no artifacts, so this class
+of misconfiguration is visible from the console.

--- a/website/content/docs/pages/xmlui-config.md
+++ b/website/content/docs/pages/xmlui-config.md
@@ -225,6 +225,26 @@ xmluiConfig: {
 
 Use `compileBindings` or `compileEventHandlers` only when you need to control one script path independently. When either compatibility alias is set, it overrides `compileScripts` for that path.
 
+Script compilation happens in two places, and both read this switch:
+
+- **At build time.** `xmlui start` and `xmlui build` compile event handlers, code-behind
+  functions, and `Globals.xs` functions into the emitted modules. The build tooling reads the
+  switch from your app description (`src/config.ts` in Vite mode, `config.json` in standalone
+  mode) under `xmluiConfig` or `appGlobals`, and from `xmlui.config.json`. When the same key is
+  set in both, `xmlui.config.json` wins.
+- **At run time.** Whatever was not compiled during the build is compiled on first use by the
+  browser runtime, which reads the switch from the same merged `xmluiConfig` / `appGlobals` view.
+
+When build-time compilation is on, `xmlui start` and `xmlui build` report what it produced, for
+example `[xmlui] Script compilation: 128 compiled artifact(s) from 130 script block(s) in 24
+file(s)`. A warning is emitted instead when compilation was requested but no artifact came out of
+it, so a misconfigured project is visible from the console.
+
+> [!NOTE] If your app description cannot be loaded by the build tooling (for example, it imports
+> stylesheets or other assets Node cannot evaluate), set the compilation switches in
+> `xmlui.config.json`. The CLI warns when it hits this case in a file that looks like it
+> configures script compilation.
+
 ---
 
 ### `compileBindings`

--- a/xmlui/src/components-core/abstractions/standalone.ts
+++ b/xmlui/src/components-core/abstractions/standalone.ts
@@ -41,7 +41,10 @@ export type StandaloneAppDescription = {
    *   (default `true`).
    * - `compileScripts` (boolean, default `false`) — compile supported XMLUI
    *   binding expressions, event handlers, and executable script declaration
-   *   functions to JavaScript.
+   *   functions to JavaScript. Read both by the browser runtime and by the build
+   *   tooling (`xmlui start` / `xmlui build`), which pre-compiles event handlers
+   *   into the emitted modules. A `compileScripts` entry in `xmlui.config.json`
+   *   overrides the one declared here.
    * - `compileBindings` (boolean, default `undefined`) — legacy compatibility
    *   alias for enabling/disabling binding compilation independently.
    * - `compileEventHandlers` (boolean, default `undefined`) — legacy

--- a/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
+++ b/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
@@ -1,25 +1,73 @@
 import { readFile } from "fs/promises";
 import path from "path";
+import { pathToFileURL } from "url";
 import type { PluginOptions } from "../vite-xmlui-plugin";
 
 type NormalizeXmluiPluginOptionsOptions = {
   devServer?: boolean;
 };
 
+type LoadXmluiPluginOptionsOptions = NormalizeXmluiPluginOptionsOptions & {
+  /** Project root to read configuration files from. Defaults to `process.cwd()`. */
+  cwd?: string;
+};
+
+/**
+ * A configuration record the build tooling reads settings from. Keys may sit at
+ * the top level (`xmlui.config.json`) or under `xmluiConfig` / `appGlobals`
+ * (the app description in `src/config.ts` or `config.json`) — the very same
+ * places the browser runtime reads them from.
+ */
+export type XmluiConfigSource = {
+  appGlobals?: Record<string, any>;
+  xmluiConfig?: Record<string, any>;
+  [key: string]: any;
+};
+
+/**
+ * Settings that turn XMLUI script compilation on. Used to decide whether an
+ * app description we failed to load was worth complaining about.
+ */
+const SCRIPT_COMPILATION_KEYS = [
+  "compileScripts",
+  "compileBindings",
+  "compileEventHandlers",
+  "compiledScriptSourceMaps",
+  "logCompiledEventHandlerSource",
+];
+
+/**
+ * App description candidates, in resolution order. The first readable file
+ * wins; `src/config.*` is the Vite-mode home of `StandaloneAppDescription`,
+ * `config.json` the standalone (buildless) one.
+ */
+const APP_DESCRIPTION_FILES = [
+  ["src", "config.ts"],
+  ["src", "config.tsx"],
+  ["src", "config.mts"],
+  ["src", "config.js"],
+  ["src", "config.mjs"],
+  ["src", "config.json"],
+  ["config.json"],
+];
+
 export function normalizeXmluiPluginOptions(
-  config: Record<string, any>,
+  config: XmluiConfigSource,
   options: NormalizeXmluiPluginOptionsOptions = {},
 ): PluginOptions {
   const xmluiConfig = config.xmluiConfig ?? {};
-  const compileScripts = config.compileScripts ?? xmluiConfig.compileScripts;
-  const compileBindings = config.compileBindings ?? xmluiConfig.compileBindings ?? compileScripts;
-  const compileEventHandlers =
-    config.compileEventHandlers ?? xmluiConfig.compileEventHandlers ?? compileScripts;
+  const appGlobals = config.appGlobals ?? {};
+  // --- Mirrors the runtime merge (see `mergeXmluiConfig` in AppContent):
+  // --- `xmluiConfig` overrides `appGlobals`, and an explicit top-level key in
+  // --- `xmlui.config.json` overrides both.
+  const setting = (key: string) => config[key] ?? xmluiConfig[key] ?? appGlobals[key];
+  const compileScripts = setting("compileScripts");
+  const compileBindings = setting("compileBindings") ?? compileScripts;
+  const compileEventHandlers = setting("compileEventHandlers") ?? compileScripts;
   const hasScriptCompilation =
     compileScripts === true || compileBindings === true || compileEventHandlers === true;
   const compiledScriptSourceMaps =
-    config.compiledScriptSourceMaps ??
-    xmluiConfig.compiledScriptSourceMaps ??
+    setting("compiledScriptSourceMaps") ??
     (options.devServer && hasScriptCompilation ? "external" : undefined);
   return {
     analyze: config.analyze,
@@ -30,18 +78,106 @@ export function normalizeXmluiPluginOptions(
     compileBindings,
     compileEventHandlers,
     compiledScriptSourceMaps,
-    logCompiledEventHandlerSource:
-      config.logCompiledEventHandlerSource ?? xmluiConfig.logCompiledEventHandlerSource,
+    logCompiledEventHandlerSource: setting("logCompiledEventHandlerSource"),
+  };
+}
+
+/**
+ * Merges the two configuration sources the build tooling knows about.
+ * `xmlui.config.json` wins over the app description, key by key.
+ */
+export function mergeXmluiConfigSources(
+  appDescription: XmluiConfigSource | undefined,
+  xmluiConfigFile: XmluiConfigSource | undefined,
+): XmluiConfigSource {
+  const appConfig = appDescription ?? {};
+  const fileConfig = xmluiConfigFile ?? {};
+  return {
+    ...fileConfig,
+    appGlobals: { ...(appConfig.appGlobals ?? {}), ...(fileConfig.appGlobals ?? {}) },
+    xmluiConfig: { ...(appConfig.xmluiConfig ?? {}), ...(fileConfig.xmluiConfig ?? {}) },
   };
 }
 
 export async function loadXmluiPluginOptions(
-  options: NormalizeXmluiPluginOptionsOptions = {},
+  options: LoadXmluiPluginOptionsOptions = {},
 ): Promise<PluginOptions> {
-  try {
-    const rawConfig = await readFile(path.join(process.cwd(), "xmlui.config.json"), "utf-8");
-    return normalizeXmluiPluginOptions(JSON.parse(rawConfig), options);
-  } catch {
+  const { cwd = process.cwd(), ...normalizeOptions } = options;
+  const xmluiConfigFile = await readXmluiConfigFile(cwd);
+  const appDescription = await readAppDescriptionConfig(cwd);
+  if (!xmluiConfigFile && !appDescription) {
     return {};
   }
+  return normalizeXmluiPluginOptions(
+    mergeXmluiConfigSources(appDescription, xmluiConfigFile),
+    normalizeOptions,
+  );
+}
+
+async function readXmluiConfigFile(cwd: string): Promise<XmluiConfigSource | undefined> {
+  try {
+    const rawConfig = await readFile(path.join(cwd, "xmlui.config.json"), "utf-8");
+    return JSON.parse(rawConfig);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reads the app description (`StandaloneAppDescription`) so that framework
+ * settings declared there — script compilation among them — reach the build
+ * pipeline as well, not just the browser runtime.
+ *
+ * The app description may import assets the Node process cannot load (SCSS,
+ * `import.meta.glob`, and friends). Such a failure is not fatal: the build goes
+ * on with `xmlui.config.json` alone, and we only complain when the unreadable
+ * file looks like it was trying to configure script compilation.
+ */
+async function readAppDescriptionConfig(cwd: string): Promise<XmluiConfigSource | undefined> {
+  for (const segments of APP_DESCRIPTION_FILES) {
+    const file = path.join(cwd, ...segments);
+    let rawConfig: string;
+    try {
+      rawConfig = await readFile(file, "utf-8");
+    } catch {
+      continue;
+    }
+    if (file.endsWith(".json")) {
+      try {
+        return pickConfigSource(JSON.parse(rawConfig));
+      } catch (error) {
+        warnUnreadableAppDescription(file, rawConfig, error);
+        return undefined;
+      }
+    }
+    try {
+      const module = await import(pathToFileURL(file).href);
+      return pickConfigSource(module?.default ?? module);
+    } catch (error) {
+      warnUnreadableAppDescription(file, rawConfig, error);
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function pickConfigSource(appDescription: unknown): XmluiConfigSource | undefined {
+  if (!appDescription || typeof appDescription !== "object") {
+    return undefined;
+  }
+  const { appGlobals, xmluiConfig } = appDescription as XmluiConfigSource;
+  return { appGlobals, xmluiConfig };
+}
+
+function warnUnreadableAppDescription(file: string, rawConfig: string, error: unknown): void {
+  // --- Apps that do not configure script compilation in their description lose
+  // --- nothing when we cannot load it, so stay quiet for them.
+  if (!SCRIPT_COMPILATION_KEYS.some((key) => rawConfig.includes(key))) {
+    return;
+  }
+  console.warn(
+    `[xmlui] Could not read "${file}" to resolve script compilation settings ` +
+      `(${(error as Error)?.message ?? error}). Build-time script compilation stays off; ` +
+      `set "compileScripts" in "xmlui.config.json" to enable it.`,
+  );
 }

--- a/xmlui/src/nodejs/vite-xmlui-plugin.ts
+++ b/xmlui/src/nodejs/vite-xmlui-plugin.ts
@@ -349,6 +349,48 @@ function createTransformSourceMap(
   };
 }
 
+/**
+ * Counters behind the build-time script compilation summary. `artifacts` counts
+ * the compiled JavaScript artifacts actually emitted, `scripts` the parsed
+ * script blocks that could have carried one, and `unsupported` those where the
+ * compiler bailed out and the runtime falls back to interpretation.
+ */
+type CompiledScriptTally = {
+  files: number;
+  scripts: number;
+  artifacts: number;
+  unsupported: number;
+};
+
+function tallyCompiledScripts(value: unknown, tally: CompiledScriptTally): CompiledScriptTally {
+  if (!value || typeof value !== "object") {
+    return tally;
+  }
+  const maybeArtifact = value as Partial<CompiledScriptArtifact>;
+  if (
+    typeof maybeArtifact.sourceId === "string" &&
+    typeof maybeArtifact.js === "string" &&
+    typeof maybeArtifact.target === "string" &&
+    Array.isArray(maybeArtifact.mappings)
+  ) {
+    tally.artifacts++;
+    return tally;
+  }
+  const maybeParsedScript = value as { __PARSED?: boolean; compiledUnsupported?: boolean };
+  if (maybeParsedScript.__PARSED === true && Array.isArray((value as any).statements)) {
+    tally.scripts++;
+    if (maybeParsedScript.compiledUnsupported === true) {
+      tally.unsupported++;
+    }
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => tallyCompiledScripts(item, tally));
+    return tally;
+  }
+  Object.values(value).forEach((item) => tallyCompiledScripts(item, tally));
+  return tally;
+}
+
 function collectCompiledArtifacts(value: unknown, artifacts: CompiledScriptArtifact[] = []) {
   if (!value || typeof value !== "object") {
     return artifacts;
@@ -471,6 +513,55 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
       sources,
       sourceOrigin,
     };
+  };
+  // --- Build-time script compilation accounting. Without it, an app that asks
+  // --- for `compileScripts` but never reaches the compiler (a misplaced or
+  // --- unreadable config) looks exactly like an app that compiled fine.
+  const compiledScriptTally: CompiledScriptTally = {
+    files: 0,
+    scripts: 0,
+    artifacts: 0,
+    unsupported: 0,
+  };
+  let compiledScriptSummaryReported = false;
+  let compiledScriptSummaryTimer: ReturnType<typeof setTimeout> | undefined;
+  const recordCompiledScripts = (value: unknown) => {
+    // --- Nothing left to count once the summary is out; the walk is not free.
+    if (!compileEventHandlers || compiledScriptSummaryReported) return;
+    compiledScriptTally.files++;
+    tallyCompiledScripts(value, compiledScriptTally);
+    if (!devServerMode) return;
+    // --- The dev server transforms lazily, so there is no build end to report
+    // --- at; summarize once the transforms settle.
+    clearTimeout(compiledScriptSummaryTimer);
+    compiledScriptSummaryTimer = setTimeout(() => reportCompiledScriptSummary(), 2000);
+    compiledScriptSummaryTimer.unref?.();
+  };
+  const reportCompiledScriptSummary = (warn?: (message: string) => void) => {
+    if (!compileEventHandlers || compiledScriptSummaryReported) return;
+    compiledScriptSummaryReported = true;
+    clearTimeout(compiledScriptSummaryTimer);
+    const { files, scripts, artifacts, unsupported } = compiledScriptTally;
+    if (artifacts === 0 && scripts > 0) {
+      const message =
+        `[xmlui] Script compilation is enabled but produced no compiled artifacts: ` +
+        `${scripts} script block(s) in ${files} file(s) will run interpreted.`;
+      if (warn) {
+        warn(message);
+      } else {
+        console.warn(message);
+      }
+      return;
+    }
+    const fallbacks =
+      unsupported > 0 ? `, ${unsupported} fell back to interpretation (unsupported construct)` : "";
+    console.log(
+      devServerMode
+        ? `[xmlui] Script compilation is active: ${artifacts} compiled artifact(s) from ` +
+            `${scripts} script block(s) in ${files} file(s) transformed so far${fallbacks}`
+        : `[xmlui] Script compilation: ${artifacts} compiled artifact(s) from ` +
+            `${scripts} script block(s) in ${files} file(s)${fallbacks}`,
+    );
   };
   const registerCompiledArtifacts = (value: unknown) => {
     if (!sourceMapsEnabled()) return;
@@ -871,6 +962,7 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
           warnings,
           ...(sourceMapsEnabled() ? { debugSources } : {}),
         };
+        recordCompiledScripts(file);
         const outputCode = browserWarningLogCode(warnings) + dataToEsm(file);
         const map = sourceMapsEnabled()
           ? createTransformSourceMap(outputCode, fileId, debugSources)
@@ -971,6 +1063,7 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
 
         const debugSources = Array.from(debugSourcesById.values());
         virtualSources?.registerAll(debugSources);
+        recordCompiledScripts(codeBehind);
         const outputCode = dataToEsm({
           ...codeBehind,
           src: code,
@@ -1033,6 +1126,11 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
     },
 
     buildEnd() {
+      // --- In dev-server mode transforms keep trickling in after the
+      // --- dependency-scan build ends, so the summary waits for them instead.
+      if (!devServerMode) {
+        reportCompiledScriptSummary((message) => this.warn(message));
+      }
       if (cyclesMode !== "off" && reactiveCycleRoots.size > 0) {
         let cycleHits: ReturnType<typeof findCycles> | null = null;
         try {

--- a/xmlui/tests/bin/vite-plugin-import.test.ts
+++ b/xmlui/tests/bin/vite-plugin-import.test.ts
@@ -706,6 +706,52 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
     });
   });
 
+  describe("Compiled Script Reporting", () => {
+    async function buildWithSummary(code: string, options: Partial<PluginOptions> = {}) {
+      const plugin = viteXmluiPlugin({
+        analyze: "off",
+        reactiveCycles: "off",
+        accessibility: "off",
+        typeContracts: "off",
+        ...options,
+      });
+      (plugin.configResolved as any)?.({ root: "/project" });
+      const ctx = {
+        warn: vi.fn(),
+        error: (message: string) => {
+          throw new Error(String(message));
+        },
+      };
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      try {
+        await (plugin.transform as any).call(ctx, code, "/project/src/Main.xmlui", {});
+        (plugin.buildEnd as any).call(ctx);
+        return { logs: log.mock.calls.map((call) => String(call[0])), warnings: ctx.warn };
+      } finally {
+        log.mockRestore();
+      }
+    }
+
+    it("reports how many compiled artifacts the build produced", async () => {
+      const { logs, warnings } = await buildWithSummary(
+        `<Button onClick="count = count + 1" />`,
+        { compileScripts: true },
+      );
+
+      expect(logs.join("\n")).toMatch(
+        /\[xmlui\] Script compilation: [1-9]\d* compiled artifact\(s\) from [1-9]\d* script block\(s\) in 1 file\(s\)/,
+      );
+      expect(warnings).not.toHaveBeenCalled();
+    });
+
+    it("stays silent about compiled scripts when compilation is off", async () => {
+      const { logs, warnings } = await buildWithSummary(`<Button onClick="count = count + 1" />`);
+
+      expect(logs.join("\n")).not.toContain("Script compilation");
+      expect(warnings).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Vite Plugin File Structure", () => {
     it("should handle .xmlui.xs files", () => {
       const componentBehindFile = "/src/Main.xmlui.xs";

--- a/xmlui/tests/nodejs/xmlui-plugin-options.test.ts
+++ b/xmlui/tests/nodejs/xmlui-plugin-options.test.ts
@@ -1,5 +1,34 @@
-import { describe, expect, it } from "vitest";
-import { normalizeXmluiPluginOptions } from "../../src/nodejs/bin/xmluiPluginOptions";
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  loadXmluiPluginOptions,
+  mergeXmluiConfigSources,
+  normalizeXmluiPluginOptions,
+} from "../../src/nodejs/bin/xmluiPluginOptions";
+
+// --- Fixture projects live inside the repo: the dynamic import that reads an
+// --- app description module must be resolvable by the test runner as well.
+const FIXTURE_ROOT = join(__dirname, "__fixtures__");
+const createdProjects: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    createdProjects.splice(0).map((project) => rm(project, { recursive: true, force: true })),
+  );
+});
+
+async function createProject(files: Record<string, string>) {
+  await mkdir(FIXTURE_ROOT, { recursive: true });
+  const root = await mkdtemp(join(FIXTURE_ROOT, "project-"));
+  createdProjects.push(root);
+  for (const [name, content] of Object.entries(files)) {
+    const file = join(root, ...name.split("/"));
+    await mkdir(join(file, ".."), { recursive: true });
+    await writeFile(file, content, "utf-8");
+  }
+  return root;
+}
 
 describe("XMLUI plugin options", () => {
   it("reads common compiled script options from xmluiConfig", () => {
@@ -125,6 +154,127 @@ describe("XMLUI plugin options", () => {
     ).toMatchObject({
       compileEventHandlers: true,
       compiledScriptSourceMaps: false,
+    });
+  });
+});
+
+describe("XMLUI plugin options from the app description", () => {
+  it("reads compiled script options from appGlobals", () => {
+    expect(
+      normalizeXmluiPluginOptions({
+        appGlobals: {
+          compileScripts: true,
+          logCompiledEventHandlerSource: true,
+        },
+      }),
+    ).toMatchObject({
+      compileScripts: true,
+      compileBindings: true,
+      compileEventHandlers: true,
+      logCompiledEventHandlerSource: true,
+    });
+  });
+
+  it("lets xmluiConfig override appGlobals", () => {
+    expect(
+      normalizeXmluiPluginOptions({
+        appGlobals: { compileScripts: true },
+        xmluiConfig: { compileEventHandlers: false },
+      }),
+    ).toMatchObject({
+      compileScripts: true,
+      compileEventHandlers: false,
+    });
+  });
+
+  it("lets top-level options override appGlobals", () => {
+    expect(
+      normalizeXmluiPluginOptions({
+        compileScripts: false,
+        appGlobals: { compileScripts: true },
+      }),
+    ).toMatchObject({
+      compileScripts: false,
+      compileEventHandlers: false,
+    });
+  });
+
+  it("enables external dev server source maps for appGlobals compiled scripts", () => {
+    expect(
+      normalizeXmluiPluginOptions(
+        { appGlobals: { compileScripts: true } },
+        { devServer: true },
+      ),
+    ).toMatchObject({
+      compileEventHandlers: true,
+      compiledScriptSourceMaps: "external",
+    });
+  });
+
+  it("merges the app description under xmlui.config.json", () => {
+    expect(
+      mergeXmluiConfigSources(
+        { appGlobals: { compileScripts: true }, xmluiConfig: { compileEventHandlers: true } },
+        { analyze: "off", xmluiConfig: { compileEventHandlers: false } },
+      ),
+    ).toEqual({
+      analyze: "off",
+      appGlobals: { compileScripts: true },
+      xmluiConfig: { compileEventHandlers: false },
+    });
+  });
+});
+
+describe("Loading XMLUI plugin options from project files", () => {
+  it("enables script compilation from appGlobals in config.json", async () => {
+    const cwd = await createProject({
+      "config.json": JSON.stringify({ name: "app", appGlobals: { compileScripts: true } }),
+    });
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: true,
+      compileEventHandlers: true,
+    });
+  });
+
+  it("enables script compilation from xmluiConfig in an app description module", async () => {
+    const cwd = await createProject({
+      "src/config.mjs": "export default { xmluiConfig: { compileScripts: true } };\n",
+    });
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: true,
+      compileEventHandlers: true,
+    });
+  });
+
+  it("lets xmlui.config.json override the app description", async () => {
+    const cwd = await createProject({
+      "xmlui.config.json": JSON.stringify({ compileScripts: false }),
+      "src/config.json": JSON.stringify({ appGlobals: { compileScripts: true } }),
+    });
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: false,
+      compileEventHandlers: false,
+    });
+  });
+
+  it("keeps script compilation off when no project file asks for it", async () => {
+    const cwd = await createProject({
+      "src/config.json": JSON.stringify({ name: "app" }),
+    });
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: undefined,
+      compileEventHandlers: undefined,
+    });
+  });
+
+  it("survives an app description that cannot be loaded", async () => {
+    const cwd = await createProject({
+      "xmlui.config.json": JSON.stringify({ compileScripts: true }),
+      "src/config.js": "import './missing-module.scss';\nexport default {};\n",
+    });
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: true,
+      compileEventHandlers: true,
     });
   });
 });


### PR DESCRIPTION
Fixes #3876.

## Root cause

Of the two candidates in the issue, it is **(1): the flag never reaches the parse-time options** — with a nuance worth recording.

`loadXmluiPluginOptions()` (`xmlui/src/nodejs/bin/xmluiPluginOptions.ts`) read `xmlui.config.json` and nothing else. An app that declares `compileScripts` in its app description — `appGlobals` or `xmluiConfig` in `src/config.ts` / `config.json`, which is what `StandaloneAppDescription` documents and what `StandaloneApp` itself honours in buildless mode — therefore never enabled the Vite plugin's compiler. That is why every parsed script in the reporter's output carried `compiled: undefined` *and* `compiledUnsupported: false`: the guarded block was never entered, exactly as they deduced.

Candidate (2) does not apply: the runtime call sites already fall back to `compileScripts` (`shouldCompileBindings` / `shouldCompileEventHandlers` in `script-runner/eval-options.ts`), reading the merged `xmluiConfig`-over-`appGlobals` view.

One correction to the issue's reading of the impact: the app was **not** running fully interpreted. When no parse-time artifact is present, the runtime compiles on first use and caches — `evaluateCompiledBinding()` for bindings, `executeCompiledEventAsyncHandler()` for handlers. The startup banner was reporting the runtime execution mode, and that mode really was "compiled". What the missing wiring cost was the *parse-time* artifacts: the first-use compile of every binding and handler, and the `"external"` source maps that make compiled handlers debuggable. So flipping this flag may well not move the 4 s benchmark — see below.

## Changes

**`xmlui/src/nodejs/bin/xmluiPluginOptions.ts`** — the CLI now merges two configuration sources before handing options to the plugin:

1. the app description: the first of `src/config.{ts,tsx,mts,js,mjs,json}` or `config.json` that exists, reading its `xmluiConfig` and `appGlobals`;
2. `xmlui.config.json`.

Each key resolves as top-level > `xmluiConfig` > `appGlobals` — the precedence `mergeXmluiConfig` already applies in the browser. `xmlui.config.json` wins over the app description, so existing projects keep their behaviour.

App descriptions are ES modules and may import things Node cannot evaluate — this repo's own `website/src/config.ts` pulls in SCSS transitively. A failed load is not fatal: the build continues on `xmlui.config.json` alone, and the CLI warns only when the file it could not read mentions a script-compilation key (so the website stays quiet, while a genuinely misconfigured project gets told).

**`xmlui/src/nodejs/vite-xmlui-plugin.ts`** — the plugin tallies emitted artifacts, parsed script blocks, and unsupported fallbacks, then reports:

```
[xmlui] Script compilation: 128 compiled artifact(s) from 130 script block(s) in 24 file(s), 2 fell back to interpretation (unsupported construct)
```

at `buildEnd`, or once dev-server transforms settle. When compilation is enabled but produced no artifacts, it warns instead. This is the machine-checkable signal the issue asks for in §C: "requested but never ran" no longer looks identical to "compiled fine".

Docs: `website/content/docs/pages/xmlui-config.md`, `.ai/xmlui/build-system.md`, and the `StandaloneAppDescription` doc comment now state where each side reads the switch from.

## Verification

Reproduced with the issue's own config (`appGlobals: { apiUrl: "/api", compileScripts: true }` in `src/config.ts`) plus a component whose handler is `rows.some(item => item.id === $props.target)`.

Dev server (`xmlui start`), fetching the component module:

| marker | before | after |
|---|---:|---:|
| `compiled: undefined` | 1 | **0** |
| `event-async` artifact | 0 | **1** |

Production build (`xmlui build --buildMode=INLINE_ALL`): `grep -c "compiled:void 0"` → **0**, with the compiled artifact present in the bundle. Both runs print the new summary line.

Against the issue's acceptance criteria: **A** holds (the emitted module contains executable JS, not just a `source:` string plus AST). **D** — the arrow callback passed to `.some()` *is* compiled; the generated body contains `runtime.call(runtime.member(__xmlui_evt_2, "some", …), …, [(async (item) => …)])`, so array-method callbacks are covered rather than falling back. **C** is addressed on the build side by the summary/warning. **F** is the open one: since the runtime was already compiling on demand, I would not expect this fix alone to move the 4 s long task, and the honest answer to "is interpretation the cause?" is that the evidence in the issue does not establish it. Worth re-measuring now that `logCompiledEventHandlerSource` and `compiledScriptSourceMaps` also reach the build from `appGlobals`.

## Tests

- `xmlui/tests/nodejs/xmlui-plugin-options.test.ts` — 11 new cases: `appGlobals` fallback, `xmluiConfig` and top-level precedence, dev-server source-map defaults, the merge helper, and `loadXmluiPluginOptions()` against fixture projects (`config.json`, `src/config.mjs`, `src/config.json` under an overriding `xmlui.config.json`, and an app description that fails to load).
- `xmlui/tests/bin/vite-plugin-import.test.ts` — the compiled-script summary is reported when compilation is on and stays silent when it is off.

`npx vitest run tests/nodejs tests/bin tests/components-core/script-compiler tests/components-core/script-runner` → 359 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
