### PR TITLE
docs: explain loading served CSV data

### DIFF
--- a/website/content/docs/pages/core-properties.md
+++ b/website/content/docs/pages/core-properties.md
@@ -124,3 +124,5 @@ When the value is a string, it is interpreted as a URL that returns JSON:
    <Text>{$item.name}: {$item.lineStatuses[0].statusSeverityDescription}</Text>
 </List>
 ```
+
+For a URL that doesn't return JSON — a served CSV or plain text file — use an explicit [`DataSource`](/docs/reference/components/DataSource#datatype) with `dataType` set instead of relying on the string-as-URL shorthand. See [Load a served CSV into a table](/docs/howto/load-a-served-csv-into-a-table).

--- a/website/content/docs/pages/howto/load-a-served-csv-into-a-table.md
+++ b/website/content/docs/pages/howto/load-a-served-csv-into-a-table.md
@@ -1,0 +1,79 @@
+# Load a served CSV into a table
+
+Point a `DataSource` at a CSV URL with `dataType="csv"` and bind `Table` columns to the header row — no upload, no manual parsing.
+
+If a CSV file is already reachable at a URL, you don't need `FileInput` or a parsing library. Set `dataType="csv"` on a `DataSource` and it fetches the file, parses it, and hands you an array of row objects keyed by the header row — the same shape a JSON API would return.
+
+```xmlui-pg copy display name="Load a served CSV into a table" id="load-served-csv"
+<App>
+  <DataSource id="products" url="/resources/files/sample-products.csv" dataType="csv" />
+
+  <Table data="{products}" testId="productsTable">
+    <Column bindTo="name" />
+    <Column bindTo="price" />
+    <Column bindTo="category" />
+    <Column bindTo="inStock" />
+  </Table>
+</App>
+```
+
+The `Column bindTo` values (`name`, `price`, `category`, `inStock`) come straight from `sample-products.csv`'s first line. Change the file and the columns you can bind to change with it.
+
+## Those explicit `Column` elements are optional
+
+When the shape of the file is not known ahead of time, let `Table` infer one column per field from the loaded rows:
+
+```xmlui-pg copy display name="Infer Table columns from the loaded CSV" id="infer-table-columns-from-csv"
+<App>
+  <DataSource id="products" url="/resources/files/sample-products.csv" dataType="csv" />
+  <Table data="{products}" testId="inferredProductsTable" />
+</App>
+```
+
+The inferred table updates when the `DataSource` finishes loading.
+
+## Data typing
+
+CSV values arrive as strings. Convert the fields you need before binding them to a table when sorting, formatting, or arithmetic must use their data type.
+
+### When the CSV already has an `id`
+
+This file includes a stable `id` column, so Table can sort its rows directly. The transform only converts `price` to a number:
+
+```xmlui-pg copy display name="Sort rows that already have IDs" id="csv-data-typing-existing-ids"
+<App>
+  <DataSource
+    id="products"
+    url="/resources/files/sample-products-with-ids.csv"
+    dataType="csv"
+    transformResult="{data => data.map(row => ({ ...row, price: Number(row.price) }))}"
+  />
+
+  <Table
+    data="{products}"
+    testId="typedProductsWithIdsTable"
+  >
+    <Column bindTo="name" />
+    <Column bindTo="price" type="currency(USD)" canSort="true" />
+    <Column bindTo="category" />
+  </Table>
+</App>
+```
+
+The `price` column opts into sorting with `canSort="true"`; clicking its header sorts the numeric values, and the currency renderer receives a number.
+
+Reach for `transformResult` (or `resultSelector` for a simpler nested-path extraction) whenever the raw parsed rows aren't ready to bind as-is — converting types is the most common case for CSV, but the same mechanism reshapes or filters rows too.
+
+---
+
+## Key points
+
+**`dataType="csv"` is a `DataSource` prop, not a component of its own**: the two-line pattern — `DataSource` plus a `Table` bound to it — is the whole recipe. No `FileInput`, no manual `Papa.parse` call.
+
+**Every value is a string until you convert it**: use `transformResult` when a value needs to sort, format, or compute correctly.
+
+## See also
+
+- [Parse uploaded files as CSV or JSON](/docs/howto/parse-uploaded-files-as-csv-or-json) — the upload-and-parse entry point (`FileInput` + `parseAs`), for when the CSV comes from the user rather than a URL
+- [Transform nested API responses](/docs/howto/filter-and-transform-data-from-an-api) — more on `resultSelector` and `transformResult`
+- [DataSource](/docs/reference/components/DataSource#datatype) — full reference, including `dataType`, `transformResult`, and `resultSelector`

--- a/website/public/resources/files/sample-products-with-ids.csv
+++ b/website/public/resources/files/sample-products-with-ids.csv
@@ -1,0 +1,7 @@
+id,name,price,category,inStock
+1,Widget,9.99,Tools,true
+2,Gadget,19.99,Electronics,true
+3,Doohickey,4.99,Misc,false
+4,Thingamajig,14.99,Tools,true
+5,Whatsit,24.99,Electronics,true
+6,Gizmo,7.99,Misc,true

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -734,6 +734,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Load a served CSV into a table"
+                            to="/docs/howto/load-a-served-csv-into-a-table"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Update UI optimistically"
                             to="/docs/howto/update-ui-optimistically"
                         />

--- a/xmlui/tests-e2e/how-to-examples/load-a-served-csv-into-a-table.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/load-a-served-csv-into-a-table.spec.ts
@@ -1,0 +1,101 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/load-a-served-csv-into-a-table.md",
+  ),
+);
+
+// The website serves /resources/files/sample-products.csv for real (see
+// website/public/resources/files/sample-products.csv), but the Playwright
+// test bed's static server does not carry that file. Mock the same URL here
+// so the parsing behavior under test — not the hosting — is what's pinned.
+const sampleProductsCsv =
+  "name,price,category,inStock\n" +
+  "Widget,9.99,Tools,true\n" +
+  "Gadget,19.99,Electronics,true\n" +
+  "Doohickey,4.99,Misc,false\n" +
+  "Thingamajig,14.99,Tools,true\n" +
+  "Whatsit,24.99,Electronics,true\n" +
+  "Gizmo,7.99,Misc,true";
+
+const sampleProductsWithIdsCsv = sampleProductsCsv
+  .split("\n")
+  .map((row, index) => (index === 0 ? `id,${row}` : `${index},${row}`))
+  .join("\n");
+
+const sampleProductsInterceptor = {
+  operations: {
+    "sample-products-csv": {
+      url: "/resources/files/sample-products.csv",
+      method: "get",
+      handler: `return ${JSON.stringify(sampleProductsCsv)};`,
+    },
+    "sample-products-with-ids-csv": {
+      url: "/resources/files/sample-products-with-ids.csv",
+      method: "get",
+      handler: `return ${JSON.stringify(sampleProductsWithIdsCsv)};`,
+    },
+  },
+};
+
+test.describe("Load a served CSV into a table", { tag: "@website" }, () => {
+  const { app, components } = extractXmluiExample(markdown, "load-served-csv");
+
+  test("header-derived bindTo produces populated cells", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor: sampleProductsInterceptor });
+
+    const table = page.getByTestId("productsTable");
+    await expect(table).toContainText("Widget");
+    await expect(table).toContainText("9.99");
+    await expect(table).toContainText("Tools");
+    await expect(table).toContainText("true");
+    await expect(table).toContainText("Gizmo");
+  });
+});
+
+test.describe("Infer Table columns from the loaded CSV", { tag: "@website" }, () => {
+  const { app, components } = extractXmluiExample(markdown, "infer-table-columns-from-csv");
+
+  test("loaded rows create sortable columns without explicit Column children", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor: sampleProductsInterceptor });
+
+    const table = page.getByTestId("inferredProductsTable");
+    await expect(table.locator("th")).toHaveCount(4);
+    await expect(table.locator("th").nth(0)).toContainText("name");
+    await expect(table.locator("th").nth(1)).toContainText("price");
+    await expect(table).toContainText("Widget");
+    await expect(table).toContainText("24.99");
+
+    const priceHeader = table.locator("th").filter({ hasText: "price" }).locator("button");
+    await expect(priceHeader).toBeVisible();
+  });
+});
+
+test.describe("Sort CSV values with row identity", { tag: "@website" }, () => {
+  const { app: existingIdApp, components: existingIdComponents } = extractXmluiExample(
+    markdown,
+    "csv-data-typing-existing-ids",
+  );
+
+  test("rows with an existing id sort after price conversion", async ({ initTestBed, page }) => {
+    await initTestBed(existingIdApp, {
+      components: existingIdComponents,
+      apiInterceptor: sampleProductsInterceptor,
+    });
+
+    const table = page.getByTestId("typedProductsWithIdsTable");
+    await expect(table.locator("th").filter({ hasText: "price" }).locator("button")).toBeVisible();
+    await table.locator("th").filter({ hasText: "price" }).locator("button").click();
+    await expect(table.locator("tbody tr").first()).toContainText("4.99");
+  });
+});


### PR DESCRIPTION
Jon's Codex (Bram 0.6.6, main thread, GPT-5, macOS, Tuck) speaking from the XMLUI project (github.com/xmlui-org/xmlui):

## Summary

- add a how-to for loading a served CSV through `DataSource dataType="csv"` into a `Table`
- document header-derived bindings, inferred columns, row identity, and numeric conversion for sorting
- cross-link the core `data` property reference and add a served CSV fixture
- cover all three playground examples with website E2E tests

Refs #3886

## Verification

- `npm run _e2e -- xmlui/tests-e2e/how-to-examples/load-a-served-csv-into-a-table.spec.ts --workers=2` — 3 passed
