### PR TITLE
docs: explain cross-view Table correlation

### DIFF
--- a/website/content/docs/pages/howto/correlate-a-table-with-another-view.md
+++ b/website/content/docs/pages/howto/correlate-a-table-with-another-view.md
@@ -1,0 +1,105 @@
+# Correlate a Table with another view
+
+Hovering a `Table` row highlights the matching rows in a companion view below it; clicking pins the highlight so it survives scrolling and pointer movement, until the same row is clicked again or another row is clicked.
+
+The views are linked by a shared key: the Table's `id` matches each companion item's `orderId`. The example keeps that key visible as an **Order** column and label, so the relationship is understandable before you hover.
+
+The state model is two variables: one holds the transient hover target, the other holds the pinned target. `onRowEnter` and `onRowLeave` set and clear the hover variable, but only while nothing is pinned — once a pin is live, hovering a different row must not steal the highlight. `onRowClick` toggles the pin: the same row releases it, a different row moves it. Every surface that needs to know "what's active right now" reads `pinned ?? hovered` — the pin wins when present, the hover value stands in when it isn't.
+
+```xmlui-pg copy display name="Hover to highlight, click to pin" height="700px"
+---app display
+<App
+  var.hoveredId="{null}"
+  var.pinnedId="{null}"
+  var.orders="{[
+    { id: 1, customer: 'Acme Corp', total: 420 },
+    { id: 2, customer: 'Globex', total: 150 },
+    { id: 3, customer: 'Initech', total: 980 }
+  ]}"
+>
+  <VStack gap="$space-4">
+    <Table
+      data="{orders.map(order => ({
+        ...order,
+        isActive: (pinnedId ?? hoveredId) === order.id
+      }))}"
+      onRowEnter="(item) => { if (!pinnedId) hoveredId = item.id; }"
+      onRowLeave="() => { if (!pinnedId) hoveredId = null; }"
+      onRowClick="(item) => {
+        pinnedId = pinnedId === item.id ? null : item.id;
+      }"
+    >
+      <Column bindTo="id" header="Order" width="80px" />
+      <Column bindTo="customer" header="Customer">
+        <Text
+          testId="{'order-' + $item.id}"
+          width="100%"
+          backgroundColor="{$item.isActive ? '$color-primary-100' : ''}"
+        >{$cell}</Text>
+      </Column>
+      <Column bindTo="total" header="Total">
+        <Text
+          width="100%"
+          backgroundColor="{$item.isActive ? '$color-primary-100' : ''}"
+        >${$cell}</Text>
+      </Column>
+    </Table>
+
+    <Text variant="secondary">
+      Shared Order values connect the rows: the Table's id matches each item's orderId.
+    </Text>
+    <Text variant="strong">Items</Text>
+    <Items
+      data="{[
+        { orderId: 1, product: 'Keyboard', qty: 4 },
+        { orderId: 1, product: 'Mouse', qty: 1 },
+        { orderId: 2, product: 'Monitor', qty: 10 },
+        { orderId: 3, product: 'Webcam', qty: 2 },
+        { orderId: 3, product: 'Headset', qty: 3 }
+      ]}"
+    >
+      <HStack
+        testId="{'line-' + $item.product}"
+        padding="$space-2"
+        verticalAlignment="center"
+        backgroundColor="{(pinnedId ?? hoveredId) === $item.orderId 
+          ? '$color-primary-100' : ''}"
+      >
+        <Text width="80px" variant="secondary">Order {$item.orderId}</Text>
+        <Text width="100px">{$item.product}</Text>
+        <Text variant="secondary">qty {$item.qty}</Text>
+      </HStack>
+    </Items>
+
+    <Text variant="secondary">
+      {pinnedId ? 'Pinned: order ' + pinnedId : 'Hover an order to preview its items; click to pin.'}
+    </Text>
+  </VStack>
+</App>
+```
+
+## Key points
+
+**Two variables, one derived expression**: `hoveredId` and `pinnedId` are the only state. Nothing else needs its own variable — every place that renders a highlight computes it inline from `pinnedId ?? hoveredId`, so the pin and the hover can never fall out of sync with each other.
+
+**Guard the hover handlers, not the read side**: `onRowEnter` and `onRowLeave` check `if (!pinnedId)` before touching `hoveredId`. This is what makes "hovering while pinned does not move the highlight" true — the hover variable simply stops updating while a pin is live, rather than every reader having to re-check which one currently applies.
+
+**`onRowClick` is a toggle, not a setter**: `pinnedId = pinnedId === item.id ? null : item.id` covers all three cases the scenario needs — clicking the pinned row clears it, clicking a different row replaces it, and clicking when nothing is pinned sets it — in one line.
+
+**The visual cue reuses conditional `backgroundColor`**: both the `Table` cell wrapper and the companion `Items` row compute their `backgroundColor` from the same `(pinnedId ?? hoveredId) === ...` comparison against their own id field. See [Highlight rows conditionally](/docs/howto/highlight-rows-conditionally) for the underlying technique — this page applies it to interaction state instead of data values.
+
+## Why not selection
+
+`rowsSelectable` with single selection looks like a shortcut to the same behavior, and it isn't one: clicking a row always **sets** the selection to that row — there is no code path that clicks a selected row and clears it. A pin needs release-on-second-click, and single-row selection cannot express that; it can only ever select "the" row.
+
+`rowClick` is the right tool here precisely because it stays out of selection's way: it "reports the click without replacing or suppressing selection," so it's free for the app to interpret as a toggle, an action, or anything else that isn't "the current choice." Reach for `rowsSelectable` and `selectionDidChange` instead when a row should stay chosen until something else is picked — see [Build a master–detail layout](/docs/howto/build-a-master-detail-layout) for that case. Reach for `rowClick` when the click is a toggle, not a choice.
+
+One more boundary worth knowing before you rely on it: `rowClick` does not fire for a click on the selection checkbox, nor for a click on an interactive control (a button, say) inside a cell. That's what lets a pin toggle and per-row action buttons coexist in the same table without one intercepting the other's clicks.
+
+---
+
+## See also
+
+- [Highlight rows conditionally](/docs/howto/highlight-rows-conditionally) — the `backgroundColor`/`color` technique this page applies to interaction state
+- [Build a master–detail layout](/docs/howto/build-a-master-detail-layout) — use `rowsSelectable` instead when a row should stay chosen, not toggled
+- [Enable multi-row selection in a table](/docs/howto/enable-multi-row-selection-in-a-table) — selection for bulk actions rather than correlation

