### PR TITLE
fix: compile the constructs that silently fell back, and report what compilation did

### DIFF
--- a/.ai/xmlui/build-system.md
+++ b/.ai/xmlui/build-system.md
@@ -267,8 +267,16 @@ over `appGlobals` — the same precedence the browser runtime applies (`mergeXml
 build-time compiler; without it the flag only ever enabled runtime compilation.
 
 App descriptions are ES modules and may import assets Node cannot evaluate (SCSS,
-`import.meta.glob`). A failed load is not fatal: the build continues with `xmlui.config.json`
-alone, and the CLI warns only when the unreadable file mentions a script-compilation key.
+`import.meta.glob`). The loader tries a plain Node import first; when that fails and the file
+mentions a script-compilation key, it retries through Vite's `runnerImport` with the xmlui plugin
+applied and stylesheets stubbed, which resolves `import.meta.glob`, `.xmlui` imports, and
+TypeScript exactly as the browser build does. The Vite retry is gated on that keyword check
+because it evaluates the whole module graph the description pulls in. A failed load is still not
+fatal: the build continues with `xmlui.config.json` alone, and the CLI warns.
+
+`getViteConfig({ devServer })` decides whether dev-only defaults apply. Only `xmlui start` passes
+`true`; it is what turns on `compiledScriptSourceMaps: "external"`. A production build therefore
+emits compiled artifacts without mappings, embedded sources, or absolute developer paths.
 
 The plugin counts the artifacts it emits and reports them (`[xmlui] Script compilation: …`) at
 `buildEnd`, or shortly after the dev server settles. When compilation is enabled but no artifact

--- a/.ai/xmlui/expression-eval.md
+++ b/.ai/xmlui/expression-eval.md
@@ -72,6 +72,32 @@ deduplicated `kind:"debug-source"` Inspector trace event per artifact/range. The
 metadata only (source URL, original file, target, range, artifact ID, sourcemap mode), not full source
 text.
 
+Artifacts only keep their debug payload (`mappings`, `sources`, `sourceText`, `sourceUrl`,
+`displayName`) when source maps are on. A production build emits `js` alone, with project-relative
+`sourceId`s — `createCompiledScriptFunctionBody` reads nothing else when source maps are off.
+
+## Compiled Script Coverage
+
+Both targets compile the same language surface; the differences below are the whole list.
+
+| Construct | `binding-sync` | `event-async` |
+|---|---|---|
+| literals, identifiers, member and calculated member access | yes | yes |
+| unary / binary / prefix / postfix operators, assignments | yes | yes |
+| conditional (`a ? b : c`) and sequence (`a, b`) expressions | yes | yes |
+| array, object, and template literals, including spread operands | yes | yes |
+| function invocation, `new` expressions | yes | yes |
+| arrow functions | yes | yes — natively for callback arguments and declarations, otherwise as a lazy interpreted arrow |
+| statements (`if`, loops, `switch`, `try`, `throw`, destructuring declarations, nested functions) | n/a (expressions only) | yes |
+| `await` expressions | no — not part of XMLScript | no — not part of XMLScript |
+| regular-expression literals | yes | only outside a lazy arrow: they cannot be serialised into one |
+| `async` arrow functions | no | no |
+
+When a target refuses a node it throws `UnsupportedCompiledScriptNodeError`, naming the construct
+and its source position. The caller records that reason on the emitted block
+(`compiledUnsupportedReason`), emits it as a build warning, and the runtime falls back to
+interpretation for that block only.
+
 ## Reactive Cycle Detection
 
 Reactive bindings are also inspected as a graph. `collectComponentDefGraph()`

--- a/.changeset/compiled-script-coverage.md
+++ b/.changeset/compiled-script-coverage.md
@@ -1,0 +1,33 @@
+---
+"xmlui": patch
+---
+
+Compile the expression forms that used to force interpretation, and report what compilation
+actually did.
+
+The event-handler compiler refused conditional (`a ? b : c`), sequence, `new`, and spread
+expressions, so any handler or declaration function containing one silently fell back to
+interpretation — a ternary inside a `function` declaration was enough. All four now compile, in
+the async emitter and in the native emitter, so callbacks such as `rows.filter(r => r.tag ? a : b)`
+stay compiled instead of falling back to a lazy interpreted arrow.
+
+Fallbacks are no longer silent. Diagnostics name the construct and its source position instead of
+a raw node number, code-behind compilation warnings reach the build log (they were being dropped),
+the emitted block carries the reason as `compiledUnsupportedReason`, and the startup banner reports
+the effective state — how many artifacts were compiled, how many fell back, and why — instead of
+the requested flags.
+
+Production builds no longer ship compiled-script debug payload. `getViteConfig` applied the
+dev-server source-map default to every command, so builds embedded per-token mappings, complete
+original sources, and absolute developer paths. Those now belong to `xmlui start` only, and build
+artifacts keep project-relative source ids.
+
+`compileScripts` is honoured as the umbrella switch at the parse-time binding call sites and in
+`evalBinding`, and an app description that only Vite can evaluate (the `getLocalIcons()` /
+`import.meta.glob` pattern) is now read through Vite's module runner, so `appGlobals.compileScripts`
+works where the docs say it does.
+
+Two interpreter bugs found while checking compiled/interpreted parity are fixed as well:
+`Array.prototype.sort(comparator)` was a silent no-op (script callbacks are async and the native
+`sort` coerced the returned promise to `NaN`), and comma-sequence expressions evaluated every
+operand from the pre-sequence state and produced a pending promise as their value.

--- a/.changeset/compiled-script-coverage.md
+++ b/.changeset/compiled-script-coverage.md
@@ -27,7 +27,8 @@ artifacts keep project-relative source ids.
 `import.meta.glob` pattern) is now read through Vite's module runner, so `appGlobals.compileScripts`
 works where the docs say it does.
 
-Two interpreter bugs found while checking compiled/interpreted parity are fixed as well:
+Three interpreter bugs found while checking compiled/interpreted parity are fixed as well:
 `Array.prototype.sort(comparator)` was a silent no-op (script callbacks are async and the native
-`sort` coerced the returned promise to `NaN`), and comma-sequence expressions evaluated every
-operand from the pre-sequence state and produced a pending promise as their value.
+`sort` coerced the returned promise to `NaN`), comma-sequence expressions evaluated every operand
+from the pre-sequence state and produced a pending promise as their value, and object-literal
+spread threw on a `null` operand instead of ignoring it as JavaScript does.

--- a/.changeset/compiled-script-coverage.md
+++ b/.changeset/compiled-script-coverage.md
@@ -27,6 +27,12 @@ artifacts keep project-relative source ids.
 `import.meta.glob` pattern) is now read through Vite's module runner, so `appGlobals.compileScripts`
 works where the docs say it does.
 
+A handler that hands a callback to `debounce`, a timer, or a subscription has already finished by
+the time that callback runs, and the dispatcher aborts the run's `$cancel` token on completion. The
+compiled runtime consulted that token on every call, so such a callback died with
+`HandlerCancelledError` and its work vanished silently; it now runs, while cancellation during a
+handler run is unchanged.
+
 Three interpreter bugs found while checking compiled/interpreted parity are fixed as well:
 `Array.prototype.sort(comparator)` was a silent no-op (script callbacks are async and the native
 `sort` coerced the returned promise to `NaN`), comma-sequence expressions evaluated every operand

--- a/website/content/docs/pages/xmlui-config.md
+++ b/website/content/docs/pages/xmlui-config.md
@@ -258,8 +258,8 @@ banner:
 
 A block that falls back also carries its reason (`compiledUnsupportedReason`) in the emitted
 module, so the state is checkable from the build output and not only from the console. When
-compilation is requested but nothing was pre-compiled, the startup line says so instead of
-claiming success.
+compilation is requested but nothing was pre-compiled, the build warns and the startup line says
+so — those scripts are compiled on first use instead — rather than claiming success.
 
 ### What compiles
 

--- a/website/content/docs/pages/xmlui-config.md
+++ b/website/content/docs/pages/xmlui-config.md
@@ -231,19 +231,55 @@ Script compilation happens in two places, and both read this switch:
   functions, and `Globals.xs` functions into the emitted modules. The build tooling reads the
   switch from your app description (`src/config.ts` in Vite mode, `config.json` in standalone
   mode) under `xmluiConfig` or `appGlobals`, and from `xmlui.config.json`. When the same key is
-  set in both, `xmlui.config.json` wins.
-- **At run time.** Whatever was not compiled during the build is compiled on first use by the
-  browser runtime, which reads the switch from the same merged `xmluiConfig` / `appGlobals` view.
+  set in both, `xmlui.config.json` wins. App descriptions that only Vite can evaluate — the
+  `getLocalIcons()` pattern uses `import.meta.glob`, for instance — are loaded through Vite's
+  module runner, so the switch is honoured there too.
+- **At run time.** Binding expressions, and anything the build did not pre-compile, are compiled
+  on first use by the browser runtime, which reads the switch from the same merged
+  `xmluiConfig` / `appGlobals` view. Reactive bindings have no build-time artifacts by design:
+  prop values are parsed lazily in the browser, so `compileScripts` covers them at run time.
 
-When build-time compilation is on, `xmlui start` and `xmlui build` report what it produced, for
-example `[xmlui] Script compilation: 128 compiled artifact(s) from 130 script block(s) in 24
-file(s)`. A warning is emitted instead when compilation was requested but no artifact came out of
-it, so a misconfigured project is visible from the console.
+### What compilation reports
 
-> [!NOTE] If your app description cannot be loaded by the build tooling (for example, it imports
-> stylesheets or other assets Node cannot evaluate), set the compilation switches in
-> `xmlui.config.json`. The CLI warns when it hits this case in a file that looks like it
-> configures script compilation.
+When build-time compilation is on, `xmlui start` and `xmlui build` report what it produced:
+
+```
+[xmlui] Script compilation: 128 compiled artifact(s) from 130 script block(s) in 24 file(s), 2 fell back to interpretation (unsupported construct)
+[xmlui] Could not compile event handler /src/components/List.xmlui#event-4 (unsupported literal (node type 109) at line 12, column 24); falling back to interpreted execution.
+```
+
+At startup the app repeats the effective state in the browser console, under the execution-mode
+banner:
+
+```
+[xmlui] App started in compiled script mode (bindings: compiled, event handlers: compiled)
+[xmlui] Script artifacts: 128 compiled at build time, 2 fell back to interpretation. Fallback reasons: unsupported literal (node type 109) at line 12, column 24.
+```
+
+A block that falls back also carries its reason (`compiledUnsupportedReason`) in the emitted
+module, so the state is checkable from the build output and not only from the console. When
+compilation is requested but nothing was pre-compiled, the startup line says so instead of
+claiming success.
+
+### What compiles
+
+Both compiler targets accept the same language surface: literals, identifiers, member access,
+operators and assignments, conditional (`a ? b : c`) and sequence expressions, array / object /
+template literals including spread, function invocation, `new`, and arrow functions. The
+event-handler target additionally compiles statements — `if`, loops, `switch`, `try`, `throw`,
+destructuring declarations, and nested function declarations. Arrow callbacks passed to array
+methods (`.some()`, `.filter()`, `.map()`, `.forEach()`) compile to native JavaScript functions.
+
+Two constructs never compile, because XMLScript does not support them at all: `await` expressions
+and `async` arrow functions. A regular-expression literal compiles unless it sits inside an arrow
+that has to be handed to the interpreter, since it cannot be serialised into one.
+
+Compiled and interpreted execution are expected to agree. If you find a case where they do not,
+that is a bug — please report it.
+
+> [!NOTE] If your app description cannot be loaded by the build tooling at all, set the
+> compilation switches in `xmlui.config.json`. The CLI warns when it hits this case in a file
+> that looks like it configures script compilation.
 
 ---
 

--- a/xmlui/package.json
+++ b/xmlui/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "playwright test -c ..",
     "test:e2e:compiled-scripts": "cross-env XMLUI_COMPILE_SCRIPTS=true playwright test -c .. --max-failures=25",
     "measure:compiled-bindings": "tsx scripts/measure-compiled-bindings.ts",
+    "measure:compiled-events": "tsx scripts/measure-compiled-events.ts",
     "measure:standalone-size": "node scripts/measure-standalone-size.mjs",
     "test:e2e-summary": "node scripts/e2e-test-summary.js",
     "test:e2e-website-examples": "playwright test -c .. --grep \"@website\"",

--- a/xmlui/scripts/measure-compiled-events.ts
+++ b/xmlui/scripts/measure-compiled-events.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+
+/**
+ * Interpreted vs compiled event-handler execution, on the shapes that dominate a
+ * data-heavy screen: declaration functions called per row, array callbacks over a few
+ * hundred items, and an object rebuild.
+ *
+ * Companion to `measure-compiled-bindings.ts`, which covers synchronous bindings.
+ * Both paths are checked for identical results before either is timed, so a speedup
+ * can never come from doing less work.
+ *
+ * Usage: `npm --prefix xmlui run measure:compiled-events`
+ *        `XMLUI_EVENT_MEASURE_ROWS=1000 npm --prefix xmlui run measure:compiled-events`
+ */
+import { performance } from "node:perf_hooks";
+
+import {
+  compileEventAsyncStatementSource,
+  executeCompiledEventAsyncArtifact,
+} from "../src/components-core/script-compiler";
+import { Parser } from "../src/parsers/scripting/Parser";
+import { processStatementQueueAsync } from "../src/components-core/script-runner/process-statement-async";
+
+const iterations = Number.parseInt(process.env.XMLUI_EVENT_MEASURE_ITERATIONS ?? "200", 10);
+const rowCount = Number.parseInt(process.env.XMLUI_EVENT_MEASURE_ROWS ?? "300", 10);
+
+type Case = {
+  name: string;
+  source: string;
+  state: () => Record<string, any>;
+};
+
+const rows = () =>
+  Array.from({ length: rowCount }, (_, index) => ({
+    id: index,
+    name: `case-${index}`,
+    type: index % 3,
+    tag: index % 5 === 0 ? "flagged" : null,
+  }));
+
+const cases: Case[] = [
+  {
+    name: "ternary declaration per row",
+    source:
+      "function typeLabel(value) { return value === 1 ? 'Automated' : (value === 2 ? 'Manual' : 'Other'); }" +
+      " return rows.map(row => typeLabel(row.type));",
+    state: () => ({ rows: rows() }),
+  },
+  {
+    name: "filter + some over rows",
+    source:
+      "const visible = rows.filter(row => row.tag ? row.tag === 'flagged' : false);" +
+      " return [visible.length, rows.some(row => row.id === target)];",
+    state: () => ({ rows: rows(), target: rowCount - 1 }),
+  },
+  {
+    name: "spread rebuild",
+    source: "return rows.map(row => ({ ...row, label: row.name ? row.name : '(none)' })).length;",
+    state: () => ({ rows: rows() }),
+  },
+  {
+    name: "sort with comparator",
+    source: "const copy = rows.slice(); copy.sort((a, b) => b.id - a.id); return copy[0].id;",
+    state: () => ({ rows: rows() }),
+  },
+];
+
+function createEvalContext(state: Record<string, any>) {
+  return {
+    localContext: state,
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  } as any;
+}
+
+async function runInterpreted(testCase: Case): Promise<any> {
+  const evalContext = createEvalContext(testCase.state());
+  await processStatementQueueAsync(new Parser(testCase.source).parseStatements(), evalContext);
+  return evalContext.mainThread?.returnValue;
+}
+
+function createCompiledRunner(testCase: Case): () => Promise<any> {
+  const artifact = compileEventAsyncStatementSource(
+    testCase.source,
+    `measure:compiled-events:${testCase.name}`,
+  );
+  return () => executeCompiledEventAsyncArtifact(artifact, createEvalContext(testCase.state()));
+}
+
+async function measure(run: () => Promise<any>): Promise<{ elapsedMs: number; last: any }> {
+  const startedAt = performance.now();
+  let last: any;
+  for (let i = 0; i < iterations; i++) {
+    last = await run();
+  }
+  return { elapsedMs: performance.now() - startedAt, last };
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `XMLUI compiled event measurement (${iterations} iterations per case, ${rowCount} rows)`,
+  );
+  for (const testCase of cases) {
+    const expected = JSON.stringify(await runInterpreted(testCase));
+    const compiledRunner = createCompiledRunner(testCase);
+    const compiledWarmup = JSON.stringify(await compiledRunner());
+    if (compiledWarmup !== expected) {
+      throw new Error(
+        `${testCase.name}: compiled result ${compiledWarmup} does not match interpreted ${expected}`,
+      );
+    }
+
+    const interpreted = await measure(() => runInterpreted(testCase));
+    const compiled = await measure(compiledRunner);
+    const ratio = interpreted.elapsedMs / compiled.elapsedMs;
+    console.log(
+      `${testCase.name}: interpreted=${interpreted.elapsedMs.toFixed(1)}ms ` +
+        `compiled=${compiled.elapsedMs.toFixed(1)}ms ratio=${ratio.toFixed(2)}x`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/xmlui/src/abstractions/scripting/Compilation.ts
+++ b/xmlui/src/abstractions/scripting/Compilation.ts
@@ -47,6 +47,12 @@ export type ParsedEventValue = {
   source?: string;
   compiled?: CompiledScriptArtifact;
   compiledUnsupported?: boolean;
+  /**
+   * Why compilation was skipped, when `compiledUnsupported` is true: the construct
+   * that stopped it and where it is, e.g.
+   * `"unsupported await expression (node type 119) at line 3, column 14"`.
+   */
+  compiledUnsupportedReason?: string;
   directives?: EventHandlerDirectiveInfo;
 }
 

--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -83,11 +83,22 @@ import {
   registerAuditSink as registerAuditSinkImpl,
   registerAuditHeuristic as registerAuditHeuristicImpl,
 } from "../audit";
+import type { CompoundComponentDef } from "../../abstractions/ComponentDefs";
 import { getScriptExecutionMode } from "../script-runner/eval-options";
+import {
+  collectParsedScriptInventory,
+  formatParsedScriptInventory,
+} from "../script-compiler/script-inventory";
 
 // --- The properties of the AppContent component
 type AppContentProps = {
   rootContainer: ContainerWrapperDef;
+  /**
+   * The app's user-defined components. They hold most of an app's script blocks and
+   * are not reachable from the entry-point container, so the startup
+   * script-compilation report needs them handed over explicitly.
+   */
+  appComponents?: CompoundComponentDef[];
   routerBaseName: string;
   globalProps?: GlobalProps;
   xmluiConfig?: Record<string, any>;
@@ -123,6 +134,7 @@ function safeDecodeHash(hash: string): string {
  */
 export function AppContent({
   rootContainer,
+  appComponents,
   routerBaseName,
   globalProps,
   xmluiConfig: xmluiConfigRaw,
@@ -655,14 +667,38 @@ export function AppContent({
   const tableOfContentsContext = useContext(TableOfContentsContext);
   const isNestedApp = globalProps?.isNested;
 
+  // --- The artifact report is a startup fact, not a per-render one: log it once.
+  const scriptInventoryReported = useRef(false);
   useEffect(() => {
-    if (typeof console !== "undefined" && console.log) {
-      console.log(
-        `[xmlui] App started in ${scriptExecutionMode.mode} script mode ` +
-          `(bindings: ${scriptExecutionMode.bindings}, event handlers: ${scriptExecutionMode.eventHandlers})`,
-      );
+    if (typeof console === "undefined" || !console.log) {
+      return;
     }
-  }, [scriptExecutionMode]);
+    console.log(
+      `[xmlui] App started in ${scriptExecutionMode.mode} script mode ` +
+        `(bindings: ${scriptExecutionMode.bindings}, event handlers: ${scriptExecutionMode.eventHandlers})`,
+    );
+    // --- The line above reports the requested mode. When compilation is on, follow it
+    // --- with what the app definition actually carries, so "compiled" can never again
+    // --- hide a build that produced no artifacts at all (issue #3879).
+    if (scriptExecutionMode.mode === "interpreted" || !rootContainer) {
+      return;
+    }
+    if (scriptInventoryReported.current) {
+      return;
+    }
+    scriptInventoryReported.current = true;
+    try {
+      const inventory = collectParsedScriptInventory([rootContainer, ...(appComponents ?? [])]);
+      const summary = formatParsedScriptInventory(inventory);
+      if (inventory.compiled === 0 && inventory.total > 0 && console.warn) {
+        console.warn(summary);
+      } else {
+        console.log(summary);
+      }
+    } catch {
+      // --- Reporting must never break app startup.
+    }
+  }, [scriptExecutionMode, rootContainer, appComponents]);
 
   useEffect(() => {
     onInit?.();

--- a/xmlui/src/components-core/rendering/AppContent.tsx
+++ b/xmlui/src/components-core/rendering/AppContent.tsx
@@ -689,12 +689,10 @@ export function AppContent({
     scriptInventoryReported.current = true;
     try {
       const inventory = collectParsedScriptInventory([rootContainer, ...(appComponents ?? [])]);
-      const summary = formatParsedScriptInventory(inventory);
-      if (inventory.compiled === 0 && inventory.total > 0 && console.warn) {
-        console.warn(summary);
-      } else {
-        console.log(summary);
-      }
+      // --- Informational, not a warning: an app with no build-time artifacts still
+      // --- compiles its scripts on first use. The build-side report is the one that
+      // --- warns, because that is where "requested but never ran" is a misconfiguration.
+      console.log(formatParsedScriptInventory(inventory));
     } catch {
       // --- Reporting must never break app startup.
     }

--- a/xmlui/src/components-core/rendering/AppWrapper.tsx
+++ b/xmlui/src/components-core/rendering/AppWrapper.tsx
@@ -268,6 +268,7 @@ export const AppWrapper = ({
                 <AppContent
                   onInit={onInit}
                   rootContainer={node as ContainerWrapperDef}
+                  appComponents={contributes.compoundComponents}
                   routerBaseName={baseName}
                   globalProps={globalProps}
                   xmluiConfig={xmluiConfig}

--- a/xmlui/src/components-core/script-compiler/errors.ts
+++ b/xmlui/src/components-core/script-compiler/errors.ts
@@ -1,14 +1,23 @@
 import type { ScripNodeBase } from "../script-runner/ScriptingSourceTree";
 import { sourceRangeFromNode } from "./source";
+import { describeScriptNodeType } from "./node-names";
 import type { CompiledScriptSourceRange } from "./types";
 
 export class UnsupportedCompiledScriptNodeError extends Error {
+  /** Human-readable name of the construct, e.g. `"await expression"`. */
+  public readonly nodeTypeName: string;
+
   constructor(
     public readonly nodeType: string,
     public readonly sourceId: string,
     public readonly sourceRange?: CompiledScriptSourceRange,
   ) {
-    super(`Unsupported ${nodeType} node in compiled script target '${sourceId}'.`);
+    const nodeTypeName = describeScriptNodeType(nodeType);
+    super(
+      `Unsupported ${nodeTypeName} (node type ${nodeType}) in compiled script target ` +
+        `'${sourceId}'${formatSourcePosition(sourceRange)}.`,
+    );
+    this.nodeTypeName = nodeTypeName;
     this.name = "UnsupportedCompiledScriptNodeError";
   }
 }
@@ -17,5 +26,36 @@ export function throwUnsupportedCompiledScriptNode(
   node: Pick<ScripNodeBase, "type" | "startToken" | "endToken">,
   sourceId: string,
 ): never {
-  throw new UnsupportedCompiledScriptNodeError(String(node.type), sourceId, sourceRangeFromNode(node));
+  throw new UnsupportedCompiledScriptNodeError(
+    String(node.type),
+    sourceId,
+    sourceRangeFromNode(node),
+  );
+}
+
+/**
+ * One-line, machine-checkable reason a script block fell back to interpretation:
+ * the construct that stopped compilation and where it is. Stored next to
+ * `compiledUnsupported` so a fallback is never just a bare boolean, and printed by
+ * the build tooling.
+ */
+export function describeCompiledScriptFallback(error: unknown): string {
+  if (error instanceof UnsupportedCompiledScriptNodeError) {
+    return (
+      `unsupported ${error.nodeTypeName} (node type ${error.nodeType})` +
+      `${formatSourcePosition(error.sourceRange)}`
+    );
+  }
+  const message = (error as Error)?.message;
+  return message ? `compilation failed: ${message}` : "compilation failed";
+}
+
+function formatSourcePosition(sourceRange?: CompiledScriptSourceRange): string {
+  if (sourceRange?.startLine === undefined) {
+    return "";
+  }
+  const column = sourceRange.startColumn;
+  return column === undefined
+    ? ` at line ${sourceRange.startLine}`
+    : ` at line ${sourceRange.startLine}, column ${column + 1}`;
 }

--- a/xmlui/src/components-core/script-compiler/event-runtime.ts
+++ b/xmlui/src/components-core/script-compiler/event-runtime.ts
@@ -327,6 +327,42 @@ export const eventAsyncRuntime = {
     return await completePromise(new allowedConstructor(...args));
   },
 
+  // --- Spread operands. Each helper enforces exactly what the interpreter enforces
+  // --- for that position (see `eval-tree-async.ts`), so a spread that throws when
+  // --- interpreted throws with the same message when compiled.
+  spreadArrayItem(value: any): any[] {
+    if (!Array.isArray(value)) {
+      throw new Error("Spread operator within an array literal expects an array operand.");
+    }
+    return value;
+  },
+
+  spreadCallArg(value: any): any[] {
+    if (!Array.isArray(value)) {
+      throw new Error("Spread operator within a function invocation expects an array operand.");
+    }
+    return value;
+  },
+
+  spreadNewArg(value: any): any[] {
+    if (!Array.isArray(value)) {
+      throw new Error("Spread operator within a new expression expects an array operand.");
+    }
+    return value;
+  },
+
+  /**
+   * Object-literal spread. The interpreter copies own entries of arrays and objects
+   * and ignores everything else; `null` and non-objects contribute nothing rather
+   * than throwing.
+   */
+  spreadObjectValue(value: any): Record<string, any> {
+    if (value && typeof value === "object") {
+      return value as Record<string, any>;
+    }
+    return {};
+  },
+
   assignId(
     name: string,
     op: AssignmentSymbols,

--- a/xmlui/src/components-core/script-compiler/event-runtime.ts
+++ b/xmlui/src/components-core/script-compiler/event-runtime.ts
@@ -38,6 +38,30 @@ type EventStatementBoundaryOptions = {
   checkYield?: boolean;
 };
 
+type CompiledInvocationState = { depth: number; settled: boolean };
+
+const INVOCATION_STATE = Symbol.for("xmlui.compiledInvocationState");
+
+function invocationState(evalContext: BindingTreeEvaluationContext): CompiledInvocationState {
+  const holder = evalContext as unknown as Record<symbol, CompiledInvocationState | undefined>;
+  let state = holder[INVOCATION_STATE];
+  if (!state) {
+    state = { depth: 0, settled: false };
+    Object.defineProperty(evalContext, INVOCATION_STATE, {
+      value: state,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return state;
+}
+
+function isSettledInvocation(evalContext: BindingTreeEvaluationContext): boolean {
+  const holder = evalContext as unknown as Record<symbol, CompiledInvocationState | undefined>;
+  return holder[INVOCATION_STATE]?.settled === true;
+}
+
 export const eventAsyncRuntime = {
   createInvocation(options?: { yieldIntervalMs?: number; suppressYield?: boolean }) {
     const invocation = Object.create(this) as typeof eventAsyncRuntime & {
@@ -167,12 +191,40 @@ export const eventAsyncRuntime = {
   },
 
   async checkCancel(evalContext: BindingTreeEvaluationContext): Promise<void> {
-    const cancelToken = evalContext.localContext?.$cancel;
-    if (cancelToken?.throwIfAborted) {
-      cancelToken.throwIfAborted();
+    // --- `$cancel` belongs to the handler *run*. The dispatcher aborts it in its
+    // --- `finally`, on normal completion as well as supersession, so that
+    // --- `$cancel.onAbort` teardown fires. A callback the handler handed to something
+    // --- that invokes it later (`debounce`, a subscription, a timer) therefore always
+    // --- finds an aborted token — and must not be killed by it. The interpreted path
+    // --- never consulted `$cancel` at all; this keeps the compiled path in step
+    // --- without giving up cancellation while the handler is actually running.
+    if (!isSettledInvocation(evalContext)) {
+      const cancelToken = evalContext.localContext?.$cancel;
+      if (cancelToken?.throwIfAborted) {
+        cancelToken.throwIfAborted();
+      }
     }
     if (evalContext.cancellationToken?.cancelled) {
       throw new HandlerCancelledError("user");
+    }
+  },
+
+  /**
+   * Marks the start of a compiled handler run on this evaluation context. Nested runs
+   * are counted, so an inner one finishing does not release the outer one's
+   * cancellation.
+   */
+  beginInvocation(evalContext: BindingTreeEvaluationContext): void {
+    const state = invocationState(evalContext);
+    state.depth++;
+  },
+
+  /** Marks the end of a compiled handler run — see `checkCancel`. */
+  endInvocation(evalContext: BindingTreeEvaluationContext): void {
+    const state = invocationState(evalContext);
+    state.depth--;
+    if (state.depth <= 0) {
+      state.settled = true;
     }
   },
 

--- a/xmlui/src/components-core/script-compiler/index.ts
+++ b/xmlui/src/components-core/script-compiler/index.ts
@@ -12,7 +12,12 @@ export {
   createCompiledScriptCache,
   createCompiledScriptCacheKey,
 } from "./cache";
-export { UnsupportedCompiledScriptNodeError, throwUnsupportedCompiledScriptNode } from "./errors";
+export {
+  UnsupportedCompiledScriptNodeError,
+  describeCompiledScriptFallback,
+  throwUnsupportedCompiledScriptNode,
+} from "./errors";
+export { describeScriptNodeType } from "./node-names";
 export { createCompiledScriptMapping, createDebugSourceUrl, sourceRangeFromNode } from "./source";
 export {
   createCompiledScriptGeneratedSourceUrl,

--- a/xmlui/src/components-core/script-compiler/node-names.ts
+++ b/xmlui/src/components-core/script-compiler/node-names.ts
@@ -1,0 +1,64 @@
+import * as T from "../../parsers/scripting/ScriptingNodeTypes";
+
+/**
+ * Readable names for XMLScript AST node types.
+ *
+ * Compiler diagnostics used to quote the raw numeric node type ("Unsupported 103
+ * node"), which told an app author nothing about which line of their code to change.
+ */
+const SCRIPT_NODE_TYPE_NAMES: Record<number, string> = {
+  [T.T_BLOCK_STATEMENT]: "block statement",
+  [T.T_EMPTY_STATEMENT]: "empty statement",
+  [T.T_EXPRESSION_STATEMENT]: "expression statement",
+  [T.T_ARROW_EXPRESSION_STATEMENT]: "arrow expression statement",
+  [T.T_LET_STATEMENT]: "let declaration",
+  [T.T_CONST_STATEMENT]: "const declaration",
+  [T.T_VAR_STATEMENT]: "var declaration",
+  [T.T_IF_STATEMENT]: "if statement",
+  [T.T_RETURN_STATEMENT]: "return statement",
+  [T.T_BREAK_STATEMENT]: "break statement",
+  [T.T_CONTINUE_STATEMENT]: "continue statement",
+  [T.T_WHILE_STATEMENT]: "while statement",
+  [T.T_DO_WHILE_STATEMENT]: "do-while statement",
+  [T.T_FOR_STATEMENT]: "for statement",
+  [T.T_FOR_IN_STATEMENT]: "for-in statement",
+  [T.T_FOR_OF_STATEMENT]: "for-of statement",
+  [T.T_THROW_STATEMENT]: "throw statement",
+  [T.T_TRY_STATEMENT]: "try statement",
+  [T.T_SWITCH_STATEMENT]: "switch statement",
+  [T.T_FUNCTION_DECLARATION]: "function declaration",
+  [T.T_ASYNC_FUNCTION_DECLARATION]: "async function declaration",
+  [T.T_IMPORT_DECLARATION]: "import declaration",
+  [T.T_UNARY_EXPRESSION]: "unary expression",
+  [T.T_BINARY_EXPRESSION]: "binary expression",
+  [T.T_SEQUENCE_EXPRESSION]: "sequence expression",
+  [T.T_CONDITIONAL_EXPRESSION]: "conditional expression",
+  [T.T_FUNCTION_INVOCATION_EXPRESSION]: "function invocation",
+  [T.T_MEMBER_ACCESS_EXPRESSION]: "member access",
+  [T.T_CALCULATED_MEMBER_ACCESS_EXPRESSION]: "calculated member access",
+  [T.T_IDENTIFIER]: "identifier",
+  [T.T_TEMPLATE_LITERAL_EXPRESSION]: "template literal",
+  [T.T_LITERAL]: "literal",
+  [T.T_ARRAY_LITERAL]: "array literal",
+  [T.T_OBJECT_LITERAL]: "object literal",
+  [T.T_SPREAD_EXPRESSION]: "spread expression",
+  [T.T_ASSIGNMENT_EXPRESSION]: "assignment",
+  [T.T_NO_ARG_EXPRESSION]: "no-argument expression",
+  [T.T_ARROW_EXPRESSION]: "arrow function",
+  [T.T_PREFIX_OP_EXPRESSION]: "prefix operator",
+  [T.T_POSTFIX_OP_EXPRESSION]: "postfix operator",
+  [T.T_REACTIVE_VAR_DECLARATION]: "reactive var declaration",
+  [T.T_AWAIT_EXPRESSION]: "await expression",
+  [T.T_NEW_EXPRESSION]: "new expression",
+  [T.T_VAR_DECLARATION]: "variable declaration",
+  [T.T_DESTRUCTURE]: "destructuring pattern",
+  [T.T_ARRAY_DESTRUCTURE]: "array destructuring pattern",
+  [T.T_OBJECT_DESTRUCTURE]: "object destructuring pattern",
+  [T.T_SWITCH_CASE]: "switch case",
+  [T.T_IMPORT_SPECIFIER]: "import specifier",
+};
+
+export function describeScriptNodeType(nodeType: string | number): string {
+  const numericType = typeof nodeType === "number" ? nodeType : Number(nodeType);
+  return SCRIPT_NODE_TYPE_NAMES[numericType] ?? "expression";
+}

--- a/xmlui/src/components-core/script-compiler/script-inventory.ts
+++ b/xmlui/src/components-core/script-compiler/script-inventory.ts
@@ -1,0 +1,106 @@
+/**
+ * Counts the parse-time script artifacts an app actually shipped.
+ *
+ * The startup banner used to report the *requested* compilation flags, so it read
+ * "compiled" whether the build had produced 700 artifacts or none at all. This walk
+ * lets it report what is really there, and name the constructs behind any fallback.
+ */
+export type ParsedScriptInventory = {
+  /** Parsed script blocks found in the app definition. */
+  total: number;
+  /** Blocks that carry a compiled JavaScript artifact. */
+  compiled: number;
+  /** Blocks the compiler refused; `reasons` says why. */
+  unsupported: number;
+  /**
+   * Blocks with neither an artifact nor an "unsupported" marker — compilation never
+   * ran for them at build time, so they are compiled on first use instead.
+   */
+  notAttempted: number;
+  /** Distinct fallback reasons, in first-seen order. */
+  reasons: string[];
+};
+
+const MAX_TRACKED_REASONS = 10;
+
+export function collectParsedScriptInventory(value: unknown): ParsedScriptInventory {
+  const inventory: ParsedScriptInventory = {
+    total: 0,
+    compiled: 0,
+    unsupported: 0,
+    notAttempted: 0,
+    reasons: [],
+  };
+  const seenReasons = new Set<string>();
+  const visited = new Set<unknown>();
+
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== "object") {
+      return;
+    }
+    if (visited.has(node)) {
+      return;
+    }
+    visited.add(node);
+
+    const parsed = node as {
+      compiled?: unknown;
+      compiledUnsupported?: boolean;
+      compiledUnsupportedReason?: string;
+    };
+    // --- Every compilable slot carries a boolean `compiledUnsupported`, whether it is
+    // --- an event handler or a code-behind function declaration.
+    if (typeof parsed.compiledUnsupported === "boolean") {
+      inventory.total++;
+      if (parsed.compiled) {
+        inventory.compiled++;
+      } else if (parsed.compiledUnsupported === true) {
+        inventory.unsupported++;
+        const reason = parsed.compiledUnsupportedReason;
+        if (reason && !seenReasons.has(reason) && seenReasons.size < MAX_TRACKED_REASONS) {
+          seenReasons.add(reason);
+          inventory.reasons.push(reason);
+        }
+      } else {
+        inventory.notAttempted++;
+      }
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    Object.values(node as Record<string, unknown>).forEach(walk);
+  };
+
+  walk(value);
+  return inventory;
+}
+
+/**
+ * The line the startup banner adds under the execution-mode line: what the build
+ * produced, what fell back, and why.
+ */
+export function formatParsedScriptInventory(inventory: ParsedScriptInventory): string {
+  if (inventory.total === 0) {
+    return "[xmlui] No parsed script blocks found in the app definition.";
+  }
+  if (inventory.compiled === 0 && inventory.unsupported === 0) {
+    return (
+      `[xmlui] Script compilation is on, but none of the ${inventory.total} script block(s) ` +
+      `carry a build-time artifact — they are compiled on first use instead. To pre-compile ` +
+      `them, set "compileScripts" in xmlui.config.json (or in the app description read by ` +
+      `xmlui start / xmlui build).`
+    );
+  }
+  const parts = [
+    `${inventory.compiled} compiled at build time`,
+    `${inventory.unsupported} fell back to interpretation`,
+  ];
+  if (inventory.notAttempted > 0) {
+    parts.push(`${inventory.notAttempted} compiled on first use`);
+  }
+  const reasons =
+    inventory.reasons.length > 0 ? ` Fallback reasons: ${inventory.reasons.join("; ")}.` : "";
+  return `[xmlui] Script artifacts: ${parts.join(", ")}.${reasons}`;
+}

--- a/xmlui/src/components-core/script-compiler/targets/event-async-executor.ts
+++ b/xmlui/src/components-core/script-compiler/targets/event-async-executor.ts
@@ -46,14 +46,23 @@ export async function executeCompiledEventAsyncArtifact(
   });
   await invocation.initialize(evalContext);
   emitCompiledScriptDebugSourceTrace(artifact, evalContext);
-  return await instantiateCompiledScriptArtifact<Promise<any>>(artifact, invocation, {
-    sourceMapMode: evalContext.options?.compiledScriptSourceMaps,
-    generatedSourceUrl: getExternalGeneratedSourceUrl(artifact),
-    sourceMapUrl: getExternalSourceMapUrl(artifact),
-  }).execute({
-    evalContext,
-    thread,
-  });
+  // --- Bracket the run so callbacks this handler leaves behind (a `debounce` body, a
+  // --- subscription) can tell they are being invoked after it finished — the
+  // --- dispatcher aborts the run's `$cancel` token on completion. See
+  // --- `eventAsyncRuntime.checkCancel`.
+  eventAsyncRuntime.beginInvocation(evalContext);
+  try {
+    return await instantiateCompiledScriptArtifact<Promise<any>>(artifact, invocation, {
+      sourceMapMode: evalContext.options?.compiledScriptSourceMaps,
+      generatedSourceUrl: getExternalGeneratedSourceUrl(artifact),
+      sourceMapUrl: getExternalSourceMapUrl(artifact),
+    }).execute({
+      evalContext,
+      thread,
+    });
+  } finally {
+    eventAsyncRuntime.endInvocation(evalContext);
+  }
 }
 
 export async function executeCompiledEventAsyncHandler(

--- a/xmlui/src/components-core/script-compiler/targets/event-async.ts
+++ b/xmlui/src/components-core/script-compiler/targets/event-async.ts
@@ -8,6 +8,7 @@ import {
   T_BLOCK_STATEMENT,
   T_BREAK_STATEMENT,
   T_CALCULATED_MEMBER_ACCESS_EXPRESSION,
+  T_CONDITIONAL_EXPRESSION,
   T_CONST_STATEMENT,
   T_CONTINUE_STATEMENT,
   T_DO_WHILE_STATEMENT,
@@ -23,10 +24,12 @@ import {
   T_LET_STATEMENT,
   T_LITERAL,
   T_MEMBER_ACCESS_EXPRESSION,
+  T_NEW_EXPRESSION,
   T_OBJECT_LITERAL,
   T_POSTFIX_OP_EXPRESSION,
   T_PREFIX_OP_EXPRESSION,
   T_RETURN_STATEMENT,
+  T_SEQUENCE_EXPRESSION,
   T_SPREAD_EXPRESSION,
   T_DESTRUCTURE,
   T_SWITCH_STATEMENT,
@@ -45,6 +48,7 @@ import {
   type BlockStatement,
   type BreakStatement,
   type CalculatedMemberAccessExpression,
+  type ConditionalExpression,
   type ConstStatement,
   type ContinueStatement,
   type DoWhileStatement,
@@ -59,12 +63,14 @@ import {
   type IfStatement,
   type LetStatement,
   type MemberAccessExpression,
+  type NewExpression,
   type ObjectLiteral,
   type ObjectLiteralProp,
   type ObjectDestructure,
   type PostfixOpExpression,
   type PrefixOpExpression,
   type ReturnStatement,
+  type SequenceExpression,
   type Statement,
   type SwitchStatement,
   type TemplateLiteralExpression,
@@ -469,6 +475,14 @@ function expressionMayYield(expr: Expression, context: CompilerContext): boolean
       return expressionMayYield(expr.expr, context);
     case T_SPREAD_EXPRESSION:
       return expressionMayYield(expr.expr, context);
+    case T_CONDITIONAL_EXPRESSION:
+      return (
+        expressionMayYield(expr.cond, context) ||
+        expressionMayYield(expr.thenE, context) ||
+        expressionMayYield(expr.elseE, context)
+      );
+    case T_SEQUENCE_EXPRESSION:
+      return expr.exprs.some((item) => expressionMayYield(item, context));
     case T_ARROW_EXPRESSION:
     case T_LITERAL:
     case T_IDENTIFIER:
@@ -629,6 +643,16 @@ function isNativeExpressionSafe(expr: Expression, context: CompilerContext): boo
       return (
         isNativeExpressionSafe(expr.left, context) && isNativeExpressionSafe(expr.right, context)
       );
+    case T_CONDITIONAL_EXPRESSION:
+      return (
+        isNativeExpressionSafe(expr.cond, context) &&
+        isNativeExpressionSafe(expr.thenE, context) &&
+        isNativeExpressionSafe(expr.elseE, context)
+      );
+    case T_SEQUENCE_EXPRESSION:
+      return (
+        expr.exprs.length > 0 && expr.exprs.every((item) => isNativeExpressionSafe(item, context))
+      );
     case T_ARRAY_LITERAL:
       return expr.items.every(
         (item) => item.type !== T_SPREAD_EXPRESSION && isNativeExpressionSafe(item, context),
@@ -724,6 +748,23 @@ function emitNativeExpression(
       emitNativeExpression(writer, expr.left, context);
       writer.write(` ${expr.op} `);
       emitNativeExpression(writer, expr.right, context);
+      writer.write(")");
+      return;
+    case T_CONDITIONAL_EXPRESSION:
+      writer.write("(", expr);
+      emitNativeExpression(writer, expr.cond, context);
+      writer.write(" ? ");
+      emitNativeExpression(writer, expr.thenE, context);
+      writer.write(" : ");
+      emitNativeExpression(writer, expr.elseE, context);
+      writer.write(")");
+      return;
+    case T_SEQUENCE_EXPRESSION:
+      writer.write("(", expr);
+      expr.exprs.forEach((item, index) => {
+        if (index > 0) writer.write(", ");
+        emitNativeExpression(writer, item, context);
+      });
       writer.write(")");
       return;
     case T_ARRAY_LITERAL:
@@ -1645,8 +1686,17 @@ function emitExpression(
     case T_BINARY_EXPRESSION:
       emitBinaryExpression(writer, expr, context);
       return;
+    case T_CONDITIONAL_EXPRESSION:
+      emitConditionalExpression(writer, expr, context);
+      return;
+    case T_SEQUENCE_EXPRESSION:
+      emitSequenceExpression(writer, expr, context);
+      return;
     case T_FUNCTION_INVOCATION_EXPRESSION:
       emitFunctionInvocation(writer, expr, context);
+      return;
+    case T_NEW_EXPRESSION:
+      emitNewExpression(writer, expr, context);
       return;
     case T_ARROW_EXPRESSION:
       emitArrowExpression(writer, expr, context);
@@ -1738,6 +1788,99 @@ function emitBinaryExpression(
   writer.write("))", expr);
 }
 
+/**
+ * Conditional (`cond ? a : b`) expression. Both branches are emitted inline so the
+ * untaken one is never evaluated — the same laziness the interpreter has, which
+ * matters when a branch has side effects or would throw.
+ */
+function emitConditionalExpression(
+  writer: CompiledScriptCodeWriter,
+  expr: ConditionalExpression,
+  context: CompilerContext,
+): void {
+  writer.write("((await runtime.complete(");
+  emitExpression(writer, expr.cond, context);
+  writer.write(")) ? (await runtime.complete(");
+  emitExpression(writer, expr.thenE, context);
+  writer.write(")) : (await runtime.complete(");
+  emitExpression(writer, expr.elseE, context);
+  writer.write(")))", expr);
+}
+
+/**
+ * Comma-sequence expression: every operand is evaluated left to right, the last one
+ * is the value.
+ */
+function emitSequenceExpression(
+  writer: CompiledScriptCodeWriter,
+  expr: SequenceExpression,
+  context: CompilerContext,
+): void {
+  if (!expr.exprs || expr.exprs.length === 0) {
+    throwUnsupportedCompiledScriptNode(expr, context.sourceId);
+  }
+  writer.write("(");
+  expr.exprs.forEach((item, index) => {
+    if (index > 0) writer.write(", ");
+    writer.write("await runtime.complete(");
+    emitExpression(writer, item, context);
+    writer.write(")");
+  });
+  writer.write(")", expr);
+}
+
+/**
+ * `new X(...)`. The constructor goes through `runtime.construct`, which applies the
+ * same allow-list the interpreter applies, so compilation cannot widen what a script
+ * is permitted to instantiate.
+ */
+function emitNewExpression(
+  writer: CompiledScriptCodeWriter,
+  expr: NewExpression,
+  context: CompilerContext,
+): void {
+  writer.write("(await runtime.construct(await runtime.complete(");
+  emitExpression(writer, expr.callee, context);
+  writer.write("), ");
+  emitNewArgumentArray(writer, expr.arguments, context);
+  writer.write("))", expr);
+}
+
+function emitNewArgumentArray(
+  writer: CompiledScriptCodeWriter,
+  args: Expression[],
+  context: CompilerContext,
+): void {
+  writer.write("[");
+  args.forEach((arg, index) => {
+    if (index > 0) writer.write(", ");
+    if (arg.type === T_SPREAD_EXPRESSION) {
+      emitSpreadOperand(writer, arg as SpreadExpression, "spreadNewArg", context);
+      return;
+    }
+    writer.write("await runtime.complete(");
+    emitExpression(writer, arg, context);
+    writer.write(")");
+  });
+  writer.write("]");
+}
+
+/**
+ * Emits a `...expr` operand. The runtime helper enforces the operand rules the
+ * interpreter enforces (e.g. "expects an array operand"), so a spread that throws
+ * interpreted also throws compiled.
+ */
+function emitSpreadOperand(
+  writer: CompiledScriptCodeWriter,
+  spread: SpreadExpression,
+  helper: "spreadArrayItem" | "spreadCallArg" | "spreadNewArg" | "spreadObjectValue",
+  context: CompilerContext,
+): void {
+  writer.write(`...runtime.${helper}(await runtime.complete(`);
+  emitExpression(writer, spread.expr, context);
+  writer.write("))", spread);
+}
+
 function emitArrayLiteral(
   writer: CompiledScriptCodeWriter,
   expr: ArrayLiteral,
@@ -1747,7 +1890,8 @@ function emitArrayLiteral(
   expr.items.forEach((item, index) => {
     if (index > 0) writer.write(", ");
     if (item.type === T_SPREAD_EXPRESSION) {
-      throwUnsupportedCompiledScriptNode(item, context.sourceId);
+      emitSpreadOperand(writer, item as SpreadExpression, "spreadArrayItem", context);
+      return;
     }
     writer.write("await runtime.complete(");
     emitExpression(writer, item, context);
@@ -1765,7 +1909,8 @@ function emitObjectLiteral(
   expr.props.forEach((prop, index) => {
     if (index > 0) writer.write(", ");
     if (!Array.isArray(prop) && !("kind" in prop)) {
-      throwUnsupportedCompiledScriptNode(prop, context.sourceId);
+      emitSpreadOperand(writer, prop as SpreadExpression, "spreadObjectValue", context);
+      return;
     }
     if (!Array.isArray(prop)) {
       throwUnsupportedCompiledScriptNode(prop.value, context.sourceId);
@@ -1867,7 +2012,8 @@ function emitCompletedArgumentList(
   args.forEach((arg, index) => {
     if (index > 0) writer.write(", ");
     if (arg.type === T_SPREAD_EXPRESSION) {
-      throwUnsupportedCompiledScriptNode(arg, context.sourceId);
+      emitSpreadOperand(writer, arg as SpreadExpression, "spreadCallArg", context);
+      return;
     }
     writer.write("await runtime.complete(");
     emitExpression(writer, arg, context);
@@ -1897,7 +2043,8 @@ function emitArgumentArray(
   args.forEach((arg, index) => {
     if (index > 0) writer.write(", ");
     if (arg.type === T_SPREAD_EXPRESSION) {
-      throwUnsupportedCompiledScriptNode(arg, context.sourceId);
+      emitSpreadOperand(writer, arg as SpreadExpression, "spreadCallArg", context);
+      return;
     }
     if (arg.type === T_ARROW_EXPRESSION) {
       if (arrowReferencesCompilerLocals(arg, context)) {

--- a/xmlui/src/components-core/script-compiler/targets/event-async.ts
+++ b/xmlui/src/components-core/script-compiler/targets/event-async.ts
@@ -347,8 +347,9 @@ function emitEventArrowCall(
     // let the whole handler fall back to interpreted execution (existing, safe behavior).
     throwUnsupportedCompiledScriptNode(expr, context.sourceId);
   }
-  if (containsNonSerializableLiteral(expr)) {
-    throwUnsupportedCompiledScriptNode(expr, context.sourceId);
+  const nonSerializable = findNonSerializableLiteral(expr);
+  if (nonSerializable) {
+    throwUnsupportedCompiledScriptNode(nonSerializable, context.sourceId);
   }
   writer.write("await runtime.call(runtime.arrow(", expr);
   writer.write(JSON.stringify(expr), expr);
@@ -2026,8 +2027,14 @@ function emitArrowExpression(
   expr: ArrowExpression,
   context: CompilerContext,
 ): void {
-  if (expr.async || containsNonSerializableLiteral(expr)) {
+  if (expr.async) {
     throwUnsupportedCompiledScriptNode(expr, context.sourceId);
+  }
+  // --- Report the literal itself, not the arrow that holds it: "unsupported literal
+  // --- at line 4" points at the code to change, "unsupported arrow function" does not.
+  const nonSerializable = findNonSerializableLiteral(expr);
+  if (nonSerializable) {
+    throwUnsupportedCompiledScriptNode(nonSerializable, context.sourceId);
   }
   writer.write("runtime.arrow(");
   writer.write(JSON.stringify(expr), expr);
@@ -2547,26 +2554,37 @@ function canSerializeLiteral(value: any): boolean {
   );
 }
 
-function containsNonSerializableLiteral(node: any): boolean {
+/**
+ * Finds the first literal a lazy (interpreted) arrow cannot carry — a regular
+ * expression, for instance, which does not survive `JSON.stringify`. Returns the
+ * literal node so diagnostics can point at it.
+ */
+function findNonSerializableLiteral(node: any): any | undefined {
   if (!node || typeof node !== "object") {
-    return false;
+    return undefined;
   }
   if (node.type === T_LITERAL) {
-    return !canSerializeLiteral(node.value);
+    return canSerializeLiteral(node.value) ? undefined : node;
   }
   for (const [key, value] of Object.entries(node)) {
     if (key === "startToken" || key === "endToken" || key === "source" || key === "parenthesized") {
       continue;
     }
     if (Array.isArray(value)) {
-      if (value.some((item) => containsNonSerializableLiteral(item))) {
-        return true;
+      for (const item of value) {
+        const found = findNonSerializableLiteral(item);
+        if (found) {
+          return found;
+        }
       }
-    } else if (containsNonSerializableLiteral(value)) {
-      return true;
+      continue;
+    }
+    const found = findNonSerializableLiteral(value);
+    if (found) {
+      return found;
     }
   }
-  return false;
+  return undefined;
 }
 
 function assertJsIdentifier(expr: Pick<Identifier, "name">, sourceId: string): void {

--- a/xmlui/src/components-core/script-runner/AttributeValueParser.ts
+++ b/xmlui/src/components-core/script-runner/AttributeValueParser.ts
@@ -5,6 +5,7 @@ import { compileBindingSyncExpression } from "../script-compiler/targets/binding
 import {
   createCompiledSources,
   createSegmentSourceOrigin,
+  shouldCompileBindingOption,
   type ParseBindingOptions,
 } from "./ParameterParser";
 
@@ -88,7 +89,7 @@ export function parseAttributeValue(
           // --- Successfully parsed expression, get dependencies
           result.segments.push({
             expr,
-            compiled: options.compileBindings
+            compiled: shouldCompileBindingOption(options)
               ? compileBindingSyncExpression(expr!, {
                   sourceId,
                   sourceText: exprText,

--- a/xmlui/src/components-core/script-runner/BindingTreeEvaluationContext.ts
+++ b/xmlui/src/components-core/script-runner/BindingTreeEvaluationContext.ts
@@ -111,6 +111,11 @@ class CancellationToken {
 export type EvalTreeOptions = {
   defaultToOptionalMemberAccess?: boolean;
   /**
+   * Umbrella switch for script compilation. Implies both `compileBindings` and
+   * `compileEventHandlers` unless one of those is set explicitly.
+   */
+  compileScripts?: boolean;
+  /**
    * Experimental switch for compiled synchronous binding expressions.
    *
    * Default: `false`. Set via `App.xmluiConfig.compileScripts`; the legacy

--- a/xmlui/src/components-core/script-runner/ParameterParser.ts
+++ b/xmlui/src/components-core/script-runner/ParameterParser.ts
@@ -8,6 +8,11 @@ import type {
 import { compileBindingSyncExpression } from "../script-compiler/targets/binding-sync";
 
 export type ParseBindingOptions = {
+  /**
+   * Umbrella switch: compiles binding expressions unless `compileBindings` says
+   * otherwise. Mirrors `xmluiConfig.compileScripts`.
+   */
+  compileScripts?: boolean;
   compileBindings?: boolean;
   sourceId?: string;
   sourceUrl?: string;
@@ -143,6 +148,15 @@ export function parseParameterString(
   return result;
 }
 
+/**
+ * `compileScripts` is the umbrella switch; `compileBindings` remains a per-path
+ * override. Both parse-time call sites read it through here so the umbrella flag
+ * cannot silently miss one of them.
+ */
+export function shouldCompileBindingOption(options: ParseBindingOptions): boolean {
+  return options.compileBindings ?? options.compileScripts ?? false;
+}
+
 function createCompiledBindingArtifact(
   expr: Expression,
   sourceText: string,
@@ -150,7 +164,7 @@ function createCompiledBindingArtifact(
   segmentIndex: number,
   expressionStart: number,
 ): CompiledScriptArtifact | undefined {
-  if (!options.compileBindings) {
+  if (!shouldCompileBindingOption(options)) {
     return undefined;
   }
   const sourceId = `${options.sourceId ?? "inline"}#expr-${segmentIndex}`;

--- a/xmlui/src/components-core/script-runner/ScriptingSourceTree.ts
+++ b/xmlui/src/components-core/script-runner/ScriptingSourceTree.ts
@@ -591,6 +591,8 @@ export type CodeDeclarationCompilation = {
   source?: string;
   compiled?: CompiledScriptArtifact;
   compiledUnsupported?: boolean;
+  /** Why compilation was skipped — see `ParsedEventValue.compiledUnsupportedReason`. */
+  compiledUnsupportedReason?: string;
   sourceId?: string;
   sourceRange?: CompiledScriptSourceRange;
 };

--- a/xmlui/src/components-core/script-runner/asyncProxy.ts
+++ b/xmlui/src/components-core/script-runner/asyncProxy.ts
@@ -25,6 +25,10 @@ asyncProxies.set(Array.prototype.flatMap, asyncFlatMap);
 asyncProxies.set(Array.prototype.some, asyncSome);
 asyncProxies.set(Array.prototype.reduce, asyncReduce);
 asyncProxies.set(Array.prototype.reduceRight, asyncReduceRight);
+asyncProxies.set(Array.prototype.sort, asyncSort);
+if ((Array.prototype as any).toSorted) {
+  asyncProxies.set((Array.prototype as any).toSorted, asyncToSorted);
+}
 if (Array.prototype.findLast) {
   asyncProxies.set(Array.prototype.findLast, asyncFindLast);
 }
@@ -94,6 +98,80 @@ async function asyncFindLast(arr: any[], predicate: (...args: any[]) => boolean)
 async function asyncFindLastIndex(arr: any[], predicate: (...args: any[]) => boolean) {
   const results = await Promise.all(arr.map(predicate));
   return arr.findLastIndex((_v, index) => results[index]);
+}
+
+/**
+ * The async implementation of `Array.prototype.sort`.
+ *
+ * XMLScript callbacks are asynchronous, and the native `sort` coerces the promise a
+ * comparator returns to `NaN` — so every comparison compared equal and `sort(cmp)`
+ * silently left the array untouched, while the argument-less `sort()` worked. This
+ * awaits each comparison instead, sorts stably (as the native one does), and writes
+ * the result back in place before returning the same array.
+ */
+async function asyncSort(arr: any[], comparator?: (...args: any[]) => any) {
+  if (typeof comparator !== "function") {
+    return arr.sort(comparator as undefined);
+  }
+  const sorted = await asyncSortedCopy(arr, comparator);
+  for (let i = 0; i < sorted.length; i++) {
+    arr[i] = sorted[i];
+  }
+  return arr;
+}
+
+// The async implementation of Array.prototype.toSorted (leaves the receiver alone)
+async function asyncToSorted(arr: any[], comparator?: (...args: any[]) => any) {
+  if (typeof comparator !== "function") {
+    return (arr as any).toSorted(comparator);
+  }
+  return await asyncSortedCopy(arr, comparator);
+}
+
+/**
+ * Stable merge sort with awaited comparisons. `undefined` entries take no part in the
+ * comparisons and land at the end, as the specified `sort` behaviour requires.
+ */
+async function asyncSortedCopy(arr: any[], comparator: (...args: any[]) => any): Promise<any[]> {
+  const values: any[] = [];
+  let undefinedCount = 0;
+  for (let i = 0; i < arr.length; i++) {
+    if (arr[i] === undefined) {
+      undefinedCount++;
+    } else {
+      values.push(arr[i]);
+    }
+  }
+  const sorted = await asyncMergeSort(values, comparator);
+  for (let i = 0; i < undefinedCount; i++) {
+    sorted.push(undefined);
+  }
+  return sorted;
+}
+
+async function asyncMergeSort(values: any[], comparator: (...args: any[]) => any): Promise<any[]> {
+  if (values.length <= 1) {
+    return values;
+  }
+  const middle = values.length >> 1;
+  const left = await asyncMergeSort(values.slice(0, middle), comparator);
+  const right = await asyncMergeSort(values.slice(middle), comparator);
+  const merged: any[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const order = Number(await comparator(left[leftIndex], right[rightIndex]));
+    // --- `<= 0` (and `NaN`, which compares false) keeps the left element first —
+    // --- that is what makes the merge stable.
+    if (order > 0) {
+      merged.push(right[rightIndex++]);
+    } else {
+      merged.push(left[leftIndex++]);
+    }
+  }
+  while (leftIndex < left.length) merged.push(left[leftIndex++]);
+  while (rightIndex < right.length) merged.push(right[rightIndex++]);
+  return merged;
 }
 
 // The async implementation of Array.prototype.asyncReduce

--- a/xmlui/src/components-core/script-runner/eval-tree-async.ts
+++ b/xmlui/src/components-core/script-runner/eval-tree-async.ts
@@ -269,7 +269,7 @@ async function evalCalculatedMemberAccessAsync(
   return evalCalculatedMemberAccessCore(thisStack, expr, evalContext, thread);
 }
 
-function evalSequenceAsync(
+async function evalSequenceAsync(
   evaluator: EvaluatorAsyncFunction,
   thisStack: any[],
   expr: SequenceExpression,
@@ -279,15 +279,17 @@ function evalSequenceAsync(
   if (!expr.exprs || expr.exprs.length === 0) {
     throw new Error(`Missing expression sequence`);
   }
-  const result = expr.exprs.map(async (e) => {
-    const value = await evaluator(thisStack, e, evalContext, thread);
-    setExprValue(e, { value }, thread);
+  // --- Strictly left to right: an earlier operand's side effects must be visible
+  // --- to the later ones. Mapping the operands through an async callback started
+  // --- them all from the same state and pushed a pending promise as the value.
+  let lastValue: any;
+  for (const item of expr.exprs) {
+    lastValue = await evaluator(thisStack, item, evalContext, thread);
+    setExprValue(item, { value: lastValue }, thread);
     thisStack.pop();
-    return value;
-  });
-  const lastObj = result[result.length - 1];
-  thisStack.push(lastObj);
-  return lastObj;
+  }
+  thisStack.push(lastValue);
+  return lastValue;
 }
 
 async function evalArrayLiteralAsync(

--- a/xmlui/src/components-core/script-runner/eval-tree-async.ts
+++ b/xmlui/src/components-core/script-runner/eval-tree-async.ts
@@ -339,8 +339,9 @@ async function evalObjectLiteralAsync(
         for (let i = 0; i < spreadItems.length; i++) {
           objectHash[i] = spreadItems[i];
         }
-      } else if (typeof spreadItems === "object") {
-        // --- Spread of a hash object
+      } else if (spreadItems && typeof spreadItems === "object") {
+        // --- Spread of a hash object. `null` contributes nothing, as it does in
+        // --- JavaScript — `Object.entries(null)` would throw.
         for (const [key, value] of Object.entries(spreadItems)) {
           objectHash[key] = value;
         }

--- a/xmlui/src/components-core/script-runner/eval-tree-sync.ts
+++ b/xmlui/src/components-core/script-runner/eval-tree-sync.ts
@@ -133,7 +133,9 @@ export function evalBinding(
   evalTrace("eval", () =>
     String((expr as any)?.source ?? "").slice(0, 80) || "type:" + String((expr as any)?.type ?? "?"),
   );
-  if (evalContext.options?.compileBindings && expr.type !== T_ARROW_EXPRESSION) {
+  const compileBindings =
+    evalContext.options?.compileBindings ?? evalContext.options?.compileScripts ?? false;
+  if (compileBindings && expr.type !== T_ARROW_EXPRESSION) {
     const previousArrowInvoker = evalContext.compiledArrowInvoker;
     evalContext.compiledArrowInvoker = (arrowExpr, args, arrowEvalContext, arrowThread) =>
       executeArrowExpressionSync(

--- a/xmlui/src/components-core/script-runner/eval-tree-sync.ts
+++ b/xmlui/src/components-core/script-runner/eval-tree-sync.ts
@@ -387,8 +387,9 @@ function evalObjectLiteral(
         for (let i = 0; i < spreadItems.length; i++) {
           objectHash[i] = spreadItems[i];
         }
-      } else if (typeof spreadItems === "object") {
-        // --- Spread of a hash object
+      } else if (spreadItems && typeof spreadItems === "object") {
+        // --- Spread of a hash object. `null` contributes nothing, as it does in
+        // --- JavaScript — `Object.entries(null)` would throw.
         for (const [key, value] of Object.entries(spreadItems)) {
           objectHash[key] = value;
         }

--- a/xmlui/src/components/ComponentProvider.tsx
+++ b/xmlui/src/components/ComponentProvider.tsx
@@ -953,6 +953,22 @@ export class ComponentRegistry {
   }
 
   /**
+   * The compound component definitions this app registered (as opposed to the
+   * built-in and extension ones). Used by the startup script-compilation report,
+   * which has to look beyond the entry point to see every script block the app
+   * actually ships.
+   */
+  getAppCompoundComponentDefs(): CompoundComponentDef[] {
+    const defs: CompoundComponentDef[] = [];
+    this.pool.get(APP_NS)?.forEach((entry) => {
+      if (entry.compoundComponentDef) {
+        defs.push(entry.compoundComponentDef);
+      }
+    });
+    return defs;
+  }
+
+  /**
    * This method retrieves the registry entry of a component registered
    * with the specified key.
    * @param componentName The unique ID of the component
@@ -1154,6 +1170,7 @@ export class ComponentRegistry {
         );
       },
       isCompoundComponent: true,
+      compoundComponentDef,
       metadata: mergedMetadata,
       udcContract: normalizedContract,
     };

--- a/xmlui/src/components/ComponentRegistryContext.tsx
+++ b/xmlui/src/components/ComponentRegistryContext.tsx
@@ -16,6 +16,11 @@ export type ComponentRegistryEntry = {
   // Indicates whether this entry represents a compound (user-defined) component
   isCompoundComponent?: boolean;
 
+  // For compound components: the definition this entry was registered from.
+  // Kept so app-level tooling (e.g. the startup script-compilation report) can
+  // inspect the script blocks a user-defined component ships.
+  compoundComponentDef?: CompoundComponentDef;
+
   // For compound components: the UDC sandbox contract parsed from
   // explicit <Prop>/<Event>/<Method>/<Slot> declarations.  Used by analyzer
   // rules (e.g. udc-slot-undeclared) to enforce the declared surface

--- a/xmlui/src/nodejs/bin/start.ts
+++ b/xmlui/src/nodejs/bin/start.ts
@@ -31,7 +31,7 @@ export const start = async ({ port, withMock = true, proxy }: XmlUiStartOptions)
   }
 
   try {
-    let viteConfig = await getViteConfig({});
+    let viteConfig = await getViteConfig({ devServer: true });
     const server = await createServer({
       ...viteConfig,
       server: {

--- a/xmlui/src/nodejs/bin/viteConfig.ts
+++ b/xmlui/src/nodejs/bin/viteConfig.ts
@@ -12,6 +12,12 @@ type ViteConfigData = {
   flatDist?: boolean;
   withRelativeRoot?: boolean;
   flatDistUiPrefix?: string;
+  /**
+   * True only for `xmlui start`. It turns on dev-only defaults — notably compiled
+   * script source maps, whose per-token mappings and embedded original sources have
+   * no place in a production bundle.
+   */
+  devServer?: boolean;
 };
 
 const logger = createLogger();
@@ -77,6 +83,7 @@ export async function getViteConfig({
   flatDist = false,
   withRelativeRoot = false,
   flatDistUiPrefix = "",
+  devServer = false,
 }: ViteConfigData = {}) {
   //TODO finish this (merge smart)
   let overrides: UserConfig = {};
@@ -87,7 +94,7 @@ export async function getViteConfig({
     // console.error(e);
   }
 
-  const xmluiPluginOptions = await loadXmluiPluginOptions({ devServer: true });
+  const xmluiPluginOptions = await loadXmluiPluginOptions({ devServer });
 
   // Single instance shared by the main pipeline and the dep-scanner pipeline.
   // The dep scanner runs a separate Rolldown build that only sees plugins

--- a/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
+++ b/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
@@ -128,10 +128,12 @@ async function readXmluiConfigFile(cwd: string): Promise<XmluiConfigSource | und
  * settings declared there — script compilation among them — reach the build
  * pipeline as well, not just the browser runtime.
  *
- * The app description may import assets the Node process cannot load (SCSS,
- * `import.meta.glob`, and friends). Such a failure is not fatal: the build goes
- * on with `xmlui.config.json` alone, and we only complain when the unreadable
- * file looks like it was trying to configure script compilation.
+ * The description may use syntax or assets a plain Node import cannot evaluate —
+ * `import.meta.glob`, stylesheets, `.xmlui` imports. Those are retried through Vite's
+ * module runner, but only for settings `xmlui.config.json` has not already answered,
+ * since that retry evaluates the whole module graph the description pulls in. If even
+ * that fails the build goes on with `xmlui.config.json` alone, and we complain only
+ * when the unreadable file looks like it was configuring script compilation.
  */
 async function readAppDescriptionConfig(
   cwd: string,

--- a/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
+++ b/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
@@ -104,7 +104,7 @@ export async function loadXmluiPluginOptions(
 ): Promise<PluginOptions> {
   const { cwd = process.cwd(), ...normalizeOptions } = options;
   const xmluiConfigFile = await readXmluiConfigFile(cwd);
-  const appDescription = await readAppDescriptionConfig(cwd);
+  const appDescription = await readAppDescriptionConfig(cwd, xmluiConfigFile);
   if (!xmluiConfigFile && !appDescription) {
     return {};
   }
@@ -133,7 +133,10 @@ async function readXmluiConfigFile(cwd: string): Promise<XmluiConfigSource | und
  * on with `xmlui.config.json` alone, and we only complain when the unreadable
  * file looks like it was trying to configure script compilation.
  */
-async function readAppDescriptionConfig(cwd: string): Promise<XmluiConfigSource | undefined> {
+async function readAppDescriptionConfig(
+  cwd: string,
+  xmluiConfigFile: XmluiConfigSource | undefined,
+): Promise<XmluiConfigSource | undefined> {
   for (const segments of APP_DESCRIPTION_FILES) {
     const file = path.join(cwd, ...segments);
     let rawConfig: string;
@@ -156,10 +159,11 @@ async function readAppDescriptionConfig(cwd: string): Promise<XmluiConfigSource 
     } catch (nodeImportError) {
       // --- A plain Node import cannot evaluate Vite-only syntax such as
       // --- `import.meta.glob` (the shape the `getLocalIcons()` pattern in our own app
-      // --- templates uses) or asset imports. Retry through Vite's module runner —
-      // --- but only when the file looks like it configures script compilation, since
-      // --- the retry evaluates the whole module graph the description pulls in.
-      if (!mentionsScriptCompilation(rawConfig)) {
+      // --- templates uses) or asset imports. Retry through Vite's module runner — but
+      // --- only for settings this project has not already answered in
+      // --- `xmlui.config.json`, since the retry evaluates the whole module graph the
+      // --- description pulls in.
+      if (!hasUnansweredScriptCompilationKey(rawConfig, xmluiConfigFile)) {
         return undefined;
       }
       try {
@@ -223,6 +227,31 @@ async function importAppDescriptionThroughVite(cwd: string, file: string): Promi
 
 function mentionsScriptCompilation(rawConfig: string): boolean {
   return SCRIPT_COMPILATION_KEYS.some((key) => rawConfig.includes(key));
+}
+
+/**
+ * True when the app description mentions a script-compilation key that
+ * `xmlui.config.json` does not already settle. `xmlui.config.json` wins per key, so
+ * reading the description again could not change the outcome for keys it defines.
+ */
+function hasUnansweredScriptCompilationKey(
+  rawConfig: string,
+  xmluiConfigFile: XmluiConfigSource | undefined,
+): boolean {
+  return SCRIPT_COMPILATION_KEYS.some(
+    (key) => rawConfig.includes(key) && !definesSetting(xmluiConfigFile, key),
+  );
+}
+
+function definesSetting(config: XmluiConfigSource | undefined, key: string): boolean {
+  if (!config) {
+    return false;
+  }
+  return (
+    config[key] !== undefined ||
+    config.xmluiConfig?.[key] !== undefined ||
+    config.appGlobals?.[key] !== undefined
+  );
 }
 
 function pickConfigSource(appDescription: unknown): XmluiConfigSource | undefined {

--- a/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
+++ b/xmlui/src/nodejs/bin/xmluiPluginOptions.ts
@@ -153,12 +153,76 @@ async function readAppDescriptionConfig(cwd: string): Promise<XmluiConfigSource 
     try {
       const module = await import(pathToFileURL(file).href);
       return pickConfigSource(module?.default ?? module);
-    } catch (error) {
-      warnUnreadableAppDescription(file, rawConfig, error);
-      return undefined;
+    } catch (nodeImportError) {
+      // --- A plain Node import cannot evaluate Vite-only syntax such as
+      // --- `import.meta.glob` (the shape the `getLocalIcons()` pattern in our own app
+      // --- templates uses) or asset imports. Retry through Vite's module runner —
+      // --- but only when the file looks like it configures script compilation, since
+      // --- the retry evaluates the whole module graph the description pulls in.
+      if (!mentionsScriptCompilation(rawConfig)) {
+        return undefined;
+      }
+      try {
+        return pickConfigSource(await importAppDescriptionThroughVite(cwd, file));
+      } catch (viteImportError) {
+        warnUnreadableAppDescription(file, rawConfig, viteImportError ?? nodeImportError);
+        return undefined;
+      }
     }
   }
   return undefined;
+}
+
+/**
+ * Evaluates the app description with Vite's plugin pipeline applied, so
+ * `import.meta.glob`, `.xmlui` imports, and TypeScript all resolve exactly as they do
+ * in the browser build. Stylesheets are stubbed out: an app description never needs
+ * them, and CSS preprocessing is not configured for the module runner environment.
+ */
+async function importAppDescriptionThroughVite(cwd: string, file: string): Promise<unknown> {
+  const { runnerImport } = await import("vite");
+  const { default: viteXmluiPlugin } = await import("../vite-xmlui-plugin");
+  const stubbedStyles = new Set<string>();
+  const stubStyles = {
+    name: "xmlui:app-description-style-stub",
+    enforce: "pre" as const,
+    resolveId(id: string) {
+      if (!/\.(css|scss|sass|less|styl|stylus)(\?.*)?$/.test(id)) {
+        return null;
+      }
+      // --- The stub id must not keep the stylesheet extension, or Vite's CSS
+      // --- transform claims it again.
+      const stubId = `\0xmlui-style-stub-${stubbedStyles.size}.js`;
+      stubbedStyles.add(stubId);
+      return stubId;
+    },
+    load(id: string) {
+      return stubbedStyles.has(id) ? "export default {};" : null;
+    },
+  };
+  const imported = await runnerImport<Record<string, any>>(pathToFileURL(file).href, {
+    root: cwd,
+    configFile: false,
+    logLevel: "silent",
+    plugins: [
+      stubStyles,
+      viteXmluiPlugin({
+        analyze: "off",
+        reactiveCycles: "off",
+        accessibility: "off",
+        typeContracts: "off",
+      }) as any,
+    ],
+    resolve: {
+      extensions: [".js", ".ts", ".jsx", ".tsx", ".json", ".xmlui", ".xmlui.xs", ".xs"],
+    },
+  });
+  const module = imported.module as Record<string, any>;
+  return module?.default ?? module;
+}
+
+function mentionsScriptCompilation(rawConfig: string): boolean {
+  return SCRIPT_COMPILATION_KEYS.some((key) => rawConfig.includes(key));
 }
 
 function pickConfigSource(appDescription: unknown): XmluiConfigSource | undefined {
@@ -172,7 +236,7 @@ function pickConfigSource(appDescription: unknown): XmluiConfigSource | undefine
 function warnUnreadableAppDescription(file: string, rawConfig: string, error: unknown): void {
   // --- Apps that do not configure script compilation in their description lose
   // --- nothing when we cannot load it, so stay quiet for them.
-  if (!SCRIPT_COMPILATION_KEYS.some((key) => rawConfig.includes(key))) {
+  if (!mentionsScriptCompilation(rawConfig)) {
     return;
   }
   console.warn(

--- a/xmlui/src/nodejs/vite-xmlui-plugin.ts
+++ b/xmlui/src/nodejs/vite-xmlui-plugin.ts
@@ -404,20 +404,26 @@ function stripCompiledArtifactDebugData(value: unknown, projectRoot: string): vo
   if (!value || typeof value !== "object") {
     return;
   }
-  const maybeArtifact = value as Partial<CompiledScriptArtifact>;
+  const maybeArtifact = value as Partial<CompiledScriptArtifact> & {
+    compiled?: unknown;
+    compiledUnsupported?: boolean;
+  };
+  const isArtifact =
+    typeof maybeArtifact.js === "string" &&
+    typeof maybeArtifact.target === "string" &&
+    Array.isArray(maybeArtifact.mappings);
   // --- Code-behind declarations carry a `sourceId` of their own, next to the
-  // --- artifact's; both are absolute module paths at build time.
-  if (typeof maybeArtifact.sourceId === "string") {
+  // --- artifact's; both are absolute module paths at build time. The extra shape
+  // --- checks keep this off a `sourceId` that is merely an app's own prop value.
+  const isCompiledSlot =
+    maybeArtifact.compiled !== undefined || typeof maybeArtifact.compiledUnsupported === "boolean";
+  if (typeof maybeArtifact.sourceId === "string" && (isArtifact || isCompiledSlot)) {
     (value as { sourceId: string }).sourceId = relativizeSourcePath(
       maybeArtifact.sourceId,
       projectRoot,
     );
   }
-  if (
-    typeof maybeArtifact.js === "string" &&
-    typeof maybeArtifact.target === "string" &&
-    Array.isArray(maybeArtifact.mappings)
-  ) {
+  if (isArtifact) {
     const artifact = value as CompiledScriptArtifact;
     artifact.mappings = [];
     artifact.sources = [];

--- a/xmlui/src/nodejs/vite-xmlui-plugin.ts
+++ b/xmlui/src/nodejs/vite-xmlui-plugin.ts
@@ -376,10 +376,12 @@ function tallyCompiledScripts(value: unknown, tally: CompiledScriptTally): Compi
     tally.artifacts++;
     return tally;
   }
-  const maybeParsedScript = value as { __PARSED?: boolean; compiledUnsupported?: boolean };
-  if (maybeParsedScript.__PARSED === true && Array.isArray((value as any).statements)) {
+  // --- Every compilable slot carries a boolean `compiledUnsupported`, whether it is an
+  // --- event handler (`__PARSED`) or a code-behind function declaration.
+  const maybeScript = value as { compiledUnsupported?: boolean };
+  if (typeof maybeScript.compiledUnsupported === "boolean") {
     tally.scripts++;
-    if (maybeParsedScript.compiledUnsupported === true) {
+    if (maybeScript.compiledUnsupported) {
       tally.unsupported++;
     }
   }
@@ -389,6 +391,60 @@ function tallyCompiledScripts(value: unknown, tally: CompiledScriptTally): Compi
   }
   Object.values(value).forEach((item) => tallyCompiledScripts(item, tally));
   return tally;
+}
+
+/**
+ * Fields a compiled artifact only needs when source maps are on. `mappings` holds one
+ * entry per emitted token and `sources[].sourceText` the complete original module, so
+ * shipping them in a production build multiplied bundle size and put developer paths
+ * and full script sources into the browser payload for no runtime benefit —
+ * `createCompiledScriptFunctionBody` reads `js` alone when source maps are off.
+ */
+function stripCompiledArtifactDebugData(value: unknown, projectRoot: string): void {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  const maybeArtifact = value as Partial<CompiledScriptArtifact>;
+  // --- Code-behind declarations carry a `sourceId` of their own, next to the
+  // --- artifact's; both are absolute module paths at build time.
+  if (typeof maybeArtifact.sourceId === "string") {
+    (value as { sourceId: string }).sourceId = relativizeSourcePath(
+      maybeArtifact.sourceId,
+      projectRoot,
+    );
+  }
+  if (
+    typeof maybeArtifact.js === "string" &&
+    typeof maybeArtifact.target === "string" &&
+    Array.isArray(maybeArtifact.mappings)
+  ) {
+    const artifact = value as CompiledScriptArtifact;
+    artifact.mappings = [];
+    artifact.sources = [];
+    delete artifact.sourceText;
+    delete artifact.sourceUrl;
+    delete artifact.displayName;
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => stripCompiledArtifactDebugData(item, projectRoot));
+    return;
+  }
+  Object.values(value).forEach((item) => stripCompiledArtifactDebugData(item, projectRoot));
+}
+
+/**
+ * Turns an absolute path prefix into a project-relative one so build output does not
+ * carry the developer's directory layout.
+ */
+function relativizeSourcePath(sourcePath: string, projectRoot: string): string {
+  if (!projectRoot) {
+    return sourcePath;
+  }
+  const normalizedRoot = projectRoot.endsWith("/") ? projectRoot : `${projectRoot}/`;
+  return sourcePath.startsWith(normalizedRoot)
+    ? `/${sourcePath.slice(normalizedRoot.length)}`
+    : sourcePath;
 }
 
 function collectCompiledArtifacts(value: unknown, artifacts: CompiledScriptArtifact[] = []) {
@@ -514,6 +570,22 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
       sourceOrigin,
     };
   };
+  // --- Code-behind compilation warnings (`Globals.xs`, `.xmlui.xs`, inline
+  // --- `<script>`). The collector records why a declaration function fell back to
+  // --- interpretation; before, that reason was computed and then dropped, which is
+  // --- what made compilation fallbacks look silent.
+  const pendingCodeBehindWarnings: string[] = [];
+  const collectCodeBehindWarnings = (codeBehind: { warnings?: string[] } | undefined) => {
+    if (codeBehind?.warnings?.length) {
+      pendingCodeBehindWarnings.push(...codeBehind.warnings);
+    }
+  };
+  const drainCodeBehindWarnings = (warn: (message: string) => void) => {
+    while (pendingCodeBehindWarnings.length > 0) {
+      warn(`[xmlui] ${pendingCodeBehindWarnings.shift()}`);
+    }
+  };
+
   // --- Build-time script compilation accounting. Without it, an app that asks
   // --- for `compileScripts` but never reaches the compiler (a misplaced or
   // --- unreadable config) looks exactly like an app that compiled fine.
@@ -674,6 +746,7 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
           collectorSources,
         ),
       );
+      collectCodeBehindWarnings(codeBehind);
       removeCodeBehindTokensFromTree(codeBehind);
       inlineComponent.component = {
         ...inlineComponent.component,
@@ -755,6 +828,7 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
                 collectorSources,
               ),
             );
+            collectCodeBehindWarnings(codeBehind);
             removeCodeBehindTokensFromTree(codeBehind);
 
             // --- Display any module errors or warnings found
@@ -789,6 +863,7 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
         if (warnings.length > 0) {
           warnings.forEach((msg) => this.warn(`[xmlui] ${msg}`));
         }
+        drainCodeBehindWarnings((message) => this.warn(message));
 
         // --- Run static analyzer when not disabled
         if (analyzeMode !== "off") {
@@ -963,6 +1038,9 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
           ...(sourceMapsEnabled() ? { debugSources } : {}),
         };
         recordCompiledScripts(file);
+        if (!sourceMapsEnabled()) {
+          stripCompiledArtifactDebugData(file, projectRoot);
+        }
         const outputCode = browserWarningLogCode(warnings) + dataToEsm(file);
         const map = sourceMapsEnabled()
           ? createTransformSourceMap(outputCode, fileId, debugSources)
@@ -1027,7 +1105,9 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
             collectorSources,
           ),
         );
+        collectCodeBehindWarnings(codeBehind);
         removeCodeBehindTokensFromTree(codeBehind);
+        drainCodeBehindWarnings((message) => this.warn(message));
 
         // --- Display any module errors as warnings
         if (codeBehind.moduleErrors && Object.keys(codeBehind.moduleErrors).length > 0) {
@@ -1064,6 +1144,9 @@ export default function viteXmluiPlugin(pluginOptions: PluginOptions = {}): Plug
         const debugSources = Array.from(debugSourcesById.values());
         virtualSources?.registerAll(debugSources);
         recordCompiledScripts(codeBehind);
+        if (!sourceMapsEnabled()) {
+          stripCompiledArtifactDebugData(codeBehind, projectRoot);
+        }
         const outputCode = dataToEsm({
           ...codeBehind,
           src: code,

--- a/xmlui/src/parsers/scripting/code-behind-collect.ts
+++ b/xmlui/src/parsers/scripting/code-behind-collect.ts
@@ -19,6 +19,7 @@ import { clearAllModuleCaches } from "./ModuleCache";
 import { ModuleLoader } from "./ModuleLoader";
 import { compileEventAsyncStatements } from "../../components-core/script-compiler/targets/event-async";
 import { createDebugSourceUrl } from "../../components-core/script-compiler/source";
+import { describeCompiledScriptFallback } from "../../components-core/script-compiler/errors";
 import type {
   CompiledScriptSource,
   CompiledScriptSourceMapMode,
@@ -304,10 +305,12 @@ function attachCompiledFunctionArtifact(
     arrow.compiledUnsupported = false;
     arrow.sourceRange = arrow.compiled.sourceRange;
   } catch (error) {
+    const reason = describeCompiledScriptFallback(error);
     arrow.compiledUnsupported = true;
+    arrow.compiledUnsupportedReason = reason;
     (context.result.warnings ??= []).push(
-      `Could not compile code-behind function ${sourceId}; ` +
-        `falling back to interpreted execution. ${(error as Error).message}`,
+      `Could not compile code-behind function ${sourceId} (${reason}); ` +
+        `falling back to interpreted execution.`,
     );
   }
 }

--- a/xmlui/src/parsers/xmlui-parser/transform.ts
+++ b/xmlui/src/parsers/xmlui-parser/transform.ts
@@ -18,6 +18,7 @@ import type { GetText, XmluiParserOptions } from "./parser";
 import type { ParsedEventValue } from "../../abstractions/scripting/Compilation";
 import { compileEventAsyncStatements } from "../../components-core/script-compiler/targets/event-async";
 import { createDebugSourceUrl } from "../../components-core/script-compiler/source";
+import { describeCompiledScriptFallback } from "../../components-core/script-compiler/errors";
 import { extractEventHandlerDirectives } from "../../components-core/utils/event-handler-directives";
 import { prepareCompiledHandlerStatements } from "../../components-core/utils/statementUtils";
 import { DIAGS_TRANSFORM, TransformDiag, type TransformDiagPositionless } from "./diagnostics";
@@ -1527,6 +1528,7 @@ function transformXmluiNode(
       const sourceId = `${fileId}#event-${parseId}`;
       let compiled: ParsedEventValue["compiled"] | undefined;
       let compiledUnsupported = false;
+      let compiledUnsupportedReason: string | undefined;
       if (parserOptions.compileEventHandlers) {
         try {
           const compileOptions = {
@@ -1558,9 +1560,10 @@ function transformXmluiNode(
           }
         } catch (error) {
           compiledUnsupported = true;
+          compiledUnsupportedReason = describeCompiledScriptFallback(error);
           const message =
-            `Could not compile event handler ${sourceId}; ` +
-            `falling back to interpreted execution. ${(error as Error).message}`;
+            `Could not compile event handler ${sourceId} (${compiledUnsupportedReason}); ` +
+            `falling back to interpreted execution.`;
           if (warnings) {
             warnings.push(message);
           }
@@ -1582,6 +1585,7 @@ function transformXmluiNode(
         source: value,
         compiled,
         compiledUnsupported,
+        ...(compiledUnsupportedReason ? { compiledUnsupportedReason } : {}),
       } as ParsedEventValue;
     } catch {
       if (parser.errors.length > 0) {

--- a/xmlui/tests-e2e/compiled-declaration-parity.spec.ts
+++ b/xmlui/tests-e2e/compiled-declaration-parity.spec.ts
@@ -257,7 +257,8 @@ test.describe("compiled declaration parity", () => {
       expected: 21,
     },
     {
-      name: "unsupported compiled declaration falls back to interpreted execution",
+      // --- `new` compiles since plan #3879; kept as a parity case for constructors.
+      name: "declaration constructing an object",
       source: `<Button testId="run" onClick="testState = epochYear()">Run</Button>`,
       description: {
         codeBehind: `
@@ -268,6 +269,12 @@ test.describe("compiled declaration parity", () => {
       },
       expected: 1970,
     },
+    // --- There is no longer a construct that a declaration can both fall back on and
+    // --- still execute: since plan #3879 the compiler covers everything the
+    // --- interpreter runs, and what is left (`await`, async arrows) is rejected by
+    // --- both. The fallback path itself is covered by
+    // --- `tests/parsers/scripting/code-behind-import.test.ts` and
+    // --- `tests/components-core/compiled-events/event-async-handler-arrow.test.ts`.
   ];
 
   for (const testCase of cases) {

--- a/xmlui/tests/bin/vite-plugin-import.test.ts
+++ b/xmlui/tests/bin/vite-plugin-import.test.ts
@@ -322,7 +322,7 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
         `,
         join(srcDir, "Main.xmlui"),
         dir,
-        { compileEventHandlers: true },
+        { compileEventHandlers: true, compiledScriptSourceMaps: "external" },
       );
 
       const mod = await importGeneratedModule(result.code);
@@ -426,7 +426,7 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
         `<Button onClick="count = count + 1" />`,
         "/project/src/Main.xmlui",
         "/project",
-        { compileEventHandlers: true },
+        { compileEventHandlers: true, compiledScriptSourceMaps: "external" },
       );
 
       const mod = await importGeneratedModule(result.code);
@@ -444,7 +444,7 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
         `<Button onClick="count = count + 1" />`,
         "/project/src/Main.xmlui",
         "/project",
-        { compileScripts: true },
+        { compileScripts: true, compiledScriptSourceMaps: "external" },
       );
 
       const mod = await importGeneratedModule(result.code);
@@ -481,6 +481,7 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
       const source = `<App><script>function add(a, b) { return a + b; }</script></App>`;
       const { result } = await transformXmlui(source, "/project/src/Main.xmlui", "/project", {
         compileEventHandlers: true,
+        compiledScriptSourceMaps: "external",
       });
 
       const mod = await importGeneratedModule(result.code);
@@ -509,6 +510,7 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
 </App>`;
       const { result } = await transformXmlui(source, "/project/src/Main.xmlui", "/project", {
         compileEventHandlers: true,
+        compiledScriptSourceMaps: "external",
       });
 
       const mod = await importGeneratedModule(result.code);
@@ -533,7 +535,7 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
         `<App><script>function add(a, b) { return a + b; }</script></App>`,
         "/project/src/Main.xmlui",
         "/project",
-        { compileScripts: true },
+        { compileScripts: true, compiledScriptSourceMaps: "external" },
       );
 
       const mod = await importGeneratedModule(result.code);
@@ -706,6 +708,71 @@ describe("Vite Plugin Import Integration (Built Mode)", () => {
     });
   });
 
+  describe("Production artifact hygiene", () => {
+    const HANDLER_APP = `<Button onClick="count = count + 1" />`;
+
+    it("omits source text, developer paths, and mappings when source maps are off", async () => {
+      const { result } = await transformXmlui(HANDLER_APP, "/project/src/Main.xmlui", "/project", {
+        compileScripts: true,
+      });
+
+      const mod = await importGeneratedModule(result.code);
+      const compiled = mod.default.component.events.click.compiled;
+
+      expect(compiled.js).toContain("return (async () =>");
+      expect(compiled.sourceText).toBeUndefined();
+      expect(compiled.sourceUrl).toBeUndefined();
+      expect(compiled.displayName).toBeUndefined();
+      expect(compiled.sources).toEqual([]);
+      expect(compiled.mappings).toEqual([]);
+    });
+
+    it("keeps the debug payload when source maps are requested", async () => {
+      const { result } = await transformXmlui(HANDLER_APP, "/project/src/Main.xmlui", "/project", {
+        compileScripts: true,
+        compiledScriptSourceMaps: "external",
+      });
+
+      const mod = await importGeneratedModule(result.code);
+      const compiled = mod.default.component.events.click.compiled;
+
+      expect(compiled.sourceText).toBe("count = count + 1");
+      expect(compiled.mappings.length).toBeGreaterThan(0);
+    });
+
+    it("rewrites absolute artifact source ids to project-relative ones", async () => {
+      const { result } = await transformXmlui(
+        `<App><script>function add(a, b) { return a + b; }</script></App>`,
+        "/project/src/Main.xmlui",
+        "/project",
+        { compileScripts: true },
+      );
+
+      const mod = await importGeneratedModule(result.code);
+      const sourceId = mod.default.component.scriptCollected.functions.add.compiled.sourceId;
+
+      expect(sourceId).toBe("/src/Main.xmlui#function-add");
+      expect(result.code).not.toContain("/project/src/Main.xmlui");
+    });
+
+    it("shrinks the emitted module compared with the source-map build", async () => {
+      const { result: lean } = await transformXmlui(
+        HANDLER_APP,
+        "/project/src/Main.xmlui",
+        "/project",
+        { compileScripts: true },
+      );
+      const { result: withMaps } = await transformXmlui(
+        HANDLER_APP,
+        "/project/src/Main.xmlui",
+        "/project",
+        { compileScripts: true, compiledScriptSourceMaps: "external" },
+      );
+
+      expect(lean.code.length).toBeLessThan(withMaps.code.length / 2);
+    });
+  });
+
   describe("Compiled Script Reporting", () => {
     async function buildWithSummary(code: string, options: Partial<PluginOptions> = {}) {
       const plugin = viteXmluiPlugin({
@@ -828,6 +895,7 @@ function run(value) { return double(value); }`;
       const source = `function run(value) { return value + 1; }`;
       const { result } = await transformXmlui(source, "/project/src/Main.xmlui.xs", "/project", {
         compileEventHandlers: true,
+        compiledScriptSourceMaps: "external",
       });
 
       const mod = await importGeneratedModule(result.code);
@@ -848,6 +916,7 @@ function run(value) { return double(value); }`;
       const source = `function run(value) { return value + 1; }`;
       const { result } = await transformXmlui(source, "/project/src/Main.xmlui.xs", "/project", {
         compileScripts: true,
+        compiledScriptSourceMaps: "external",
       });
 
       const mod = await importGeneratedModule(result.code);
@@ -861,6 +930,7 @@ function run(value) { return double(value); }`;
       const source = `function formatName(value) { return value.toUpperCase(); }`;
       const { result } = await transformXmlui(source, "/project/src/Globals.xs", "/project", {
         compileEventHandlers: true,
+        compiledScriptSourceMaps: "external",
       });
 
       const mod = await importGeneratedModule(result.code);

--- a/xmlui/tests/components-core/compiled-events/deferred-callback-cancel.test.ts
+++ b/xmlui/tests/components-core/compiled-events/deferred-callback-cancel.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileEventAsyncStatementSource,
+  executeCompiledEventAsyncArtifact,
+} from "../../../src/components-core/script-compiler";
+
+/**
+ * A handler often hands a callback to something that invokes it later — `debounce`,
+ * a timer, a subscription. The dispatcher aborts the run's `$cancel` token in its
+ * `finally`, on normal completion as well as supersession, so by the time such a
+ * callback runs its originating token is always aborted. It must still run: the
+ * interpreted path never consulted `$cancel` for these, and a compiled one that
+ * throws `HandlerCancelledError` silently drops the app's work.
+ */
+function createEvalContext(localContext: Record<string, any>) {
+  return {
+    localContext,
+    eventArgs: [],
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  } as any;
+}
+
+function abortedCancelToken() {
+  return {
+    aborted: true,
+    throwIfAborted() {
+      const error = new Error("Handler cancelled (user)");
+      error.name = "HandlerCancelledError";
+      throw error;
+    },
+  };
+}
+
+const DEBOUNCE_HANDLER = `e => {
+  changed++;
+  schedule((term) => {
+    results = term ? [term] : [];
+    invoked++;
+  }, e);
+}`;
+
+describe("callbacks invoked after their handler finished", () => {
+  it("runs a deferred callback even though the handler's $cancel was aborted", async () => {
+    let deferred: (() => Promise<void>) | undefined;
+    const localContext: Record<string, any> = {
+      changed: 0,
+      invoked: 0,
+      results: [],
+      schedule: (fn: (value: string) => any, value: string) => {
+        deferred = async () => {
+          await fn(value);
+        };
+      },
+    };
+    const evalContext = createEvalContext(localContext);
+    const artifact = compileEventAsyncStatementSource(
+      DEBOUNCE_HANDLER,
+      "deferred#debounce-handler",
+    );
+
+    evalContext.eventArgs = ["Laptop"];
+    await executeCompiledEventAsyncArtifact(artifact, evalContext);
+    expect(localContext.changed).toBe(1);
+
+    // --- What the dispatcher does once the handler settles.
+    localContext.$cancel = abortedCancelToken();
+
+    await expect(deferred?.()).resolves.toBeUndefined();
+    expect(localContext.results).toEqual(["Laptop"]);
+    expect(localContext.invoked).toBe(1);
+  });
+
+  it("still cancels while the handler itself is running", async () => {
+    const localContext: Record<string, any> = {
+      steps: 0,
+      trip: () => {
+        localContext.$cancel = abortedCancelToken();
+      },
+    };
+    const evalContext = createEvalContext(localContext);
+    const artifact = compileEventAsyncStatementSource(
+      "steps++; trip(); steps++;",
+      "deferred#cancel-mid-run",
+    );
+
+    await expect(executeCompiledEventAsyncArtifact(artifact, evalContext)).rejects.toThrow(
+      /cancelled/i,
+    );
+    expect(localContext.steps).toBe(1);
+  });
+});

--- a/xmlui/tests/components-core/compiled-events/event-async-arrow-and-codebehind.test.ts
+++ b/xmlui/tests/components-core/compiled-events/event-async-arrow-and-codebehind.test.ts
@@ -491,20 +491,34 @@ describe("compiled event-async arrow and callback calls", () => {
       );
     });
 
-    it("still falls back to a lazy arrow when the callback uses syntax the native emitter cannot compile", async () => {
-      // A comma (sequence) expression is not supported by the native expression
-      // emitter, so this callback must fall back to `runtime.arrow(...)` rather than
-      // failing the whole handler's compilation.
+    it("compiles a sequence expression in a callback natively", async () => {
+      // Comma (sequence) expressions used to force the lazy `runtime.arrow(...)` path;
+      // the native emitter handles them now (plan #3879).
       const source = "result = items.some(item => (item, item.id === target));";
-      const artifact = compileEventAsyncStatementSource(source, "test:event:unsupported-arrow-fallback");
+      const artifact = compileEventAsyncStatementSource(
+        source,
+        "test:event:sequence-arrow-native",
+      );
 
-      expect(artifact.js).toContain("runtime.arrow(");
+      expect(artifact.js).not.toContain("runtime.arrow(");
 
       await expectCompiledParity(source, {
         items: [{ id: 1 }, { id: 2 }],
         target: 2,
         result: false,
       });
+    });
+
+    it("still falls back to a lazy arrow when the callback uses syntax the native emitter cannot compile", () => {
+      // `await` is not part of XMLScript, so the native emitter refuses the callback
+      // and it keeps the lazy `runtime.arrow(...)` representation rather than failing
+      // the whole handler's compilation.
+      const artifact = compileEventAsyncStatementSource(
+        "result = items.some(item => (await item).id === target);",
+        "test:event:unsupported-arrow-fallback",
+      );
+
+      expect(artifact.js).toContain("runtime.arrow(");
     });
 
     it("still requires native compilation (and can fail the handler) when the callback closes over a compiled local", () => {
@@ -515,7 +529,7 @@ describe("compiled event-async arrow and callback calls", () => {
       // falling back to a lazy arrow that would produce wrong results.
       expect(() =>
         compileEventAsyncStatementSource(
-          "let target = 2; result = items.some(item => (item, item.id === target));",
+          "let target = 2; result = items.some(item => (await item).id === target);",
           "test:event:unsupported-local-referencing-arrow",
         ),
       ).toThrow();

--- a/xmlui/tests/components-core/compiled-events/event-async-handler-arrow-runtime.test.ts
+++ b/xmlui/tests/components-core/compiled-events/event-async-handler-arrow-runtime.test.ts
@@ -29,10 +29,16 @@ import {
   parseHandlerCode,
   prepareHandlerStatements,
 } from "../../../src/components-core/utils/statementUtils";
+import { processStatementQueueAsync } from "../../../src/components-core/script-runner/process-statement-async";
+import { UnsupportedCompiledScriptNodeError } from "../../../src/components-core/script-compiler";
 
 const interpreterEntries = executeArrowExpression as unknown as ReturnType<typeof vi.fn>;
 
-/** Runs a handler through the compiled pipeline, reporting its observable side effects. */
+/**
+ * Runs a handler the way `container/event-handlers.ts` does: compiled when the target
+ * supports the source, interpreted when compilation reports an unsupported node.
+ * Returns how many times the tree-walking arrow executor was entered.
+ */
 async function runCompiledHandler(source: string, localContext: Record<string, any>) {
   interpreterEntries.mockClear();
   const evalContext = createEvalContext({
@@ -40,11 +46,18 @@ async function runCompiledHandler(source: string, localContext: Record<string, a
     eventArgs: [],
     options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
   });
-  const artifact = compileEventAsyncStatements(
-    prepareHandlerStatements(parseHandlerCode(source)),
-    { sourceId: `test:runtime-proof:${source}` },
-  );
-  await executeCompiledEventAsyncArtifact(artifact, evalContext);
+  const statements = prepareHandlerStatements(parseHandlerCode(source));
+  try {
+    const artifact = compileEventAsyncStatements(statements, {
+      sourceId: `test:runtime-proof:${source}`,
+    });
+    await executeCompiledEventAsyncArtifact(artifact, evalContext);
+  } catch (error) {
+    if (!(error instanceof UnsupportedCompiledScriptNodeError)) {
+      throw error;
+    }
+    await processStatementQueueAsync(statements, evalContext);
+  }
   return interpreterEntries.mock.calls.length;
 }
 
@@ -86,18 +99,19 @@ describe("arrow event handlers execute as compiled code, not interpreted AST", (
     expect(entries).toBe(0);
   });
 
-  it("control: an unsupported body still falls back to the interpreter", async () => {
-    // --- Spread call arguments are not supported by the native emitter, so this handler
-    // --- keeps the lazy-arrow path. It proves the spy above genuinely detects interpreted
-    // --- execution, so `toBe(0)` in the tests above is a real signal rather than a spy
+  it("control: an arrow inside a data literal still runs through the interpreter", async () => {
+    // --- Callback arguments and arrow-valued declarations are compiled natively, but an
+    // --- arrow stored inside an object literal keeps the lazy representation, so calling
+    // --- it enters the tree-walking executor. This proves the spy genuinely detects
+    // --- interpreted execution, making `toBe(0)` above a real signal rather than a spy
     // --- that was never wired up.
     const seen: any[] = [];
-    const entries = await runCompiledHandler("() => { collect(...items); }", {
-      items: [1, 2, 3],
-      collect: (...args: any[]) => seen.push(args),
-    });
+    const entries = await runCompiledHandler(
+      "() => { const ops = { double: item => item * 2 }; collect(ops.double(21)); }",
+      { collect: (...args: any[]) => seen.push(args) },
+    );
 
-    expect(seen).toEqual([[1, 2, 3]]);
+    expect(seen).toEqual([[42]]);
     expect(entries).toBeGreaterThan(0);
   });
 });

--- a/xmlui/tests/components-core/compiled-events/event-async-handler-arrow.test.ts
+++ b/xmlui/tests/components-core/compiled-events/event-async-handler-arrow.test.ts
@@ -243,17 +243,28 @@ describe("compiled event handlers written as arrow functions", () => {
   });
 
   describe("preserve the interpreted fallback", () => {
-    it("falls back to the lazy arrow when the body uses an unsupported construct", async () => {
-      // --- Spread call arguments are not supported by the native emitter.
+    it("compiles spread call arguments natively", async () => {
+      // --- Spread arguments used to force the lazy-arrow path; they are now emitted
+      // --- natively, with the operand rules the interpreter applies (plan #3879).
       const source = "() => { collect(...items); }";
       const { js } = compileHandler(source);
 
-      expect(usesInterpretedArrow(js)).toBe(true);
-      expect(js).not.toContain("runtime.callNativeArrow(");
+      expect(usesInterpretedArrow(js)).toBe(false);
+      expect(js).toContain("runtime.spreadCallArg(");
 
       const seen: any[] = [];
       await runCompiled(source, { items: [1, 2, 3], collect: (...args: any[]) => seen.push(args) });
       expect(seen).toEqual([[1, 2, 3]]);
+    });
+
+    it("falls back to the lazy arrow when the body uses an unsupported construct", async () => {
+      // --- `await` is not part of XMLScript, so the native emitter refuses it and the
+      // --- callback keeps the lazy (interpreted) arrow path.
+      const source = "() => { collect(await items); }";
+      const { js } = compileHandler(source);
+
+      expect(usesInterpretedArrow(js)).toBe(true);
+      expect(js).not.toContain("runtime.callNativeArrow(");
     });
 
     it("fails compilation rather than emitting a lazy arrow that cannot see compiled locals", () => {
@@ -262,7 +273,7 @@ describe("compiled event handlers written as arrow functions", () => {
       // --- silently resolve `extra` against the interpreter's scope instead, so compilation
       // --- must fail and let the whole handler fall back to interpreted execution.
       expect(() =>
-        compileHandler("const extra = 5; (items) => { collect(extra, ...items); }"),
+        compileHandler("const extra = 5; (items) => { collect(extra, await items); }"),
       ).toThrow(/Unsupported/);
     });
 

--- a/xmlui/tests/components-core/script-compiler/event-async-parity.test.ts
+++ b/xmlui/tests/components-core/script-compiler/event-async-parity.test.ts
@@ -189,6 +189,12 @@ describe("compiled event handlers — spread operands", () => {
     expected: 2020,
   });
 
+  itRunsBothWays("ignores a null object-spread operand", {
+    source: "return { ...missing, a: 1 };",
+    context: { missing: null },
+    expected: { a: 1 },
+  });
+
   it("rejects a non-array spread operand the same way the interpreter does", async () => {
     const source = "return [...value];";
     const context = { value: 42 };

--- a/xmlui/tests/components-core/script-compiler/event-async-parity.test.ts
+++ b/xmlui/tests/components-core/script-compiler/event-async-parity.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileEventAsyncStatementSource,
+  executeCompiledEventAsyncArtifact,
+} from "../../../src/components-core/script-compiler";
+import { Parser } from "../../../src/parsers/scripting/Parser";
+import { processStatementQueueAsync } from "../../../src/components-core/script-runner/process-statement-async";
+
+/**
+ * Parity harness for plan #3879: every snippet is executed twice — once through the
+ * interpreter, once through the compiled artifact — and both the returned value and
+ * the resulting local context must agree. A construct that only *compiles* is not
+ * enough; it has to mean the same thing either way.
+ */
+type ParityCase = {
+  /** Statement source, written as the body of an event handler. */
+  source: string;
+  /** Initial local context; each run gets its own deep copy. */
+  context?: Record<string, any>;
+  /** Expected shared result, asserted against both runs. */
+  expected: unknown;
+};
+
+function cloneContext(context: Record<string, any>): Record<string, any> {
+  // --- Not `structuredClone`: several cases put host functions in the context.
+  return Object.fromEntries(
+    Object.entries(context).map(([key, value]) => [
+      key,
+      typeof value === "function" ? value : JSON.parse(JSON.stringify(value ?? null)),
+    ]),
+  );
+}
+
+function createEvalContext(context: Record<string, any>) {
+  return {
+    localContext: cloneContext(context),
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  } as any;
+}
+
+async function runInterpreted(source: string, context: Record<string, any>) {
+  const statements = new Parser(source).parseStatements();
+  const evalContext = createEvalContext(context);
+  await processStatementQueueAsync(statements, evalContext);
+  // --- The interpreter parks a handler's return value on the thread; the compiled
+  // --- path returns it directly (the dispatcher normalises both, see
+  // --- `container/event-handlers.ts`).
+  return {
+    value: evalContext.mainThread?.returnValue,
+    context: evalContext.localContext,
+  };
+}
+
+async function runCompiled(source: string, context: Record<string, any>, sourceId: string) {
+  const artifact = compileEventAsyncStatementSource(source, sourceId);
+  const evalContext = createEvalContext(context);
+  const value = await executeCompiledEventAsyncArtifact(artifact, evalContext);
+  return { value, context: evalContext.localContext, artifact };
+}
+
+function itRunsBothWays(name: string, testCase: ParityCase) {
+  it(name, async () => {
+    const context = testCase.context ?? {};
+    const interpreted = await runInterpreted(testCase.source, context);
+    const compiled = await runCompiled(testCase.source, context, `parity#${name}`);
+
+    expect(compiled.value).toEqual(testCase.expected);
+    expect(interpreted.value).toEqual(testCase.expected);
+    expect(compiled.context).toEqual(interpreted.context);
+  });
+}
+
+describe("compiled event handlers — conditional expressions", () => {
+  // --- The five declaration bodies quoted verbatim in the bug report; each one
+  // --- fell back to interpretation before conditional expressions were supported.
+  itRunsBothWays("compiles a single-return ternary (testCaseTypeLabel)", {
+    source: "return value === 1 ? 'Automata' : 'Manualis';",
+    context: { value: 1 },
+    expected: "Automata",
+  });
+
+  itRunsBothWays("compiles a ternary over a status code (suiteFactTone)", {
+    source: "return status === 2 ? 'warn' : 'neutral';",
+    context: { status: 3 },
+    expected: "neutral",
+  });
+
+  itRunsBothWays("compiles a ternary with a compound condition (submitterLabel)", {
+    source: "return myName && name === myName ? 'Me' : name;",
+    context: { name: "Ada", myName: "Ada" },
+    expected: "Me",
+  });
+
+  itRunsBothWays("compiles a ternary whose branch calls a function (toneIconColor)", {
+    source: "return tone === 'neutral' ? '$color-primary-500' : fallback(tone);",
+    context: { tone: "warn", fallback: (value: string) => `tone-${value}` },
+    expected: "tone-warn",
+  });
+
+  itRunsBothWays("compiles nested ternaries (roleLabel)", {
+    source: "return role === 2 ? 'Admin' : (role === 1 ? 'Editor' : 'Viewer');",
+    context: { role: 1 },
+    expected: "Editor",
+  });
+
+  itRunsBothWays("compiles a ternary in a declaration initializer", {
+    source: "const label = flag ? 'on' : 'off'; return label;",
+    context: { flag: false },
+    expected: "off",
+  });
+
+  itRunsBothWays("compiles a ternary inside a template literal", {
+    source: "return `state: ${flag ? 'on' : 'off'}`;",
+    context: { flag: true },
+    expected: "state: on",
+  });
+
+  itRunsBothWays("compiles a ternary passed as a call argument", {
+    source: "return wrap(flag ? 1 : 2);",
+    context: { flag: false, wrap: (value: number) => value * 10 },
+    expected: 20,
+  });
+
+  it("does not evaluate the untaken branch", async () => {
+    const source = "return flag ? safe() : boom();";
+    const context = {
+      flag: true,
+      safe: () => "ok",
+      boom: () => {
+        throw new Error("untaken branch was evaluated");
+      },
+    };
+
+    const compiled = await runCompiled(source, context, "parity#lazy-branch");
+    const interpreted = await runInterpreted(source, context);
+
+    expect(compiled.value).toBe("ok");
+    expect(interpreted.value).toBe("ok");
+  });
+});
+
+describe("compiled event handlers — sequence expressions", () => {
+  itRunsBothWays("evaluates every operand and yields the last", {
+    source: "let a = 0; const b = ((a = a + 1), (a = a + 2), a + 10); return [a, b];",
+    expected: [3, 13],
+  });
+});
+
+describe("compiled event handlers — new expressions", () => {
+  itRunsBothWays("constructs an allowed class", {
+    source: "const d = new Date(0); return d.getTime();",
+    expected: 0,
+  });
+
+  itRunsBothWays("constructs with arguments", {
+    source: "const e = new Error('boom'); return e.message;",
+    expected: "boom",
+  });
+
+  itRunsBothWays("throws a constructed error object", {
+    source: "try { throw new Error('nope'); } catch (err) { return err.message; }",
+    expected: "nope",
+  });
+});
+
+describe("compiled event handlers — spread operands", () => {
+  itRunsBothWays("spreads into an array literal", {
+    source: "return [0, ...items, 9];",
+    context: { items: [1, 2] },
+    expected: [0, 1, 2, 9],
+  });
+
+  itRunsBothWays("spreads into a call", {
+    source: "return pick(...items);",
+    context: { items: [3, 7], pick: (a: number, b: number) => a + b },
+    expected: 10,
+  });
+
+  itRunsBothWays("spreads into an object literal", {
+    source: "return { ...base, b: 2 };",
+    context: { base: { a: 1 } },
+    expected: { a: 1, b: 2 },
+  });
+
+  itRunsBothWays("spreads into a new expression", {
+    source: "const d = new Date(...parts); return d.getFullYear();",
+    context: { parts: [2020, 0, 1] },
+    expected: 2020,
+  });
+
+  it("rejects a non-array spread operand the same way the interpreter does", async () => {
+    const source = "return [...value];";
+    const context = { value: 42 };
+
+    await expect(runCompiled(source, context, "parity#bad-spread")).rejects.toThrow(
+      "Spread operator within an array literal expects an array operand.",
+    );
+    await expect(runInterpreted(source, context)).rejects.toThrow(
+      "Spread operator within an array literal expects an array operand.",
+    );
+  });
+});
+
+describe("compiled event handlers — arrow callbacks over the new constructs", () => {
+  itRunsBothWays("compiles a ternary inside an array callback", {
+    source: "return rows.map(row => row.id === target ? 'hit' : 'miss');",
+    context: { target: 2, rows: [{ id: 1 }, { id: 2 }] },
+    expected: ["miss", "hit"],
+  });
+
+  itRunsBothWays("compiles a ternary inside a filter predicate", {
+    source: "return rows.filter(row => (row.tag ? row.tag : 'none') === 'none');",
+    context: { rows: [{ id: 1, tag: "a" }, { id: 2 }] },
+    expected: [{ id: 2 }],
+  });
+
+  it("keeps an arrow callback with a ternary on the native compiled path", () => {
+    const artifact = compileEventAsyncStatementSource(
+      "return rows.some(row => row.id === target ? true : false);",
+      "parity#native-arrow-ternary",
+    );
+
+    // --- `runtime.arrow(` marks the lazy fallback that hands the callback body back
+    // --- to the interpreter; a natively compiled callback never emits it.
+    expect(artifact.js).not.toContain("runtime.arrow(");
+    expect(artifact.js).toContain("=>");
+  });
+});

--- a/xmlui/tests/components-core/script-compiler/event-async.test.ts
+++ b/xmlui/tests/components-core/script-compiler/event-async.test.ts
@@ -415,9 +415,27 @@ describe("event-async compiled script target", () => {
   });
 
   it("throws a structured unsupported error for unsupported nodes", () => {
+    // --- `await` is not part of XMLScript, so no target compiles it.
     expect(() =>
-      compileEventAsyncStatementSource("count = enabled ? 1 : 2;", "Main.xmlui#event-4"),
+      compileEventAsyncStatementSource("count = await getValue();", "Main.xmlui#event-4"),
     ).toThrow(UnsupportedCompiledScriptNodeError);
+  });
+
+  it("compiles conditional, sequence, new, and spread expressions", () => {
+    const sources = [
+      "count = enabled ? 1 : 2;",
+      "count = ((a = 1), (a + 1));",
+      "stamp = new Date(0);",
+      "collect(...items);",
+      "list = [...items, 1];",
+      "merged = { ...base, b: 2 };",
+    ];
+
+    for (const source of sources) {
+      expect(() =>
+        compileEventAsyncStatementSource(source, `Main.xmlui#event-supported:${source}`),
+      ).not.toThrow();
+    }
   });
 
   it("throws a structured unsupported error for non-serializable literals", () => {
@@ -431,7 +449,7 @@ describe("event-async compiled script target", () => {
 
   it("prefers a parse-time artifact over runtime AST compilation", async () => {
     const artifact = compileEventAsyncStatementSource("count = count + 1;", "Main.xmlui#event-5");
-    const unsupportedStatements = new Parser("count = enabled ? 1 : 2;").parseStatements();
+    const unsupportedStatements = new Parser("count = await getValue();").parseStatements();
     const evalContext = {
       localContext: { count: 1, enabled: true },
       options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
@@ -443,14 +461,14 @@ describe("event-async compiled script target", () => {
       undefined,
       artifact,
       "Main.xmlui#event-unsupported",
-      "count = enabled ? 1 : 2;",
+      "count = await getValue();",
     );
 
     expect(evalContext.localContext.count).toBe(2);
   });
 
   it("runtime-compiles and cache keys statement handlers when no artifact exists", async () => {
-    const unsupportedStatements = new Parser("count = enabled ? 1 : 2;").parseStatements();
+    const unsupportedStatements = new Parser("count = await getValue();").parseStatements();
     const evalContext = {
       localContext: { count: 1, enabled: true },
       options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
@@ -463,7 +481,7 @@ describe("event-async compiled script target", () => {
         undefined,
         undefined,
         "Main.xmlui#event-runtime",
-        "count = enabled ? 1 : 2;",
+        "count = await getValue();",
       ),
     ).rejects.toBeInstanceOf(UnsupportedCompiledScriptNodeError);
   });

--- a/xmlui/tests/components-core/script-compiler/script-inventory.test.ts
+++ b/xmlui/tests/components-core/script-compiler/script-inventory.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectParsedScriptInventory,
+  formatParsedScriptInventory,
+} from "../../../src/components-core/script-compiler/script-inventory";
+
+function parsedScript(extra: Record<string, any> = {}) {
+  return {
+    __PARSED: true,
+    statements: [{ type: 3 }],
+    parseId: 1,
+    compiledUnsupported: false,
+    ...extra,
+  };
+}
+
+describe("parsed script inventory", () => {
+  it("counts compiled, unsupported, and never-attempted blocks", () => {
+    const appDefinition = {
+      component: {
+        events: { click: parsedScript({ compiled: { js: "return 1;" } }) },
+        children: [
+          {
+            events: {
+              press: parsedScript({
+                compiledUnsupported: true,
+                compiledUnsupportedReason: "unsupported await expression (node type 119)",
+              }),
+            },
+          },
+          { events: { hover: parsedScript() } },
+        ],
+      },
+    };
+
+    expect(collectParsedScriptInventory(appDefinition)).toEqual({
+      total: 3,
+      compiled: 1,
+      unsupported: 1,
+      notAttempted: 1,
+      reasons: ["unsupported await expression (node type 119)"],
+    });
+  });
+
+  it("survives cycles in the definition graph", () => {
+    const node: any = { events: { click: parsedScript({ compiled: { js: "" } }) } };
+    node.self = node;
+
+    expect(collectParsedScriptInventory(node).compiled).toBe(1);
+  });
+
+  it("reports fallback reasons in the summary line", () => {
+    const summary = formatParsedScriptInventory({
+      total: 3,
+      compiled: 1,
+      unsupported: 2,
+      notAttempted: 0,
+      reasons: ["unsupported await expression (node type 119) at line 4, column 3"],
+    });
+
+    expect(summary).toContain("1 compiled at build time");
+    expect(summary).toContain("2 fell back to interpretation");
+    expect(summary).toContain("unsupported await expression");
+  });
+
+  it("says so when compilation is on but nothing was pre-compiled", () => {
+    const summary = formatParsedScriptInventory({
+      total: 4,
+      compiled: 0,
+      unsupported: 0,
+      notAttempted: 4,
+      reasons: [],
+    });
+
+    expect(summary).toContain("none of the 4 script block(s) carry a build-time artifact");
+    expect(summary).toContain("xmlui.config.json");
+  });
+});

--- a/xmlui/tests/components-core/script-runner/async-sort.test.ts
+++ b/xmlui/tests/components-core/script-runner/async-sort.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileEventAsyncStatementSource,
+  executeCompiledEventAsyncArtifact,
+} from "../../../src/components-core/script-compiler";
+import { Parser } from "../../../src/parsers/scripting/Parser";
+import { processStatementQueueAsync } from "../../../src/components-core/script-runner/process-statement-async";
+
+/**
+ * `Array.prototype.sort(comparator)` used to be a silent no-op in XMLScript: script
+ * callbacks are asynchronous, and the native `sort` coerced the returned promise to
+ * `NaN`, so every pair compared equal. Only the argument-less `sort()` worked.
+ * These cases pin the fix on both execution paths.
+ */
+async function runInterpreted(source: string, context: Record<string, any> = {}) {
+  const evalContext = {
+    localContext: { ...context },
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  } as any;
+  await processStatementQueueAsync(new Parser(source).parseStatements(), evalContext);
+  return evalContext.mainThread?.returnValue;
+}
+
+async function runCompiled(source: string, context: Record<string, any> = {}) {
+  const artifact = compileEventAsyncStatementSource(source, `sort#${source}`);
+  const evalContext = {
+    localContext: { ...context },
+    options: { compileEventHandlers: true, defaultToOptionalMemberAccess: true },
+  } as any;
+  return await executeCompiledEventAsyncArtifact(artifact, evalContext);
+}
+
+function itSortsBothWays(name: string, source: string, expected: unknown) {
+  it(name, async () => {
+    await expect(runInterpreted(source)).resolves.toEqual(expected);
+    await expect(runCompiled(source)).resolves.toEqual(expected);
+  });
+}
+
+describe("Array.prototype.sort with a script comparator", () => {
+  itSortsBothWays(
+    "sorts numbers ascending in place",
+    "const a = [3, 1, 2]; a.sort((x, y) => x - y); return a;",
+    [1, 2, 3],
+  );
+
+  itSortsBothWays(
+    "returns the same array instance it sorted",
+    "const a = [3, 1, 2]; return a.sort((x, y) => x - y) === a;",
+    true,
+  );
+
+  itSortsBothWays(
+    "sorts descending",
+    "const a = [1, 3, 2]; return a.sort((x, y) => y - x);",
+    [3, 2, 1],
+  );
+
+  itSortsBothWays(
+    "sorts objects by a field",
+    "const a = [{ n: 2 }, { n: 1 }, { n: 3 }]; a.sort((p, q) => p.n - q.n); return a.map(o => o.n);",
+    [1, 2, 3],
+  );
+
+  itSortsBothWays(
+    "sorts strings with localeCompare",
+    "const a = ['b', 'a', 'c']; return a.sort((x, y) => x.localeCompare(y));",
+    ["a", "b", "c"],
+  );
+
+  itSortsBothWays(
+    "keeps the argument-less form working",
+    "const a = [3, 1, 2]; return a.sort();",
+    [1, 2, 3],
+  );
+
+  itSortsBothWays(
+    "is stable for equal keys",
+    "const a = [{ k: 1, i: 0 }, { k: 0, i: 1 }, { k: 1, i: 2 }, { k: 0, i: 3 }];" +
+      " return a.sort((p, q) => p.k - q.k).map(o => o.i);",
+    [1, 3, 0, 2],
+  );
+
+  itSortsBothWays(
+    "moves undefined entries to the end without comparing them",
+    "const a = [3, undefined, 1]; return a.sort((x, y) => x - y);",
+    [1, 3, undefined],
+  );
+
+  itSortsBothWays(
+    "leaves the receiver untouched with toSorted",
+    "const a = [3, 1, 2]; const b = a.toSorted((x, y) => x - y); return [a, b];",
+    [
+      [3, 1, 2],
+      [1, 2, 3],
+    ],
+  );
+});

--- a/xmlui/tests/components-core/script-runner/compiled-binding-path.test.ts
+++ b/xmlui/tests/components-core/script-runner/compiled-binding-path.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { evalBinding } from "../../../src/components-core/script-runner/eval-tree-sync";
+import { createBindingEvalOptions } from "../../../src/components-core/script-runner/eval-options";
+import { clearCompiledScriptDebugSourceTraceForTests } from "../../../src/components-core/script-compiler/debug-source-trace";
+import { Parser } from "../../../src/parsers/scripting/Parser";
+
+/**
+ * Runtime proof that `compileScripts` routes binding expressions — the
+ * `var.rows="{applyFilters(...)}"` shape — through the compiled executor.
+ *
+ * Bindings have no build-time artifacts: prop values are parsed lazily in the browser,
+ * so counting artifacts in a bundle cannot tell you whether bindings are compiled. The
+ * observable signal is the compiled executor's `kind:"debug-source"` Inspector trace,
+ * which only the compiled path emits.
+ */
+type TraceEntry = { kind?: string; target?: string };
+
+function traceBuffer(): TraceEntry[] {
+  return (globalThis as any).window._xsLogs as TraceEntry[];
+}
+
+function evaluate(source: string, xmluiConfig: Record<string, any>, state: Record<string, any>) {
+  clearCompiledScriptDebugSourceTraceForTests();
+  (globalThis as any).window._xsLogs = [];
+  const expr = new Parser(source).parseExpr()!;
+  const value = evalBinding(expr, {
+    localContext: state,
+    appContext: { xmluiConfig: { ...xmluiConfig, xsVerbose: true } },
+    options: createBindingEvalOptions({
+      xmluiConfig: { ...xmluiConfig, compiledScriptSourceMaps: "inline" },
+    } as any),
+  } as any);
+  return {
+    value,
+    compiledTraces: traceBuffer().filter((entry) => entry.kind === "debug-source").length,
+  };
+}
+
+const ROWS = [
+  { id: 1, name: "alpha" },
+  { id: 2, name: "beta" },
+];
+
+describe("compileScripts routes bindings through the compiled executor", () => {
+  let restoreWindow = false;
+
+  beforeEach(() => {
+    if (typeof (globalThis as any).window === "undefined") {
+      (globalThis as any).window = {};
+      restoreWindow = true;
+    }
+    (globalThis as any).window._xsLogs = [];
+  });
+
+  afterEach(() => {
+    if (restoreWindow) {
+      delete (globalThis as any).window;
+      restoreWindow = false;
+    }
+  });
+
+  it("compiles a helper-call binding", () => {
+    const { value, compiledTraces } = evaluate(
+      "applyFilters(rows, 'al')",
+      { compileScripts: true },
+      {
+        rows: ROWS,
+        applyFilters: (list: any[], q: string) => list.filter((r) => r.name.includes(q)),
+      },
+    );
+
+    expect(value).toEqual([ROWS[0]]);
+    expect(compiledTraces).toBeGreaterThan(0);
+  });
+
+  it("compiles a binding with an inline array callback", () => {
+    const { value, compiledTraces } = evaluate(
+      "rows.filter(row => row.id > 1).length",
+      { compileScripts: true },
+      { rows: ROWS },
+    );
+
+    expect(value).toBe(1);
+    expect(compiledTraces).toBeGreaterThan(0);
+  });
+
+  it("control: stays interpreted when compilation is off", () => {
+    const { value, compiledTraces } = evaluate(
+      "rows.filter(row => row.id > 1).length",
+      {},
+      { rows: ROWS },
+    );
+
+    expect(value).toBe(1);
+    expect(compiledTraces).toBe(0);
+  });
+
+  it("control: compileBindings: false opts bindings out of the umbrella switch", () => {
+    const { value, compiledTraces } = evaluate(
+      "rows.filter(row => row.id > 1).length",
+      { compileScripts: true, compileBindings: false },
+      { rows: ROWS },
+    );
+
+    expect(value).toBe(1);
+    expect(compiledTraces).toBe(0);
+  });
+});

--- a/xmlui/tests/components-core/script-runner/eval-options.test.ts
+++ b/xmlui/tests/components-core/script-runner/eval-options.test.ts
@@ -8,6 +8,8 @@ import {
 import { Parser } from "../../../src/parsers/scripting/Parser";
 import { extractParam } from "../../../src/components-core/utils/extractParam";
 import { processStatementQueueAsync } from "../../../src/components-core/script-runner/process-statement-async";
+import { parseAttributeValue } from "../../../src/components-core/script-runner/AttributeValueParser";
+import { evalBinding } from "../../../src/components-core/script-runner/eval-tree-sync";
 
 describe("binding eval options", () => {
   it("leaves compileBindings disabled by default", () => {
@@ -197,5 +199,36 @@ describe("script execution mode", () => {
       bindings: "compiled",
       eventHandlers: "interpreted",
     });
+  });
+});
+
+describe("compileScripts implies binding compilation at every call site", () => {
+  it("compiles a parsed attribute binding under the umbrella switch", () => {
+    const parsed = parseAttributeValue("{count + 1}", {
+      compileScripts: true,
+      sourceId: "Main.xmlui",
+    });
+
+    expect(parsed.segments[0].compiled).toMatchObject({ target: "binding-sync" });
+  });
+
+  it("lets compileBindings: false opt one path out", () => {
+    const parsed = parseAttributeValue("{count + 1}", {
+      compileScripts: true,
+      compileBindings: false,
+      sourceId: "Main.xmlui",
+    });
+
+    expect(parsed.segments[0].compiled).toBeUndefined();
+  });
+
+  it("evaluates a binding through the compiled path under the umbrella switch", () => {
+    const expr = new Parser("count + 1").parseExpr()!;
+    const evalContext = {
+      localContext: { count: 41 },
+      options: { compileScripts: true, defaultToOptionalMemberAccess: true },
+    } as any;
+
+    expect(evalBinding(expr, evalContext)).toBe(42);
   });
 });

--- a/xmlui/tests/nodejs/xmlui-plugin-options.test.ts
+++ b/xmlui/tests/nodejs/xmlui-plugin-options.test.ts
@@ -289,6 +289,28 @@ describe("Loading XMLUI plugin options from project files", () => {
     });
   }, 30000);
 
+  it("skips the Vite retry when xmlui.config.json already answers", async () => {
+    // --- The description needs Vite to evaluate, but `xmlui.config.json` settles the
+    // --- only key it mentions, so re-reading it could not change the outcome.
+    const cwd = await createProject({
+      "xmlui.config.json": JSON.stringify({ compileScripts: false }),
+      "src/config.ts": [
+        "const App = { appGlobals: { compileScripts: true, icons: import.meta.glob('/icons/*') } };",
+        "export default App;",
+        "",
+      ].join("\n"),
+    });
+
+    const startedAt = Date.now();
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: false,
+      compileEventHandlers: false,
+    });
+    // --- A Vite module-runner import takes hundreds of milliseconds; skipping it is
+    // --- the point of this case.
+    expect(Date.now() - startedAt).toBeLessThan(250);
+  });
+
   it("survives an app description that cannot be loaded", async () => {
     const cwd = await createProject({
       "xmlui.config.json": JSON.stringify({ compileScripts: true }),

--- a/xmlui/tests/nodejs/xmlui-plugin-options.test.ts
+++ b/xmlui/tests/nodejs/xmlui-plugin-options.test.ts
@@ -267,6 +267,28 @@ describe("Loading XMLUI plugin options from project files", () => {
     });
   });
 
+  it("reads an app description that only Vite can evaluate", async () => {
+    // --- `import.meta.glob` is a Vite transform, so a plain Node import of this file
+    // --- throws `import_meta.glob is not a function`. This is the shape the
+    // --- `getLocalIcons()` pattern in our own app templates produces.
+    const cwd = await createProject({
+      "icons/star.svg": "<svg></svg>",
+      "src/config.ts": [
+        "function getLocalIcons() {",
+        "  return import.meta.glob('/icons/**/*.svg', { import: 'default', eager: true, query: '?raw' });",
+        "}",
+        "const App = { name: 'app', icons: getLocalIcons(), appGlobals: { compileScripts: true } };",
+        "export default App;",
+        "",
+      ].join("\n"),
+    });
+
+    expect(await loadXmluiPluginOptions({ cwd })).toMatchObject({
+      compileScripts: true,
+      compileEventHandlers: true,
+    });
+  }, 30000);
+
   it("survives an app description that cannot be loaded", async () => {
     const cwd = await createProject({
       "xmlui.config.json": JSON.stringify({ compileScripts: true }),

--- a/xmlui/tests/parsers/scripting/code-behind-import.test.ts
+++ b/xmlui/tests/parsers/scripting/code-behind-import.test.ts
@@ -169,8 +169,21 @@ function getValue() {
       expect(result.warnings ?? []).toEqual([]);
     });
 
+    it("compiles a declaration that constructs an object", () => {
+      const source = "function today() { return new Date(0); }";
+
+      const result = collectCodeBehindFromSource("/main.xs", source, {
+        compileEventHandlers: true,
+      });
+
+      expect(result.functions.today.compiledUnsupported).toBe(false);
+      expect(result.functions.today.compiled?.js).toContain("runtime.construct(");
+      expect(result.warnings ?? []).toEqual([]);
+    });
+
     it("marks unsupported function compilation and keeps the declaration", () => {
-      const source = "function today() { return new Date(); }";
+      // --- `await` is not part of XMLScript, so no compiler target accepts it.
+      const source = "function today() { return await now(); }";
 
       const result = collectCodeBehindFromSource("/main.xs", source, {
         compileEventHandlers: true,


### PR DESCRIPTION
Follow-up to #3877, addressing the second Evolution.TM report. Four issues, plus the two side effects; each one turned out to be a real defect.

## Issue 3 first — it was the biggest one

The event-async compiler target simply did not implement four expression forms the binding target already handled: **conditional (`a ? b : c`), sequence, `new`, and spread**. Anything containing one refused to compile, so a ternary inside a `function` declaration — the most ordinary shape in the report — fell back to interpretation. That is the whole story behind the 111 blocks / 71 functions.

All four now compile, in the async emitter *and* in the native (pure-JS) emitter. The second half matters as much as the first: a callback like `rows.filter(row => row.tag ? a : b)` used to fail native emission and fall back to a lazy interpreted arrow even when the enclosing handler compiled.

Every function quoted verbatim in the report is covered by a test that runs it **both ways and compares** (`event-async-parity.test.ts`) — a construct that merely compiles is not enough; it has to mean the same thing. Two constructs still do not compile, because XMLScript does not support them at all: `await` and `async` arrow functions.

**Two interpreter bugs surfaced while checking that parity**, and both are fixed here:

- `Array.prototype.sort(comparator)` was a **silent no-op** — the exact behaviour the report describes. Script callbacks are asynchronous and the native `sort` coerces the returned promise to `NaN`, so every pair compared equal. It was broken identically on both paths, so it was never a compiled-vs-interpreted difference; `sort` and `toSorted` now have async-aware proxies (stable merge sort, `undefined` entries last).
- Comma-sequence expressions mapped their operands through an async callback, so every operand saw the pre-sequence state and the expression's value was a pending promise.

### A fifth bug, found by widening compilation

Making more callbacks compilable exposed one that was already there. A handler that hands a callback to something invoking it *later* — `debounce`, a timer, a subscription — has finished by the time the callback runs, and the dispatcher aborts the run's `$cancel` token in its `finally` (on normal completion too, so `$cancel.onAbort` teardown fires). The compiled runtime consulted that token on every `runtime.call`, so those callbacks died with `HandlerCancelledError` and their work vanished silently. The interpreted path never consulted `$cancel` at all, which is why only compiled handlers hit it.

Compiled runs are now bracketed (nesting-aware) and `checkCancel` skips `$cancel` once the run that created the callback has settled; cancellation *during* a run is unchanged. Caught by this repo's own `debounce-user-input-for-api-calls` website example, whose callback contains a ternary and therefore became natively compilable for the first time.

## Issue 1 — `appGlobals.compileScripts` in a TypeScript app description

`import.meta.glob` is a Vite transform, so a plain Node import of a `src/config.ts` that uses `getLocalIcons()` throws — the warning the report quotes. The loader now retries through Vite's `runnerImport` with the xmlui plugin applied and stylesheets stubbed, which resolves `import.meta.glob`, `.xmlui` imports and TypeScript exactly as the browser build does. The Vite retry is gated on the file mentioning a compilation key, because it evaluates the whole module graph the description pulls in (measured on this repo's own website config: 275 ms without, 4.7 s with — paid only by apps that ask for compilation).

Verified against the reported config verbatim: `appGlobals: { apiUrl: "/api", compileScripts: true }` plus `icons: getLocalIcons()` now enables compilation, with no warning.

## Issue 2 — bindings

Two parts, and only one of them was a bug.

The bug: `compileScripts` was not honoured at the parse-time binding call sites or in `evalBinding` — those read `compileBindings` alone. Fixed; the umbrella flag now implies binding compilation everywhere, and `compileBindings: false` remains the per-path override.

The part that is not a bug: **binding expressions have no build-time artifacts by design.** Prop values are stored as raw strings and parsed lazily in the browser (`valueExtractor`, `variable-resolution`), so counting artifacts in a bundle cannot tell you whether bindings compile — zero is the expected number. They are compiled on first use and cached, which the umbrella flag has always enabled at runtime. Since "trust me" is not evidence, `compiled-binding-path.test.ts` asserts it from the compiled executor's own `debug-source` trace, with two controls (compilation off; `compileBindings: false`) so the signal cannot pass vacuously.

## Issues 1–4 — the reporting that hid all of this

- **Code-behind warnings were computed and then dropped.** `collectCodeBehindFromSourceWithImports` produced a message naming the construct for every fallback; the Vite plugin never surfaced them. A `Globals.xs` full of fallbacks was therefore completely silent. They are build warnings now.
- **Diagnostics quoted raw node numbers.** "Unsupported 103 node" is now `unsupported conditional expression (node type 103) at line 4, column 12`, and it points at the offending literal rather than the arrow that contains it.
- **The reason travels with the block** as `compiledUnsupportedReason`, so a fallback is never a bare boolean and the state is checkable from the build output.
- **The startup banner** now follows the mode line with the effective state, and warns when compilation is on but nothing was pre-compiled:

```
[xmlui] App started in compiled script mode (bindings: compiled, event handlers: compiled)
[xmlui] Script artifacts: 14 compiled at build time, 1 fell back to interpretation. Fallback reasons: unsupported literal (node type 109) at line 1, column 24.
```

## Side effects — root cause found

`getViteConfig` passed `devServer: true` for **every** command, so production builds inherited the dev-server source-map default and shipped per-token `mappings`, complete original sources, and absolute developer paths. That is the 6.29 MB → 30.09 MB. Dev defaults now apply to `xmlui start` only, and a build without source maps emits `js` alone with project-relative source ids.

Measured on a repro app, same build twice: **5,899 bytes of debug payload per artifact**. At the report's 701 artifacts that is ~4 MB, and their handlers are much longer than the repro's. After the fix: `grep -c "C:/Users/…"`-equivalent → **0**, no `sourceText`, no mappings.

On `new Function`: the correction in the report is right, and the "never sees a `Function` or `eval` call" wording refers to *your* script text never being handed to the JS engine — compiled artifacts are generated code, instantiated once per artifact and cached. Worth stating precisely in the security docs; not changed here.

## Performance, since you asked either way

New `npm run measure:compiled-events` (checks both paths agree before timing them). 300 rows per iteration, this machine:

| workload | interpreted | compiled | ratio |
|---|---:|---:|---:|
| ternary declaration called per row | 2460.7 ms | 248.8 ms | **9.9×** |
| `filter` + `some` over rows | 771.2 ms | 410.6 ms | 1.9× |
| spread rebuild | 470.0 ms | 390.5 ms | 1.2× |
| `sort` with comparator | 1678.4 ms | 969.3 ms | 1.7× |

The first row is exactly the pattern that used to fall back, so for your hot path this is the difference between interpreted and compiled. But note the absolute numbers: 200 iterations over 300 rows costs 2.46 s interpreted, i.e. **~12 ms per full pass, ~0.04 ms per row** — two orders of magnitude below your 13–16 ms per row. Script execution does not look big enough to explain a 4 s block on its own. Please re-measure after this lands; if the number barely moves, the remaining time is somewhere else (most likely rendering), and that is worth a separate issue with the long-task profile attached.

## Against your acceptance list

| | |
|---|---|
| **P1** no silent fallbacks | build warning + `compiledUnsupportedReason` + startup line, each naming construct and position |
| **P2** ternary cases compile | yes — the five reported bodies are parity-tested |
| **P3** hot path compiles | the shapes listed (`applyFilters`, `buildSuiteIndex`, `suitePathFromIndex`, `upsertCase`, `decorateSuiteTree`, `chipTextColor`) compile; verified in an app that mirrors them |
| **P4** bindings | umbrella flag fixed; no build-time artifacts by design, compiled-path entry proven by test |
| **P5** documented config location works | yes, including `getLocalIcons()` / `import.meta.glob` |
| **P6** banner truthful | reports produced / fell back / compiled-on-first-use, with reasons |
| **P7** behaviour unchanged | parity harness compares both paths; four engine bugs fixed rather than papered over |
| **P8** production output clean | root-caused and fixed; 0 developer paths, 0 embedded sources |
| **P9** debuggability | `xmlui start` keeps `"external"` source maps; only builds are stripped |
| **P10** regression guard | parity suite, plugin artifact-hygiene tests, inventory tests, config-loading tests |

## Your four questions

1. **Should `compileScripts` imply `compileBindings` at the call site?** Yes — it does now, at every site that reads the flag.
2. **Is a conditional inside a `function` declaration genuinely unsupported?** No. It was a coverage gap in the event-async target, not a language limitation.
3. **Can the toolchain emit the refusal reason per block?** Yes — build log, emitted artifact, and startup console.
4. **Is `appGlobals` in a TypeScript app description a valid source for build-time settings?** Yes, and it now works even when the description needs Vite to evaluate. `xmlui.config.json` still wins per key.

## Verification

- 11,293 unit tests pass, including the new parity, sort, deferred-callback, inventory, artifact-hygiene, binding-path, and config-loading suites.
- Full Playwright suite re-run with `XMLUI_COMPILE_SCRIPTS=true`: **7,836 passed, 0 failed** (2 flaky, both green on retry and one of them flaky on `main` too), plus a component subset in interpreted mode.
- End-to-end on a repro app built to match the report (config.ts with `getLocalIcons()` + `appGlobals.compileScripts`, a `Globals.xs` of ternary declarations, a component with spread/`some`/`sort` handlers): dev server and `--buildMode=INLINE_ALL` both compile it, the app runs correctly in the browser on both, and the one deliberate fallback (a regex literal) is reported with its reason in all three places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
