### PR TITLE
fix(ssg): build into a private directory instead of dist/

### DIFF
--- a/.changeset/ssg-private-build-dir.md
+++ b/.changeset/ssg-private-build-dir.md
@@ -1,0 +1,18 @@
+---
+"xmlui": patch
+---
+
+`xmlui ssg` no longer builds through the project's `dist/`.
+
+The SSG pipeline needs a client build before it can prerender routes, and it used to produce
+that build in `dist/` and copy it to `dist-ssg/`. That made `ssg` a second writer of a directory
+`xmlui build` already owns. Two build tasks running against the same project concurrently would
+collide: Vite's `emptyDir` would try to clear `dist/` while the other build was writing into it,
+failing with `ENOTEMPTY: directory not empty` — or, when the timing fell the other way, silently
+copying a half-written `dist/` into `dist-ssg/` and reporting success.
+
+The client build now goes to a private `.xmlui-ssg-dist/` next to the existing `.xmlui-ssg-ssr/`,
+and is removed when the command finishes. `dist-ssg/` is unchanged; `dist/` is left alone.
+
+`build()` gains an `outDir` option (default `"dist"`) for callers that need the build output as an
+intermediate artifact rather than as the project's published output.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dist
 dist-ssg
 xmlui-optimized-output
 .xmlui-ssg-ssr/
+.xmlui-ssg-dist/
 .xmlui-ssg-entry.tsx
 
 myworkdrive/

--- a/xmlui/dev-docs/ssg-islands-regression-notes.md
+++ b/xmlui/dev-docs/ssg-islands-regression-notes.md
@@ -32,8 +32,9 @@ This is the critical path for the behavior we were debugging:
 3. SSG build flow
 
    - [xmlui/src/nodejs/bin/ssg.ts](/Users/jonudell/xmlui/xmlui/src/nodejs/bin/ssg.ts:636)
