### PR TITLE
Add how-to: find the theme variable for a text

### DIFF
--- a/website/content/docs/pages/howto/find-the-theme-variable-for-a-text.md
+++ b/website/content/docs/pages/howto/find-the-theme-variable-for-a-text.md
@@ -1,0 +1,79 @@
+# Find the theme variable for a text
+
+Identify the right `{property}-{part}-{Component}` theme var for any text-shaped part, even when the reference table doesn't list it.
+
+A `ModalDialog` title wraps onto two lines and the spacing between them looks too loose. The obvious fix is a heading theme var — the title is big, bold text, so `lineHeight-H2` seems like the right lever:
+
+```xmlui-pg copy display name="lineHeight-H2 does not reach the dialog title" height="320px"
+---app display
+<App>
+  <variable name="isOpen" value="{true}" />
+  <Theme lineHeight-H2="1">
+    <ModalDialog
+      id="demo"
+      when="{isOpen}"
+      onClose="isOpen = false"
+      title="Confirm permanent deletion of every archived record older than seven years"
+    >
+      <Text>This action cannot be undone.</Text>
+      <Button label="Dismiss" onClick="isOpen = false" />
+    </ModalDialog>
+  </Theme>
+</App>
+```
+
+Nothing changes. The wrapped lines stay exactly as loosely spaced as before `lineHeight-H2` was set. There is no error, no warning — the var is accepted and simply does nothing, because the dialog's title was never a `Heading`.
+
+## Why it fails silently
+
+`ModalDialog`'s `title` prop renders as plain text inside the dialog's own markup — not as an `H2`, not as any `Heading` component. `lineHeight-H2` only reaches an actual `<Heading level="2">` (or `<H2>`); the title text is a different part of a different component, so the var has nothing to attach to. XMLUI doesn't warn about this because, from the engine's point of view, `lineHeight-H2` is a perfectly valid theme variable — it just isn't read by anything on this page.
+
+## The method
+
+**1. Identify the component and the part, not the visual role.** Read the markup, not the rendering. "Big bold text at the top of a dialog" is a visual role; `ModalDialog`'s `title` prop is the actual part. Every part-scoped theme var is built from the part, never from what the part looks like.
+
+**2. Build the name from the part.** Part-scoped theme vars follow `{property}-{part}-{Component}` (see [Override a component's theme vars](/docs/howto/override-a-components-theme-vars)). The part name is documented per component — `ModalDialog`'s title part is `title`, so the line-height var is `lineHeight-title-ModalDialog`.
+
+**3. Assume the whole text family is available.** Every part styled as text is wired up by the same internal mechanism (`textVars` in the theme engine), which generates a fixed family of CSS properties — color, font family, size, weight, line-height, letter-spacing, and more — for that part, all at once. A component's reference table normally lists only the vars it ships an explicit default for, so `lineHeight-title-ModalDialog` can be real and settable even though no reference page names it. Grepping the source for the literal string won't find it either — the name is assembled at build time from the part and property, not written out anywhere.
+
+**4. Heading and Markdown vars are their own families.** `lineHeight-H2` reaches a real `Heading` (`<H2>` or `<Heading level="2">`). `lineHeight-H2-markdown` reaches an `H2`-level heading rendered by `<Markdown>` (see [Style per-level heading sizes](/docs/howto/style-per-level-heading-sizes)). Neither reaches a component's own title, label, or caption part — those are separate families entirely. A var from the wrong family is accepted and does nothing, which is exactly what makes this hard to debug: there's no error to search for.
+
+Applying that name instead of the heading var fixes it:
+
+```xmlui-pg copy display name="lineHeight-title-ModalDialog reaches the dialog title" height="320px"
+---app display
+<App>
+  <variable name="isOpen" value="{true}" />
+  <Theme lineHeight-title-ModalDialog="1">
+    <ModalDialog
+      id="demo"
+      when="{isOpen}"
+      onClose="isOpen = false"
+      title="Confirm permanent deletion of every archived record older than seven years"
+    >
+      <Text>This action cannot be undone.</Text>
+      <Button label="Dismiss" onClick="isOpen = false" />
+    </ModalDialog>
+  </Theme>
+</App>
+```
+
+Same wrapped title, same two lines — now set tight instead of loose. Nothing else about the dialog changed; only the property name did.
+
+## Key points
+
+**Name the part, not the look.** `ModalDialog`'s title, a `Card`'s title, a form field's label — each is a specific part of a specific component. Find the part's name in that component's docs, then build `{property}-{part}-{Component}`.
+
+**A part styled as text exposes the whole text-property family, not just what's defaulted.** `color`, `font-family`, `font-size`, `font-weight`, `line-height`, `letter-spacing`, `text-transform`, and the rest of the family are all generated together for a text part. A reference table that lists four vars for a part is usually reporting only the ones that ship a default — the rest still work, they're just undocumented on that page.
+
+**`Heading`/`H1`–`H6` vars and `-markdown` heading vars are separate families from every other component's text parts.** They style real headings and Markdown-rendered headings only. A component's title, label, or caption is never a `Heading`, no matter how it's styled to look like one.
+
+**When a theme var does nothing, the var is very likely for the wrong part or the wrong family — not broken.** XMLUI applies whatever var you name; it doesn't check whether the element you're picturing is actually the element that var affects.
+
+---
+
+## See also
+
+- [Override a component's theme vars](/docs/howto/override-a-components-theme-vars) — the `{property}-{part}-{Component}` naming convention
+- [Style per-level heading sizes](/docs/howto/style-per-level-heading-sizes) — the `Heading` and `-markdown` var families this page warns you away from
+- [Style ModalDialog overlay and parts](/docs/howto/style-modaldialog-overlay-and-parts) — the rest of `ModalDialog`'s documented theme vars

--- a/website/content/docs/pages/howto/style-per-level-heading-sizes.md
+++ b/website/content/docs/pages/howto/style-per-level-heading-sizes.md
@@ -35,6 +35,9 @@ Each heading level (H1–H6) gets its own family of theme variables sharing the 
 </App>
 ```
 
+> [!WARNING]
+> These vars only reach real `Heading`/`H1`–`H6` components and, with the `-markdown` suffix, headings rendered by `<Markdown>`. They do **not** reach text that merely looks like a heading — a `ModalDialog` title, a `Card` title, a form section label. Setting `lineHeight-H2` on a dialog title is accepted and does nothing, silently. See [Find the theme variable for a text](/docs/howto/find-the-theme-variable-for-a-text) for the method that identifies the right var for a component's own title/label/caption parts.
+
 ## Key points
 
 **`textColor-Heading` sets all six levels at once**: Use it as a global override when all headings should share one color. Per-level vars like `textColor-H2` take precedence when both are set, so you can override individual levels without repeating the global.

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1451,6 +1451,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Find the theme variable for a text"
+                            to="/docs/howto/find-the-theme-variable-for-a-text"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Customize Select & AutoComplete menus"
                             to="/docs/howto/customize-select-and-autocomplete-menus"
                         />

--- a/xmlui/tests-e2e/how-to-examples/find-the-theme-variable-for-a-text.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/find-the-theme-variable-for-a-text.spec.ts
@@ -1,0 +1,82 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/find-the-theme-variable-for-a-text.md",
+  ),
+);
+
+async function computedLineHeightAndFontSize(page: any) {
+  const title = page.locator("#dialogTitle");
+  await expect(title).toBeVisible();
+  return title.evaluate((el: HTMLElement) => {
+    const style = getComputedStyle(el);
+    return { lineHeight: parseFloat(style.lineHeight), fontSize: parseFloat(style.fontSize) };
+  });
+}
+
+test.describe("lineHeight-H2 does not reach the dialog title", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "lineHeight-H2 does not reach the dialog title",
+  );
+
+  // Pins the trap the how-to opens with: lineHeight-H2="1" is set on the
+  // Theme wrapping the dialog, but the title's part family is
+  // "title-ModalDialog", not "H2" — so the override is accepted and does
+  // nothing. The title keeps its natural (looser than 1x) line-height.
+  test("dialog title's computed line-height is unaffected by lineHeight-H2", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const { lineHeight, fontSize } = await computedLineHeightAndFontSize(page);
+
+    // lineHeight-H2="1" would compute to exactly 1x font-size if it had taken
+    // effect. It didn't, so the ratio stays well above 1 (the natural
+    // default is "loose").
+    expect(lineHeight / fontSize).toBeGreaterThan(1.2);
+  });
+
+  test("Dismiss button still closes the dialog", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    await expect(page.locator("#dialogTitle")).toBeVisible();
+    await page.getByRole("button", { name: "Dismiss" }).click();
+    await expect(page.locator("#dialogTitle")).not.toBeVisible();
+  });
+});
+
+test.describe("lineHeight-title-ModalDialog reaches the dialog title", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "lineHeight-title-ModalDialog reaches the dialog title",
+  );
+
+  // Pins the fix: the correctly-named var, lineHeight-title-ModalDialog="1",
+  // does change the title's computed line-height, to (approximately) exactly
+  // 1x its font-size.
+  test("dialog title's computed line-height changes with lineHeight-title-ModalDialog", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const { lineHeight, fontSize } = await computedLineHeightAndFontSize(page);
+
+    expect(lineHeight / fontSize).toBeLessThan(1.05);
+  });
+
+  test("Dismiss button still closes the dialog", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    await expect(page.locator("#dialogTitle")).toBeVisible();
+    await page.getByRole("button", { name: "Dismiss" }).click();
+    await expect(page.locator("#dialogTitle")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Jon's Claude (main thread, Fable 5) speaking from the XMLUI project (github.com/xmlui-org/xmlui):

Closes #3842.

## What this adds

A new how-to, **Find the theme variable for a text**, teaching the identification method rather than a var list:

1. Identify the component and part, not the visual role — a modal's big text is its `title` prop, not a `Heading`.
2. Build the name from the part: `{property}-{part}-{Component}`.
3. Assume the whole text family is available — any part styled as text exposes all seventeen generated properties, including ones the reference table doesn't list (they're emitted by the `textVars` mixin, so the literal names appear nowhere in the source and can't be grepped for).
4. Heading (`lineHeight-H2`) and Markdown (`lineHeight-H2-markdown`) vars are separate families that never reach component title parts — and fail silently when misapplied.

The page anchors on the reported case: a wrapped `ModalDialog` title where `lineHeight-H2` does nothing and `lineHeight-title-ModalDialog` works, shown side by side in live playgrounds preselected to the wrapped state.

Also included:

- A warning block in *Style per-level heading sizes* (where the search for heading line-height lands first) cross-linking the new page.
- A spec that pins the trap, not just the fix: it asserts `lineHeight-H2` leaves the dialog title's computed line-height unchanged AND that `lineHeight-title-ModalDialog` changes it, so the page's central warning can't quietly go stale.

## Verification

- Spec: 4/4 passing, run both `--workers=1` and `--workers=4`.
- Rendered check in a live docs server: both playgrounds display the loose-vs-tight contrast without interaction; warning admonition, cross-links, and nav pager verified.

Deliberately out of scope (per the issue's own suggestion to split): whether `lineHeight-title-ModalDialog` should ship a tighter default, and the systemic question of reference tables listing only defaulted vars.

