### PR TITLE
fix(DataSource): nested request params no longer pin the router (#3889)

### DIFF
--- a/xmlui/src/components-core/loader/DataLoader.tsx
+++ b/xmlui/src/components-core/loader/DataLoader.tsx
@@ -20,7 +20,7 @@ import { DataLoaderQueryKeyGenerator } from "../utils/DataLoaderQueryKeyGenerato
 import { PageableLoader } from "../loader/PageableLoader";
 import { Loader } from "../loader/Loader";
 import { useAppContext } from "../AppContext";
-import { useShallowCompareMemoize } from "../utils/hooks";
+import { useDeepCompareMemoize } from "../utils/hooks";
 import { useIndexerContext } from "../../components/App/IndexerContext";
 import { DataLoaderMd } from "./DataLoaderMd";
 import { useApiInterceptorContext } from "../interception/useApiInterceptorContext";
@@ -134,13 +134,22 @@ function DataLoader({
   );
 
   const rawUrl = extractParam(state, loader.props.url, appContext);
-  // The *Inner / useShallowCompareMemoize two-step is used for all request params:
-  // useMemo re-evaluates when state changes; useShallowCompareMemoize suppresses
-  // React Query re-fetches when the value is referentially new but shallowly equal.
+  // The *Inner / useDeepCompareMemoize two-step is used for all request params:
+  // useMemo re-evaluates when state changes; useDeepCompareMemoize suppresses
+  // React Query re-fetches when the value is referentially new but deeply equal.
+  //
+  // Deep (not shallow) comparison is required: request payloads are routinely
+  // nested (`body="{{ sql: '...', params: [] }}"`), and a shallow compare treats
+  // the fresh inner array/object as a change on every render. That churns the
+  // `queryId` identity, which re-runs the loader's `registerComponentApi` effect,
+  // which writes new component-API state, which re-renders — an endless render
+  // loop that starves React's concurrent rendering so router transitions never
+  // commit (the URL changes but the page does not).
+  // Fixes issue #3889: https://github.com/xmlui-org/xmlui/issues/3889
   const rawQueryParamsInner = useMemo(() => {
     return extractParam(state, loader.props.queryParams, appContext);
   }, [appContext, loader.props.queryParams, state]);
-  const rawQueryParams = useShallowCompareMemoize(rawQueryParamsInner);
+  const rawQueryParams = useDeepCompareMemoize(rawQueryParamsInner);
 
   // Normalize URL and query params to handle embedded query parameters
   // This ensures consistent behavior whether params are in URL or queryParams prop
@@ -181,12 +190,12 @@ function DataLoader({
   const bodyInner = useMemo(() => {
     return extractParam(state, loader.props.body, appContext);
   }, [appContext, loader.props.body, state]);
-  const body = useShallowCompareMemoize(bodyInner);
+  const body = useDeepCompareMemoize(bodyInner);
 
   const rawBodyInner = useMemo(() => {
     return extractParam(state, loader.props.rawBody, appContext);
   }, [appContext, loader.props.rawBody, state]);
-  const rawBody = useShallowCompareMemoize(rawBodyInner);
+  const rawBody = useDeepCompareMemoize(rawBodyInner);
 
   const pagingDirection: LoaderDirections | null = useMemo(() => {
     if (loader.props.prevPageSelector && loader.props.nextPageSelector) {
@@ -675,7 +684,7 @@ function DataLoader({
     if (!hasMockData) return undefined;
     return extractParam(state, loader.props.mockData, appContext);
   }, [hasMockData, appContext, loader.props.mockData, state]);
-  const mockDataValue = useShallowCompareMemoize(mockDataInner);
+  const mockDataValue = useDeepCompareMemoize(mockDataInner);
 
   const returnMockData = useCallback(() => {
     return mockDataValue ?? null;

--- a/xmlui/tests-e2e/datasource-nested-request-params-regression.spec.ts
+++ b/xmlui/tests-e2e/datasource-nested-request-params-regression.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from "../src/testing/fixtures";
+
+/**
+ * Regression for issue #3889:
+ * https://github.com/xmlui-org/xmlui/issues/3889
+ *
+ * A `DataSource` whose request params contain a *nested* value — the idiomatic
+ * `body="{{ sql: '...', params: [] }}"` from the docs — used to pin the router:
+ * while such a page was mounted, every route transition stopped. The URL changed
+ * (NavLink clicks, direct `location.hash` assignment) but the mounted page never did.
+ *
+ * Cause: request params were memoized with a *shallow* comparison, so the fresh
+ * inner array/object counted as a change on every render. That churned the loader's
+ * `queryId` identity, re-running its `registerComponentApi` effect, which wrote new
+ * component-API state, which re-rendered — an endless render loop that starved
+ * React's concurrent rendering so the router's transition never committed.
+ *
+ * The `params` are now compared deeply, so a deeply-equal payload keeps its identity.
+ */
+
+function buildApp(dataSourceAttrs: string) {
+  return `
+<App>
+  <NavPanel>
+    <NavLink label="Home" to="/" />
+    <NavLink label="Details" to="/details" />
+  </NavPanel>
+  <Pages>
+    <Page url="/"><H1>Home Page</H1></Page>
+    <Page url="/data">
+      <DataSource id="ds" url="/api/query" ${dataSourceAttrs} />
+      <H1>Data Page</H1>
+      <Text testId="loaded" value="{ds.loaded ? 'yes' : 'no'}" />
+    </Page>
+    <Page url="/details"><H1>Details Page</H1></Page>
+  </Pages>
+</App>
+`;
+}
+
+const cases: Array<{ name: string; attrs: string }> = [
+  {
+    name: "POST body with a nested array",
+    attrs: `method="POST" body="{{ sql: 'SELECT 1', params: [] }}"`,
+  },
+  {
+    name: "POST body with a nested object",
+    attrs: `method="POST" body="{{ sql: 'SELECT 1', opts: { limit: 10 } }}"`,
+  },
+  {
+    name: "GET queryParams with a nested array",
+    attrs: `queryParams="{{ sql: 'SELECT 1', params: [] }}"`,
+  },
+  {
+    name: "POST rawBody as a value-stable string",
+    attrs: `method="POST" rawBody="{JSON.stringify({ sql: 'SELECT 1', params: [] })}"`,
+  },
+];
+
+for (const { name, attrs } of cases) {
+  test(`route transitions still run with a DataSource using ${name}`, async ({
+    page,
+    initTestBed,
+  }) => {
+    let requestCount = 0;
+    await page.route(
+      (url) => url.pathname === "/api/query",
+      async (route) => {
+        requestCount++;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([{ id: 1 }]),
+        });
+      },
+    );
+
+    await initTestBed(buildApp(attrs));
+    await page.goto("/#/data");
+    await expect(page.getByRole("heading", { name: "Data Page" })).toBeVisible();
+    await expect(page.getByTestId("loaded")).toHaveText("yes");
+
+    // Leaving the page must work — this is what the render loop used to block.
+    await page.getByRole("link", { name: "Details" }).click();
+    await expect(page.getByRole("heading", { name: "Details Page" })).toBeVisible();
+
+    // ...and navigating back in, then away again, must keep working.
+    await page.goto("/#/data");
+    await expect(page.getByTestId("loaded")).toHaveText("yes");
+    await page.getByRole("link", { name: "Home" }).click();
+    await expect(page.getByRole("heading", { name: "Home Page" })).toBeVisible();
+
+    // A deeply-equal payload must not churn the react-query key into refetches.
+    // Two visits to the page — never one request per render.
+    expect(requestCount).toBeLessThanOrEqual(2);
+  });
+}
+
+test("a deeply-equal body does not refetch when unrelated state changes", async ({
+  page,
+  initTestBed,
+}) => {
+  let requestCount = 0;
+  await page.route(
+    (url) => url.pathname === "/api/query",
+    async (route) => {
+      requestCount++;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([{ id: 1 }]),
+      });
+    },
+  );
+
+  // `when` holds the request until after mount so it cannot race the test bed's
+  // API interceptor coming up — the same pattern as the other DataSource regressions.
+  await initTestBed(`
+    <Fragment var.armed="{false}" var.tick="{0}">
+      <DataSource id="ds" url="/api/query" method="POST" when="{armed}"
+        body="{{ sql: 'SELECT 1', params: [] }}" />
+      <Button testId="arm-btn" label="Arm" onClick="armed = true" />
+      <Button testId="tick-btn" label="Tick" onClick="tick++" />
+      <Text testId="tick" value="{tick}" />
+      <Text testId="loaded" value="{ds.loaded ? 'yes' : 'no'}" />
+    </Fragment>
+  `);
+
+  await page.getByTestId("arm-btn").click();
+  await expect(page.getByTestId("loaded")).toHaveText("yes");
+  expect(requestCount).toEqual(1);
+
+  // Re-render the tree a few times; the body is deeply equal every time, so the
+  // loader must not issue another request.
+  for (let i = 0; i < 3; i++) {
+    await page.getByTestId("tick-btn").click();
+  }
+  await expect(page.getByTestId("tick")).toHaveText("3");
+  expect(requestCount).toEqual(1);
+});
+
+test("a body whose value actually changes still refetches", async ({ page, initTestBed }) => {
+  const bodies: any[] = [];
+  await page.route(
+    (url) => url.pathname === "/api/query",
+    async (route) => {
+      bodies.push(JSON.parse(route.request().postData() ?? "null"));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        // Response length tracks the request count so the UI can observe the refetch.
+        body: JSON.stringify(bodies.map((_, i) => ({ id: i + 1 }))),
+      });
+    },
+  );
+
+  await initTestBed(`
+    <Fragment var.armed="{false}" var.limit="{10}">
+      <DataSource id="ds" url="/api/query" method="POST" when="{armed}"
+        body="{{ sql: 'SELECT 1', opts: { limit: limit } }}" />
+      <Button testId="arm-btn" label="Arm" onClick="armed = true" />
+      <Button testId="bump-btn" label="Bump" onClick="limit = limit + 10" />
+      <Text testId="count" value="{ds.loaded ? ds.value.length : 0}" />
+    </Fragment>
+  `);
+
+  await page.getByTestId("arm-btn").click();
+  await expect(page.getByTestId("count")).toHaveText("1");
+  await page.getByTestId("bump-btn").click();
+  await expect(page.getByTestId("count")).toHaveText("2");
+
+  // The nested `opts.limit` change must reach the wire.
+  expect(bodies.map((b) => b?.opts?.limit)).toEqual([10, 20]);
+});


### PR DESCRIPTION
Fixes #3889.

## What was happening

A `DataSource` whose request params contained a **nested** value froze routing for as long as the page stayed mounted. `NavLink` clicks and direct `location.hash` assignment updated the URL, but the mounted page never changed. Navigating *into* such a page worked; leaving it never did.

The reporter identified the `body` object literal as the trigger and a value-stable `rawBody` string as the cure. Bisecting further, the actual trigger is **nesting**, not POST and not `body`:

| DataSource | Navigates away? |
| --- | --- |
| `method="POST" body="{{ sql: '…' }}"` (flat) | ✅ |
| `method="POST" body="{{ sql: '…', params: [] }}"` | ❌ pinned |
| `method="POST" body="{{ sql: '…', opts: { limit: 10 } }}"` | ❌ pinned |
| `queryParams="{{ sql: '…', params: [] }}"` (**GET**) | ❌ pinned |
| `method="POST" rawBody="{JSON.stringify(…)}"` | ✅ |

So a plain GET with nested `queryParams` pins the router too — the report's POST framing was incidental.

## Root cause

`DataLoader` memoized request params with `useShallowCompareMemoize`, which compares one level deep. A freshly built inner array/object therefore counted as a change on **every render**, and that fed a self-sustaining loop:

```
nested value → new `body` identity → new `queryId` identity
  → new `queryKey` + `cancel` identity
  → Loader's `registerComponentApi` effect re-runs        (Loader.tsx, deps include queryId/cancel)
  → `setComponentApis` stores new API function identities (StateContainer.tsx)
  → re-render → back to the top
```

This is an endless render loop. It issues **no extra requests** — react-query hashes its key, so the deeply-equal key still resolves to one cache entry, which is exactly why the report saw "exactly one POST per page load" and no fetch loop. What it does do is continuously starve React's concurrent rendering, so the router's transition never gets to commit: `history` updates the URL synchronously, but the deferred route render is restarted before it can finish. Hence "the URL changes but the page does not", with no console error.

`rawBody="{JSON.stringify(…)}"` cured it because a string is value-comparable, so the identity stayed stable and the loop never started.

## The fix

Compare the request params **deeply** (`useDeepCompareMemoize`) in `DataLoader`, for `queryParams`, `body`, `rawBody` and `mockData`.

This was already the stated intent of the existing two-step — the in-code comment says it exists to suppress re-fetches when a value is "referentially new but shallowly equal"; shallow comparison just could not deliver that for the nested payloads the docs themselves recommend. Keeping a deeply-equal payload's identity stable breaks the loop at its source, so it fixes both `Loader` and `PageableLoader`, whose API registration shares the same shape. Values that genuinely change still get a new identity and still refetch.

`mockData` gets the same treatment: an array of object literals is rebuilt per render and shallow-compares by element reference, so it had the identical bug.

Deep comparison costs no more than the payload size, and lodash `isEqual` short-circuits on reference equality, so the already-memoized common case stays O(1).

## Tests

New `xmlui/tests-e2e/datasource-nested-request-params-regression.spec.ts`:

- Route transitions still run with nested arrays in `body`, nested objects in `body`, nested `queryParams`, and a value-stable `rawBody` — each navigating out, back in, and out again.
- A deeply-equal body does **not** refetch when unrelated state re-renders the tree.
- A body whose nested value **actually** changes still refetches, and the new value reaches the wire.

The three nested-value cases fail on `main` and pass with the fix; the other three pass both ways (guarding against over-correction into "never refetch").

Verification: full `xmlui-nonsmoke` e2e suite (6283 passed) and the unit suite (11296 passed) are green. The one unrelated `List` scroll-timing failure in the full run passes 3/3 in isolation and does not touch the loader.

## Not in this PR

- The `rawBody` parser papercut the issue mentions in passing (an attribute literal starting with `{` is read as an unclosed binding expression) is a separate docs/parser concern.
- `Loader` / `PageableLoader` still register a fresh component-API object whenever `queryId` identity churns. This fix removes the realistic way to trigger that, but stabilizing the registration would harden the whole class of "identity churn starves the router" — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)