### PR TITLE
fix(Table): render rowDetailTemplate beneath its row, not beside it

### DIFF
--- a/.changeset/table-row-detail-below-row.md
+++ b/.changeset/table-row-detail-below-row.md
@@ -1,0 +1,5 @@
+---
+"xmlui": patch
+---
+
+Fix: `Table`'s `rowDetailTemplate` now renders beneath its row instead of beside it. An expanded row already carried `flex-wrap: wrap`, but the row's `min-width: max-content` reserved space for the detail on the cell line (a wrapping flex container measures `max-content` as if every item shared one line), and the detail's flex basis matched the column total rather than the row. The detail therefore sat to the right of the last cell, and scrolled off-screen entirely once the columns overflowed horizontally.

--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -2867,6 +2867,40 @@ test.describe("Basic Functionality", () => {
       await page.getByTestId("check-expanded").click();
       await expect.poll(testStateDriver.testState).toEqual("fileA");
     });
+
+    test("renders the detail below the row cells, not beside them", async ({
+      initTestBed,
+      page,
+    }) => {
+      await initTestBed(`
+        <Table
+          data='{${JSON.stringify(fileData)}}'
+          idKey="path"
+          initiallyExpandedRowIds="{['fileB']}"
+          testId="table"
+        >
+          <Column bindTo="path" header="File" width="100px"/>
+          <Column bindTo="changes" header="Changes" width="90px"/>
+          <property name="rowDetailTemplate">
+            <VStack testId="detail-{$rowId}">
+              <Text value="{$item.diff}" />
+            </VStack>
+          </property>
+        </Table>
+      `);
+
+      const detail = page.getByTestId("detail-fileB");
+      await expect(detail).toBeVisible();
+
+      const detailBox = (await detail.boundingBox())!;
+      const cellBox = (await page.getByText("fileB", { exact: true }).boundingBox())!;
+
+      // --- The detail belongs in a full-width area *beneath* its row. Rendering it as
+      // --- another flex item inside the cell row puts it to the right of the last cell
+      // --- (and off-screen entirely once the columns overflow horizontally).
+      expect(detailBox.y).toBeGreaterThanOrEqual(cellBox.y + cellBox.height);
+      expect(detailBox.x).toBeLessThanOrEqual(cellBox.x);
+    });
   });
 
   test.describe("noDataTemplate property", () => {

--- a/xmlui/src/components/Table/TableReact.tsx
+++ b/xmlui/src/components/Table/TableReact.tsx
@@ -2486,7 +2486,14 @@ export const Table = memo(
                 ...style,
                 boxSizing: "content-box",
                 minHeight: s.rowHeight,
-                minWidth: "max-content",
+                // --- `max-content` keeps a row from shrinking below its cells while the
+                // --- table scrolls horizontally. An expanded row wraps its detail onto a
+                // --- second line (see `.expanded { flex-wrap: wrap }`), and `max-content`
+                // --- on a wrapping flex container is measured as if every item shared one
+                // --- line — which reserves room for the detail beside the cells and so
+                // --- prevents the very wrap it needs. Pin the floor to the cells' own
+                // --- width instead; it is what `max-content` resolves to for those cells.
+                minWidth: isExpanded ? s.totalColumnWidth : "max-content",
                 userSelect: effectiveRowUserSelect,
                 WebkitUserSelect: effectiveRowWebkitUserSelect,
               }}
@@ -2639,8 +2646,12 @@ export const Table = memo(
                   className={styles.rowDetailCell}
                   colSpan={s.visibleColumnCount}
                   style={{
-                    width: s.totalColumnWidth,
-                    flexBasis: s.totalColumnWidth,
+                    // --- A full-width basis is what pushes the detail onto its own line:
+                    // --- it cannot share a line with the cells at any container width.
+                    // --- Sizing it to the column total instead would let a container wide
+                    // --- enough for both fit it beside them.
+                    width: "100%",
+                    flexBasis: "100%",
                     flexShrink: 0,
                   }}
                 >


### PR DESCRIPTION
## The bug

`Table`'s `rowDetailTemplate` rendered its detail area to the right of the last cell, on the same visual line as the row. Once the columns overflowed their container horizontally, the detail was pushed off-screen entirely — so it looked like it had simply not rendered.

The component's own metadata promises the opposite: *"Template rendered in a full-width detail area beneath an expanded row."*

Repro:

```xmlui
<App>
  <Table idKey="path" initiallyExpandedRowIds="{['b.ts']}"
    data="{[
      { path: 'a.ts', changes: '+3 -1', diff: 'DETAIL A' },
      { path: 'b.ts', changes: '+12 -0', diff: 'DETAIL B' }
    ]}">
    <Column bindTo="path" header="File" width="100px" />
    <Column bindTo="changes" header="Changes" width="90px" />
    <property name="rowDetailTemplate">
      <VStack padding="$space-3" backgroundColor="$color-surface-100">
        <Text variant="mono" value="{$item.diff}" />
      </VStack>
    </property>
  </Table>
</App>
```

## Cause

The intent was already in the stylesheet — `.expanded` carries `flex-wrap: wrap`, so the detail was meant to wrap onto its own line. Two things defeated it:

- **The row's inline `min-width: max-content`.** A wrapping flex container measures `max-content` as though every item shared a single line, so the floor included the detail and reserved room for it *beside* the cells, preventing the wrap it was supposed to allow.
- **The detail's `flex-basis: <column total>`.** A container wide enough for the cells and the detail together could still fit both on one line.

`colSpan` never contributed: `.table` and `tbody` are `display: block` and rows are flex, so native table layout is off.

## Fix

Two lines in `TableReact.tsx`, no restructuring:

- Expanded rows pin `min-width` to `table.getTotalSize()` rather than `max-content`. That is what `max-content` resolves to for the cells alone, so the horizontal-scroll behaviour it was there for is preserved.
- The detail gets `flex-basis: 100%`, which cannot share a line at any container width.

The detail deliberately stays a `<td>` inside the existing `<tr>`. Moving it to a sibling row element was considered and rejected: `virtua` observes one element per item, and a `<div>` inside `<tr>` would be foster-parented out of the table during SSG hydration.

## Testing

- New regression test asserting the detail's bounding box is **below** the row's cells and left-aligned with them. Confirmed failing before the fix, passing after.
- Full `Table.spec.ts` suite: **289/289 passing**, and again at `--workers=10`.
- Type-check unchanged: 9 pre-existing errors in unrelated vitest files, identical with the change stashed.
- Both repro cases verified visually in the docs site, including the overflow case.

The existing `rowDetailTemplate` tests only asserted text content and element count — never position — which is why this went unnoticed.

## Context

Found while writing the how-to for #3858. That page originally documented `rowDetailTemplate` as the answer to the row-expansion half of the problem; the example had to be pulled once this surfaced. With this fixed, that section is worth restoring, and the `Table` reference docs (which currently omit `rowDetailTemplate`, `expandedRowIds`, `initiallyExpandedRowIds`, and `rowExpansionDidChange`) pick them up on the next `generate-all-docs` run.

Related: #3857 added the feature; #3858 is the documentation issue that surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)