### PR TITLE
docs: improve truncate text how-to

### DIFF
--- a/website/content/docs/pages/howto/size-with-font-relative-units.md
+++ b/website/content/docs/pages/howto/size-with-font-relative-units.md
@@ -1,0 +1,169 @@
+# Use `ch` when width should track character count
+
+Use `width="Nch"` when the useful way to describe a box is “make room for
+about N character positions in this font.” It is especially useful for
+monospace content—file paths, code, identifiers, terminal output—because
+every character occupies the same width.
+
+Choose the sizing rule that matches the job:
+
+| Goal | Use |
+| --- | --- |
+| Reserve about N character positions in a chosen font | `width="Nch"` |
+| Hug the text or components actually rendered | `width="fit-content"` |
+| Keep a layout width tied to the application's root text scale | `rem` |
+| Take whatever space the parent has left | `width="*"` |
+
+`ch` does not inspect or count the content. It is a font-relative ruler: one
+`ch` is the width of that font's `0` glyph. In a monospace font, that ruler
+maps directly to character positions. In a proportional font it is only an
+estimate, because other glyphs may be wider or narrower than `0`.
+
+## Put the font and the `ch` width on one wrapper
+
+For a monospace path column, put both the measuring font and `width="Nch"`
+on a shared wrapper. Let its header and values fill that wrapper:
+
+```xmlui-pg copy display name="One wrapper sets the column width" id="one-wrapper-sets-column-width" height="160px"
+<App>
+  <VStack
+    testId="path-column"
+    width="24ch"
+    fontFamily="monospace"
+    backgroundColor="$color-surface-200"
+    padding="$space-2"
+    gap="$space-1"
+  >
+    <Text
+      testId="path-heading"
+      width="100%"
+      fontFamily="sans-serif"
+      fontWeight="$fontWeight-bold"
+      value="Path"
+    />
+    <Text testId="path-value" width="100%" value="src/components/Button.tsx" />
+  </VStack>
+</App>
+```
+
+The wrapper's `fontFamily="monospace"` determines what `24ch` means. The
+header may use a different font without changing the column's physical width,
+because both children take `100%` of the already-sized wrapper.
+
+The child widths are not inherited from the wrapper—CSS width does not
+inherit. They fill the wrapper because their own widths are `100%`. A
+`VStack` also uses `itemWidth="100%"` for widthless direct children by
+default, but writing the child widths here makes the recipe explicit.
+
+## What controls the physical width
+
+The element carrying `width="24ch"` supplies the font context. Change that
+element's font and the physical width changes; change only its child text and
+the width does not.
+
+Font-relative units work on layout components as well as text components.
+XMLUI passes `ch`, `em`, `ex`, and `rem` dimension values through to
+CSS; the browser resolves them using the font context of the component that
+owns the width or height.
+
+## Why separate `ch` widths may not align
+
+If a proportional header and a monospace value each declare
+`width="20ch"`, each box measures its own font's `0`. The numbers match,
+but the physical widths do not:
+
+```xmlui-pg copy display name="Same ch count, different fonts" id="same-ch-count-different-fonts" height="140px"
+<App>
+  <VStack gap="$space-2">
+    <Text
+      testId="caption-20ch"
+      width="20ch"
+      fontFamily="sans-serif"
+      value="Path"
+      backgroundColor="$color-primary-200"
+      padding="$space-1"
+    />
+    <Text
+      testId="code-20ch"
+      width="20ch"
+      fontFamily="monospace"
+      value="index.ts"
+      backgroundColor="$color-surface-200"
+      padding="$space-1"
+    />
+  </VStack>
+</App>
+```
+
+This is a box-sizing mismatch, not text alignment inside the boxes.
+`textAlign` cannot fix it. Measure once on the shared wrapper instead of
+measuring the header and value independently.
+
+## If a `ch` width looks ignored, check the binding
+
+A valid font-relative width works on a `VStack`. An invalid interpolated
+value can produce CSS such as `undefinedch`; the browser discards that width
+without an XMLUI error, leaving the component to use its normal layout width.
+
+The fixed-width parent below makes the fallback visible. The literal
+`width="24ch"` child stays compact, while the invalid child fills the
+parent:
+
+```xmlui-pg copy display name="Valid and invalid ch bindings" id="valid-and-invalid-ch-bindings" height="190px"
+<App var.charCount="{undefined}">
+  <VStack testId="binding-parent" width="520px" gap="$space-2">
+    <VStack
+      testId="valid-width"
+      width="24ch"
+      fontFamily="monospace"
+      backgroundColor="$color-primary-200"
+      padding="$space-1"
+    >
+      <Text value="valid: 24ch" />
+    </VStack>
+    <VStack
+      testId="invalid-width"
+      width="{charCount}ch"
+      minWidth="14rem"
+      backgroundColor="$color-surface-200"
+      padding="$space-1"
+    >
+      <Text value="invalid: fills the parent" />
+    </VStack>
+  </VStack>
+</App>
+```
+
+`minWidth` is only a floor; it cannot repair an invalid `width`. If a
+container appears to ignore `ch`, check the string produced by the binding
+before changing the layout.
+
+## Other font-relative units
+
+| Unit | Resolves against | Good fit |
+| --- | --- | --- |
+| `ch` | The `0` glyph of this element's computed font | Monospace columns and character-position estimates |
+| `em` | This element's computed font size when used for width or spacing | Control geometry that should scale with its local text |
+| `rem` | The root element's font size | App-wide measurements that should ignore nested font changes |
+| `ex` | The x-height of this element's computed font | Specialized typographic alignment |
+
+When `em` is used to set `fontSize` itself, it resolves against the
+parent's font size. For layout properties such as `width`, it uses the
+element's own computed font size.
+
+Use `ch` for the monospace path-column case because changing that font also
+updates the column width. Use `em` when a box should scale with its local
+text. Use `rem` when a layout measurement should remain consistent across
+components with different fonts or font sizes; it still scales when the
+application's root font size changes.
+
+## See also
+
+- [Size Values](/docs/styles-and-themes/common-units#size) — the complete
+  size-unit reference
+- [Layout Properties](/docs/styles-and-themes/layout-props) — `width`,
+  `minWidth`, and `fontFamily`
+- [Make a component hug its content with `fit-content`](/docs/howto/know-when-to-use-fit-content) —
+  size a box from its rendered content instead of a character count
+- [Auto-size column widths with star](/docs/howto/auto-size-column-widths-with-star) —
+  divide remaining space instead of choosing an intrinsic unit

--- a/website/content/docs/pages/howto/truncate-text-with-expand-on-demand.md
+++ b/website/content/docs/pages/howto/truncate-text-with-expand-on-demand.md
@@ -1,0 +1,157 @@
+# Truncate long text and expand it on demand
+
+A description, comment, or log entry can consume too much vertical space when
+it is shown in full. Use this pattern when the reader needs a compact preview
+but must still be able to reveal the complete text. `Text`'s `maxLines` prop
+creates the preview; a state toggle removes and restores that limit without
+changing the underlying content.
+
+## Clamp known-long text and toggle the full value
+
+`maxLines` caps a `Text` at N lines, cropping the overflow with `…` by default.
+Drive it from a boolean var: return the line limit while collapsed and
+`undefined` while expanded. This first recipe assumes the content is known to
+exceed the four-line preview.
+
+```xmlui-pg copy display name="Clamp known-long text and expand on demand" id="clamp-known-long-text-and-expand-on-demand" height="360px"
+<App var.expanded="{false}">
+  <VStack
+    width="320px"
+    gap="$space-2"
+    padding="$space-3"
+    borderWidth="1px"
+    borderColor="$color-surface-300"
+  >
+    <Text
+      testId="description"
+      maxLines="{expanded ? undefined : 4}"
+      value="Field notes from the shakedown cruise: the new mast held through gusts recorded well above the manufacturer's rating, and the reefing lines ran clean on every pull, even wet and under load. Below decks the bilge stayed dry through six hours of a beam sea, and the batteries never dropped under 12.1 volts despite running the autopilot and instruments the whole leg. Two things to fix before the next passage: the port running light flickers when the boat heels past twenty degrees, and the anchor windlass needs a new solenoid, since it now takes two tries to bring the chain up." />
+    <Button
+      label="{expanded ? 'Show less' : 'Show more'}"
+      onClick="expanded = !expanded" />
+  </VStack>
+</App>
+```
+
+The `expanded` var controls both the clamp and the button's explicit “Show
+more / Show less” label. The full value always remains in the DOM—only its
+visual clamp changes—so there is no need to slice or re-fetch the text.
+
+If the content might already fit, avoid showing a useless expansion control.
+The Text component's `hasOverflow()` method reports whether its current layout
+overflows. It is a snapshot, not a reactive value: evaluate it after the text
+has rendered, and recheck after any later content or width change. Run that
+check from the lifecycle, data-loading, or resize path that owns those changes;
+XMLUI does not currently emit an overflow-change event.
+
+## Variations: crop without a marker, or force a single line
+
+**`ellipses="false"` crops without the trailing marker.** Use it when the
+container itself signals truncation (a fade, a "…" rendered separately) or
+when the ellipsis character would clash with the content, like a fixed-width
+code snippet.
+
+```xmlui-pg copy display name="Crop with and without the ellipsis marker" id="crop-with-and-without-the-ellipsis-marker" height="200px"
+<App>
+  <VStack width="220px" gap="$space-4">
+    <VStack gap="$space-1">
+      <Text variant="strong">Default — crops with "…"</Text>
+      <Text
+        testId="withEllipsis"
+        maxLines="1"
+        value="This line is longer than the box, so it has to be cropped somehow" />
+    </VStack>
+    <VStack gap="$space-1">
+      <Text variant="strong">ellipses="false" — crops with no marker</Text>
+      <Text
+        testId="withoutEllipsis"
+        maxLines="1"
+        ellipses="false"
+        value="This line is longer than the box, so it has to be cropped somehow" />
+    </VStack>
+  </VStack>
+</App>
+```
+
+Note the spelling: the prop is `ellipses`, not `ellipsis`.
+
+**`maxLines="1"` truncates to a single line** — the common shape for
+table-ish rows, list items, or anywhere a multi-line clamp would break the
+row's fixed height:
+
+```xmlui-pg copy display name="Single-line rows" id="single-line-rows" height="200px"
+<App>
+  <VStack
+    width="240px"
+    gap="$space-1"
+    borderWidth="1px"
+    borderColor="$color-surface-300"
+    padding="$space-2">
+    <Text testId="singleLineRow" maxLines="1">Q3 planning notes — budget review and headcount</Text>
+    <Text maxLines="1">Renewal: annual support contract with Meridian Labs</Text>
+    <Text maxLines="1">Incident retro — checkout latency spike on 08-14</Text>
+  </VStack>
+</App>
+```
+
+## Truncate custom content inside a Table cell
+
+A plain `Column bindTo="..."` already truncates overflowing values. For custom
+cell content, put `maxLines="1"` on the descendant `Text` in the same way. The
+current layout engine lets nested `Link` and `HStack` elements shrink with the
+cell, so no `minWidth` workaround is required:
+
+```xmlui-pg copy display name="Truncate custom Table cell content" id="truncate-custom-table-cell-content" height="280px"
+<App>
+  <Table
+    data="{[
+      { id: 1, name: 'Short', status: 'Ready' },
+      { id: 2, name: 'A moderately long name that should truncate with ellipsis', status: 'Queued' },
+      { id: 3, name: 'Another very long name that definitely overflows its column when it is not truncated properly', status: 'Needs review' }
+    ]}"
+    width="460px"
+  >
+    <Column header="ID" width="60px" bindTo="id" />
+    <Column header="Name" width="2*" bindTo="name">
+      <Link to="/items/{$item.id}">
+        <HStack gap="$space-2" verticalAlignment="center">
+          <Icon name="trash" />
+          <Text testId="cellText-{$item.id}" value="{$cell}" maxLines="1" />
+        </HStack>
+      </Link>
+    </Column>
+    <Column header="Status" width="100px" bindTo="status" />
+  </Table>
+</App>
+```
+
+The long name stays inside the middle column and the Status column remains
+visible. This nested-content case is covered because it previously regressed
+in [#2936](https://github.com/xmlui-org/xmlui/issues/2936).
+
+## Key points
+
+**`maxLines` clamps by line count, not character count.** It crops at the Nth
+line regardless of how many characters that holds, so the clamp point
+follows the container's width, not a fixed string length.
+
+**Drive `maxLines` from a var to build "show more."** Return `undefined` to
+remove the limit and a positive number to restore it. The underlying text
+never changes—only the clamp does.
+
+**`ellipses="false"` crops without the marker.** Default `true` appends `…`
+at the clamp point; set it `false` to crop silently instead. The prop is
+spelled `ellipses`.
+
+**Do not show an expansion control unless the text overflows.** Call the
+Text's `hasOverflow()` method after layout, and recheck it if later changes can
+alter the text or its available width.
+
+---
+
+## See also
+
+- [Text component](/docs/reference/components/Text) — `maxLines`, `ellipses`, and the full property list
+- [Wrap long text in a Link](/docs/howto/wrap-long-text-in-a-link) — the opposite problem: making text wrap that doesn't by default
+- [Display preformatted or monospace text](/docs/howto/display-preformatted-text) — preserve whitespace and line breaks instead of clamping them
+- [Render a custom cell with components](/docs/howto/render-a-custom-cell-with-components) — the general pattern for putting components inside a `Column`

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1506,11 +1506,6 @@
                         />
                         <NavLink
                             icon="article"
-                            label="Truncate long text and expand it on demand"
-                            to="/docs/howto/truncate-text-with-expand-on-demand"
-                        />
-                        <NavLink
-                            icon="article"
                             label="Theme DatePicker calendar items"
                             to="/docs/howto/theme-datepicker-calendar-items"
                         />

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1041,6 +1041,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Use ch when width should track character count"
+                            to="/docs/howto/size-with-font-relative-units"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Make a child fill the remaining vertical space"
                             to="/docs/howto/fill-remaining-vertical-space"
                         />
@@ -1498,6 +1503,11 @@
                             icon="article"
                             label="Display preformatted or monospace text"
                             to="/docs/howto/display-preformatted-text"
+                        />
+                        <NavLink
+                            icon="article"
+                            label="Truncate long text and expand it on demand"
+                            to="/docs/howto/truncate-text-with-expand-on-demand"
                         />
                         <NavLink
                             icon="article"

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -1506,6 +1506,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Truncate long text and expand it on demand"
+                            to="/docs/howto/truncate-text-with-expand-on-demand"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Theme DatePicker calendar items"
                             to="/docs/howto/theme-datepicker-calendar-items"
                         />

--- a/xmlui/tests-e2e/how-to-examples/size-with-font-relative-units.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/size-with-font-relative-units.spec.ts
@@ -1,0 +1,83 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/size-with-font-relative-units.md",
+  ),
+);
+
+const widthOf = async (page: any, testId: string) => {
+  const box = await page.getByTestId(testId).boundingBox();
+  expect(box).not.toBeNull();
+  return box!.width;
+};
+
+// display-only example — no interaction to test
+test.describe("One wrapper sets the column width", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "one-wrapper-sets-column-width",
+  );
+
+  test("different-font children fill the same wrapper width", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    expect(await widthOf(page, "path-heading")).toBeCloseTo(
+      await widthOf(page, "path-value"),
+      0,
+    );
+
+    const headingFont = await page
+      .getByTestId("path-heading")
+      .evaluate((element) => getComputedStyle(element).fontFamily);
+    const valueFont = await page
+      .getByTestId("path-value")
+      .evaluate((element) => getComputedStyle(element).fontFamily);
+    expect(headingFont).not.toBe(valueFont);
+  });
+});
+
+// display-only example — no interaction to test
+test.describe("Same ch count, different fonts", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "same-ch-count-different-fonts",
+  );
+
+  test("identical ch counts produce materially different physical widths", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    const caption = await widthOf(page, "caption-20ch");
+    const code = await widthOf(page, "code-20ch");
+    expect(Math.abs(caption - code)).toBeGreaterThan(20);
+  });
+});
+
+// display-only example — no interaction to test
+test.describe("Valid and invalid ch bindings", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "valid-and-invalid-ch-bindings",
+  );
+
+  test("valid ch stays compact while an invalid width falls back to the parent width", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    const parent = await widthOf(page, "binding-parent");
+    const valid = await widthOf(page, "valid-width");
+    const invalid = await widthOf(page, "invalid-width");
+
+    expect(valid).toBeLessThan(parent * 0.8);
+    expect(invalid).toBeCloseTo(parent, 0);
+  });
+});