--- a/website/src/Main.xmlui
+++ b/website/src/Main.xmlui
@@ -840,6 +840,11 @@
                         />
                         <NavLink
                             icon="article"
+                            label="Correlate a Table with another view"
+                            to="/docs/howto/correlate-a-table-with-another-view"
+                        />
+                        <NavLink
+                            icon="article"
                             label="Auto-size column widths with star"
                             to="/docs/howto/auto-size-column-widths-with-star"
                         />

--- a/xmlui/tests-e2e/how-to-examples/correlate-a-table-with-another-view.spec.ts
+++ b/xmlui/tests-e2e/how-to-examples/correlate-a-table-with-another-view.spec.ts
@@ -1,0 +1,158 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "../../src/testing/fixtures";
+import { getExampleSource, extractXmluiExample } from "../../src/testing/website-example-utils";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const markdown = getExampleSource(
+  path.join(
+    __dirname,
+    "../../../website/content/docs/pages/howto/correlate-a-table-with-another-view.md",
+  ),
+);
+
+test.describe("Hover to highlight, click to pin", { tag: "@website" }, () => {
+  const { app, components, apiInterceptor } = extractXmluiExample(
+    markdown,
+    "Hover to highlight, click to pin",
+  );
+
+  test("renders the table and the companion items", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+    await expect(page.getByRole("cell", { name: "Acme Corp" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Globex" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Initech" })).toBeVisible();
+    await expect(page.getByTestId("line-Keyboard")).toBeVisible();
+    await expect(page.getByTestId("line-Monitor")).toBeVisible();
+    await expect(page.getByTestId("line-Webcam")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Shared Order values connect the rows: the Table's id matches each item's orderId.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByText("Order 1", { exact: true })).toHaveCount(2);
+  });
+
+  test("hovering a row highlights its related companion rows", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const keyboardLine = page.getByTestId("line-Keyboard");
+    const monitorLine = page.getByTestId("line-Monitor");
+    const neutral = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Acme Corp" }).hover();
+
+    await expect
+      .poll(() => keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .not.toBe(neutral);
+    // Globex's items are unrelated to the hovered Acme Corp row.
+    await expect(monitorLine).toHaveCSS("background-color", neutral);
+  });
+
+  test("leaving the row clears the highlight when nothing is pinned", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const keyboardLine = page.getByTestId("line-Keyboard");
+    const neutral = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Acme Corp" }).hover();
+    await expect
+      .poll(() => keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .not.toBe(neutral);
+
+    // Move the pointer off the table entirely.
+    await page.getByText("Items", { exact: true }).hover();
+    await expect(keyboardLine).toHaveCSS("background-color", neutral);
+  });
+
+  test("clicking pins the highlight and it survives pointer leave", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const keyboardLine = page.getByTestId("line-Keyboard");
+    const acmeCell = page.getByTestId("order-1");
+    const neutral = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const neutralAcme = await acmeCell.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Acme Corp" }).click();
+    await expect(page.getByText("Pinned: order 1")).toBeVisible();
+
+    await expect
+      .poll(() => acmeCell.evaluate((el) => getComputedStyle(el).backgroundColor))
+      .not.toBe(neutralAcme);
+
+    const pinnedColor = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(pinnedColor).not.toBe(neutral);
+
+    // Move the pointer away — the pin, not the hover, should still be driving the highlight.
+    await page.getByText("Items", { exact: true }).hover();
+    await expect(keyboardLine).toHaveCSS("background-color", pinnedColor);
+    await expect(acmeCell).not.toHaveCSS("background-color", neutralAcme);
+  });
+
+  test("clicking the pinned row again releases it", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const keyboardLine = page.getByTestId("line-Keyboard");
+    const neutral = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Acme Corp" }).click();
+    await expect(page.getByText("Pinned: order 1")).toBeVisible();
+
+    await page.getByRole("cell", { name: "Acme Corp" }).click();
+    await expect(
+      page.getByText("Hover an order to preview its items; click to pin."),
+    ).toBeVisible();
+
+    // The pointer is still physically over the row post-release, so it still
+    // reads as hovered until the pointer actually moves off it.
+    await page.getByText("Items", { exact: true }).hover();
+    await expect(keyboardLine).toHaveCSS("background-color", neutral);
+  });
+
+  test("clicking a different row moves the pin", async ({ initTestBed, page }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const keyboardLine = page.getByTestId("line-Keyboard");
+    const webcamLine = page.getByTestId("line-Webcam");
+    const neutral = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Acme Corp" }).click();
+    await expect(page.getByText("Pinned: order 1")).toBeVisible();
+    const pinnedColor = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Initech" }).click();
+    await expect(page.getByText("Pinned: order 3")).toBeVisible();
+
+    await expect(keyboardLine).toHaveCSS("background-color", neutral);
+    await expect(webcamLine).toHaveCSS("background-color", pinnedColor);
+  });
+
+  test("hovering a different row while pinned does not move the highlight", async ({
+    initTestBed,
+    page,
+  }) => {
+    await initTestBed(app, { components, apiInterceptor });
+
+    const keyboardLine = page.getByTestId("line-Keyboard");
+    const monitorLine = page.getByTestId("line-Monitor");
+    const neutral = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    await page.getByRole("cell", { name: "Acme Corp" }).click();
+    const pinnedColor = await keyboardLine.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(pinnedColor).not.toBe(neutral);
+
+    // Hover the Globex row while Acme Corp is pinned.
+    await page.getByRole("cell", { name: "Globex" }).hover();
+
+    await expect(keyboardLine).toHaveCSS("background-color", pinnedColor);
+    await expect(monitorLine).toHaveCSS("background-color", neutral);
+    await expect(page.getByText("Pinned: order 1")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Jon's Codex (Bram 0.6.6, main thread, GPT-5, macOS, Tuck) speaking from the XMLUI project (github.com/xmlui-org/xmlui):

## Summary

- add a how-to for correlating a `Table` with a companion view through row hover and click-to-pin interactions
- demonstrate a two-variable transient/pinned state model with matching highlights across both views
- explain why single-row selection cannot implement release-on-second-click semantics
- add website E2E coverage for hover, leave, pin, release, move, and hover-while-pinned behavior

Refs #3833

## Verification

- `npm --prefix xmlui run test:e2e -- tests-e2e/how-to-examples/correlate-a-table-with-another-view.spec.ts --workers=2` — 7 passed