-   - builds the app with `buildMode: "INLINE_ALL"`
-   - copies `dist` to `dist-ssg`
+   - builds the app with `buildMode: "INLINE_ALL"` into a private `.xmlui-ssg-dist/`
+     (never the project's `dist/`, which `xmlui build` owns)
+   - copies that build output to `dist-ssg`
    - builds a temporary SSR bundle
    - renders each route via `renderPath(...)`
    - merges the rendered output into the shell HTML via `applyRenderToShell(...)`

--- a/xmlui/src/nodejs/bin/build.ts
+++ b/xmlui/src/nodejs/bin/build.ts
@@ -79,6 +79,13 @@ type UEBuildOptions = {
   withMock?: boolean;
   withHostingMetaFiles?: boolean;
   withRelativeRoot?: boolean;
+  /**
+   * Directory (relative to the current working directory) the build writes into.
+   * Defaults to "dist". Callers that only need the build output as an intermediate
+   * artifact should pass a private directory so they do not clobber -- or race with
+   * another process over -- the project's public `dist/`.
+   */
+  outDir?: string;
 };
 
 export const build = async ({
@@ -87,6 +94,7 @@ export const build = async ({
   withMock = false,
   withHostingMetaFiles = false,
   withRelativeRoot = false,
+  outDir = "dist",
 }: UEBuildOptions) => {
   const flatDistUiPrefix = "ui_";
   console.log("Building with options:", {
@@ -95,14 +103,22 @@ export const build = async ({
     withMock,
     withHostingMetaFiles,
     withRelativeRoot,
+    outDir,
+  });
+
+  const viteConfig = await getViteConfig({
+    flatDist,
+    withRelativeRoot,
+    flatDistUiPrefix,
   });
 
   await viteBuild({
-    ...(await getViteConfig({
-      flatDist,
-      withRelativeRoot,
-      flatDistUiPrefix,
-    })),
+    ...viteConfig,
+    build: {
+      ...viteConfig.build,
+      outDir,
+      emptyOutDir: true,
+    },
     define: {
       ...createXmluiAppDefines({
         buildMode,
@@ -251,7 +267,7 @@ export const build = async ({
   if (buildMode === "INLINE_ALL") {
     return;
   }
-  const distPath = "/dist";
+  const distPath = outDir;
   const themesFolder = flatDist ? "" : "themes";
   const themesFolderPath = flatDist ? distPath : path.join(distPath, themesFolder);
 

--- a/xmlui/src/nodejs/bin/ssg.ts
+++ b/xmlui/src/nodejs/bin/ssg.ts
@@ -658,7 +658,14 @@ export const ssg = async ({
 
   const cwd = process.cwd();
   const outPath = path.resolve(cwd, outDir);
-  const distPath = path.resolve(cwd, "dist");
+  // The client build is an intermediate artifact of `ssg`, so it goes into a private
+  // directory rather than the project's public `dist/`. Writing to `dist/` made `ssg` a
+  // second, undeclared writer of a directory that `xmlui build` also owns: two build
+  // tasks running concurrently in the same project would race, one emptying `dist/`
+  // while the other wrote into it (ENOTEMPTY), or -- worse -- silently producing a
+  // half-copied `dist-ssg/`. See https://github.com/xmlui-org/xmlui/issues/3848.
+  const clientBuildDir = ".xmlui-ssg-dist";
+  const clientBuildPath = path.resolve(cwd, clientBuildDir);
   const ssrBuildPath = path.resolve(cwd, ".xmlui-ssg-ssr");
   const ssrBundlePath = path.join(ssrBuildPath, "render.mjs");
   const builtIndexPath = path.join(outPath, "index.html");
@@ -670,20 +677,26 @@ export const ssg = async ({
   await mkdir(outPath, { recursive: true });
 
   log("building project assets");
-  await build({
-    buildMode: "INLINE_ALL",
-    withMock: true,
-    withHostingMetaFiles: false,
-    withRelativeRoot: false,
-    flatDist: false,
-  });
+  await rm(clientBuildPath, { recursive: true, force: true });
+  try {
+    await build({
+      buildMode: "INLINE_ALL",
+      withMock: true,
+      withHostingMetaFiles: false,
+      withRelativeRoot: false,
+      flatDist: false,
+      outDir: clientBuildDir,
+    });
 
-  if (!(await pathExists(distPath))) {
-    throw new Error(`dist folder was not generated: ${distPath}`);
+    if (!(await pathExists(clientBuildPath))) {
+      throw new Error(`client build folder was not generated: ${clientBuildPath}`);
+    }
+
+    log(`copying client build to ${outPath}`);
+    await cp(clientBuildPath, outPath, { recursive: true });
+  } finally {
+    await rm(clientBuildPath, { recursive: true, force: true });
   }
-
-  log(`copying dist to ${outPath}`);
-  await cp(distPath, outPath, { recursive: true });
 
   let shellHtml = await readFile(builtIndexPath, "utf-8");
 

--- a/xmlui/tests/nodejs/build-out-dir.test.ts
+++ b/xmlui/tests/nodejs/build-out-dir.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `build()` runs a real Vite build and reads the project's Vite config off disk.
+// Both are stubbed here: the point of these tests is the output-directory plumbing,
+// not the bundling.
+const viteBuildMock = vi.fn(async (_config: any): Promise<void> => undefined);
+
+vi.mock("vite", () => ({
+  build: (config: any) => viteBuildMock(config),
+}));
+
+vi.mock("../../src/nodejs/bin/viteConfig", () => ({
+  getViteConfig: async () => ({
+    build: {
+      rolldownOptions: { input: "index.html" },
+    },
+  }),
+}));
+
+const { build } = await import("../../src/nodejs/bin/build");
+
+function lastViteConfig() {
+  return viteBuildMock.mock.calls.at(-1)![0];
+}
+
+describe("build() output directory", () => {
+  beforeEach(() => {
+    viteBuildMock.mockClear();
+  });
+
+  it("writes to dist by default", async () => {
+    await build({ buildMode: "INLINE_ALL" });
+
+    expect(lastViteConfig().build.outDir).toBe("dist");
+  });
+
+  it("honors an explicit outDir", async () => {
+    await build({ buildMode: "INLINE_ALL", outDir: ".xmlui-ssg-dist" });
+
+    expect(lastViteConfig().build.outDir).toBe(".xmlui-ssg-dist");
+  });
+
+  it("keeps the rest of the project's build config", async () => {
+    await build({ buildMode: "INLINE_ALL", outDir: ".xmlui-ssg-dist" });
+
+    // Regression guard: the outDir override must merge into `build`, not replace it.
+    // Replacing it would drop the rolldown input and silently change what gets bundled.
+    expect(lastViteConfig().build.rolldownOptions).toEqual({ input: "index.html" });
+    expect(lastViteConfig().build.emptyOutDir).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #3848

## The problem

`xmlui ssg` needs a client build before it can prerender routes. It produced that build in `dist/` and copied it to `dist-ssg/` — which made `ssg` a second writer of a directory `xmlui build` already owns, with nothing ordering the two.

That is the race in #3848. Turbo declares `xmlui-integration-test-app#build → dist/**` and `#ssg → dist-ssg/**`, sees no shared output, and schedules them concurrently.

As the issue notes, **the crash is the lucky outcome.** When the timing falls the other way there is no error at all: `ssg` copies a half-written `dist/` into `dist-ssg/`, the run goes green, and the SSG integration tests run against that output.

## The fix

Candidate 3 from the issue — stop `xmlui ssg` writing to `dist/`.

The client build now goes to a private `.xmlui-ssg-dist/`, alongside the existing `.xmlui-ssg-ssr/` this file already uses for the SSR bundle, and is removed in a `finally` when the command finishes. `dist-ssg/` is unchanged; `dist/` is left alone.

This also settles candidate 2 (*"decide what `ssg`'s `outputs` should say"*) without ambiguity: `dist-ssg/**` is now a complete and accurate account of what the task writes, so it needed no change.

Candidate 1 (a `dependsOn` edge from `ssg` to `build`) is deliberately **not** included. With the shared writer gone the two tasks write disjoint trees, so the edge would buy nothing and cost the integration pipeline a serialized full build. It also would not have fixed the second, quieter half of the bug: with the edge, `ssg` always runs last and `dist/` — which the `vite-build` Playwright project serves — would deterministically hold `ssg`'s mock-enabled `INLINE_ALL` output rather than the `xmlui build --withMock false` output it is supposed to serve. Removing the second writer fixes both.

`build()` gains an `outDir` option (default `"dist"`), threaded into Vite's `build.outDir` and into the `CONFIG_ONLY` post-processing that writes `config.json` and the themes folder. Every existing caller keeps writing to `dist/`.

## Verification

The issue rightly warns that a green CI run proves nothing here, since passing afterwards is equally consistent with "fixed" and "got lucky". So the race was reproduced locally instead, by running the two tasks concurrently in `integration-tests/test-app` exactly as turbo does.

**Before the fix** — 5 concurrent runs, 1 failure, the same error as CI run 33099225260, same path, same stack:

```
Build failed with 1 error:

[plugin vite:prepare-out-dir]
Error: ENOTEMPTY: directory not empty, rmdir '.../integration-tests/test-app/dist/js'
    at emptyDir (vite/dist/node/chunks/node.js:1887:11)
    at prepareOutDir (vite/dist/node/chunks/node.js:32980:55)
```

**After the fix** — 13 concurrent runs, 0 failures, and every run produced a complete `dist/` (12 files) and `dist-ssg/` (15 files).

Beyond the loop:

- **`ssg` no longer touches `dist/`.** Hashed every file in `dist/` before and after a full `xmlui ssg` run: byte-identical. This is the observable that distinguishes "fixed" from "got lucky" for this fix — it holds on a single serial run, no timing required.
- `.xmlui-ssg-dist/` and `.xmlui-ssg-ssr/` are both gone after the command exits.
- `dist-ssg/` output is unchanged: same 15 files, prerendered markup and injected stylesheet links intact.
- Integration tests pass: `test:ssg` 11/11, `test:vite-build` 11/11.
- `CONFIG_ONLY` build path re-exercised (`xmlui build` with no `--buildMode`) — `dist/config.json` still lands correctly.
- `xmlui` node tests 40/40; `tsc --noEmit` clean on the changed files.

The new unit test (`xmlui/tests/nodejs/build-out-dir.test.ts`) pins the plumbing the fix rests on: that `outDir` reaches Vite's `build.outDir`, defaults to `"dist"`, and *merges* into the project's build config rather than replacing it. Confirmed it fails (3/3) with the `build:` merge removed — without it, `outDir` is silently dropped and `ssg` quietly goes back to writing `dist/`.

## Note

`xmlui ssg` no longer leaves a `dist/` behind as a side effect. Nothing in this repo consumed it — `website`'s `build-ssg` and the deploy workflow both work only out of `dist-ssg/` — but it is a visible change to the published CLI, so it ships with a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