--- a/xmlui/tests-e2e/how-to-examples/truncate-text-with-expand-on-demand.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/truncate-text-with-expand-on-demand.spec.ts
@@ -1,0 +1,162 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/truncate-text-with-expand-on-demand.md",
+  ),
+);
+
+test.describe("Clamp known-long text and expand on demand", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "clamp-known-long-text-and-expand-on-demand",
+  );
+
+  test("starts with the known-long text clamped", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const description = page.getByTestId("description");
+    const toggle = page.getByRole("button", { name: "Show more" });
+    await expect(description).toBeVisible();
+    await expect(toggle).toBeVisible();
+    await expect(description).toHaveCSS("-webkit-line-clamp", "4");
+
+    const overflows = await description.evaluate((element) => {
+      return element.scrollHeight > element.clientHeight;
+    });
+    expect(overflows).toBe(true);
+    await expect(description).toContainText("anchor windlass needs a new solenoid");
+  });
+
+  test("expands and restores the same text without changing its value", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const description = page.getByTestId("description");
+    const showMore = page.getByRole("button", { name: "Show more" });
+    await expect(description).toBeVisible();
+    await expect(showMore).toBeVisible();
+    const clampedBox = await description.boundingBox();
+    expect(clampedBox).not.toBeNull();
+
+    await showMore.click();
+    const showLess = page.getByRole("button", { name: "Show less" });
+    await expect(showLess).toBeVisible();
+
+    await expect(description).toHaveCSS("-webkit-line-clamp", "none");
+    const expandedBox = await description.boundingBox();
+    expect(expandedBox).not.toBeNull();
+    expect(expandedBox!.height).toBeGreaterThan(clampedBox!.height * 1.5);
+    await expect(description).toContainText("anchor windlass needs a new solenoid");
+
+    await showLess.click();
+    await expect(showMore).toBeVisible();
+    await expect(description).toHaveCSS("-webkit-line-clamp", "4");
+    const reClampedBox = await description.boundingBox();
+    expect(reClampedBox).not.toBeNull();
+    expect(Math.abs(reClampedBox!.height - clampedBox!.height)).toBeLessThan(2);
+  });
+});
+
+// display-only example — no interaction to test
+test.describe("Crop with and without the ellipsis marker", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "crop-with-and-without-the-ellipsis-marker",
+  );
+
+  test('ellipses="false" crops without the trailing marker', async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const withEllipsis = page.getByTestId("withEllipsis");
+    const withoutEllipsis = page.getByTestId("withoutEllipsis");
+    await expect(withEllipsis).toBeVisible();
+    await expect(withoutEllipsis).toBeVisible();
+
+    await expect(withEllipsis).toHaveCSS("text-overflow", "ellipsis");
+    await expect(withoutEllipsis).toHaveCSS("text-overflow", "clip");
+
+    // Both are actually truncated (content wider than the box) — the
+    // difference is only the marker, not whether cropping happened.
+    const ellipsisOverflows = await withEllipsis.evaluate((el) => el.scrollWidth > el.clientWidth);
+    const clipOverflows = await withoutEllipsis.evaluate((el) => el.scrollWidth > el.clientWidth);
+    expect(ellipsisOverflows).toBe(true);
+    expect(clipOverflows).toBe(true);
+  });
+});
+
+// display-only example — no interaction to test
+test.describe("Single-line rows", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(markdown, "single-line-rows");
+
+  test("keeps an overflowing row to one line", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const row = page.getByTestId("singleLineRow");
+    await expect(row).toBeVisible();
+    await expect(row).toHaveCSS("white-space", "nowrap");
+    await expect(row).toHaveCSS("text-overflow", "ellipsis");
+    expect(await row.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
+  });
+});
+
+// display-only example — no interaction to test
+test.describe("Truncate custom Table cell content", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "truncate-custom-table-cell-content",
+  );
+
+  test("the longest custom value truncates inside its cell without covering the next column", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const longest = page.getByTestId("cellText-3");
+    await expect(longest).toBeVisible();
+
+    // maxLines="1" takes the single-line ellipsis path (white-space: nowrap +
+    // text-overflow: ellipsis) rather than the multi-line webkit-line-clamp
+    // style, which only applies for maxLines > 1.
+    await expect(longest).toHaveCSS("-webkit-line-clamp", "none");
+    await expect(longest).toHaveCSS("text-overflow", "ellipsis");
+
+    const overflows = await longest.evaluate((el) => el.scrollWidth > el.clientWidth);
+    expect(overflows).toBe(true);
+
+    const dataRow = page.getByRole("row").filter({ has: longest });
+    const cells = dataRow.getByRole("cell");
+    await expect(cells).toHaveCount(3);
+    const nameCell = cells.nth(1);
+    const statusCell = cells.nth(2);
+    await expect(statusCell).toHaveText("Needs review");
+
+    const table = page.getByRole("table");
+    const [tableBox, nameCellBox, textBox, statusCellBox] = await Promise.all([
+      table.boundingBox(),
+      nameCell.boundingBox(),
+      longest.boundingBox(),
+      statusCell.boundingBox(),
+    ]);
+    expect(tableBox).not.toBeNull();
+    expect(nameCellBox).not.toBeNull();
+    expect(textBox).not.toBeNull();
+    expect(statusCellBox).not.toBeNull();
+    expect(textBox!.x + textBox!.width).toBeLessThanOrEqual(
+      nameCellBox!.x + nameCellBox!.width + 1,
+    );
+    expect(nameCellBox!.x + nameCellBox!.width).toBeLessThanOrEqual(statusCellBox!.x + 1);
+    expect(statusCellBox!.x + statusCellBox!.width).toBeLessThanOrEqual(
+      tableBox!.x + tableBox!.width + 1,
+    );
+  });
+});


### PR DESCRIPTION
Jon's Codex (main thread, gpt-5.2-codex) speaking from the XMLUI project (github.com/xmlui-org/xmlui):

## Summary
- lead with when and why to clamp long text
- document the known-long-content boundary and hasOverflow snapshot behavior
- clarify ellipses, single-line rows, and current Table-cell containment
- add stable example IDs and focused website coverage

## Verification
- npm run test:e2e-website-examples -- ../tests-e2e/how-to-examples/truncate-text-with-expand-on-demand.spec.ts --workers=2 --reporter=line
- git diff --check