### PR TITLE
fix(Table): click-to-sort no longer no-ops on rows without an id (#3887)

### DIFF
--- a/xmlui/src/components/Table/Table.spec.ts
+++ b/xmlui/src/components/Table/Table.spec.ts
@@ -7986,3 +7986,53 @@ test.describe("column binding error containment", () => {
     await expect(page.locator("td").nth(1)).toHaveText("5");
   });
 });
+
+// =============================================================================
+// SORTING ROWS WITHOUT AN ID FIELD (#3887)
+// =============================================================================
+
+test.describe("sorting data without an id field", () => {
+  // No `id` anywhere: the natural shape of CSV-sourced rows.
+  const idlessData = [
+    { name: "b-item", quantity: 5 },
+    { name: "a-item", quantity: 3 },
+    { name: "c-item", quantity: 10 },
+  ];
+
+  const nameHeader = (page: any) =>
+    page.getByRole("columnheader").filter({ hasText: "name" }).first();
+
+  const firstNameCell = (page: any) => page.locator("td").nth(0);
+
+  test("click-to-sort reorders rows that carry no id", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(idlessData)}}'>
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await expect(firstNameCell(page)).toHaveText("b-item");
+
+    await nameHeader(page).click();
+    await expect(firstNameCell(page)).toHaveText("a-item");
+
+    await nameHeader(page).click();
+    await expect(firstNameCell(page)).toHaveText("c-item");
+
+    // Third click clears the sort and restores source order.
+    await nameHeader(page).click();
+    await expect(firstNameCell(page)).toHaveText("b-item");
+  });
+
+  test("sortBy seeds the initial order on id-less rows", async ({ initTestBed, page }) => {
+    await initTestBed(`
+      <Table data='{${JSON.stringify(idlessData)}}' sortBy="name">
+        <Column bindTo="name"/>
+        <Column bindTo="quantity"/>
+      </Table>
+    `);
+
+    await expect(firstNameCell(page)).toHaveText("a-item");
+  });
+});

--- a/xmlui/src/components/Table/TableReact.tsx
+++ b/xmlui/src/components/Table/TableReact.tsx
@@ -1913,7 +1913,20 @@ export const Table = memo(
       getRowId: useCallback(
         (originalRow: any, index: number) => {
           const idVal = originalRow[idKey];
-          return idVal != null ? String(idVal) : String(index);
+          if (idVal != null) {
+            return String(idVal);
+          }
+          // --- The `index` handed in here is the row's position in the *sorted* array, so
+          // --- using it would hand every row the same id before and after a sort: the key
+          // --- list never changes, React reorders nothing, and the positionally-memoized
+          // --- cells keep painting their pre-sort content -- click-to-sort looks dead on
+          // --- id-less data (#3887). `order` is the row's 1-based position in the source
+          // --- data (stamped in `dataWithOrder`), so it is stable under sorting and paging,
+          // --- and it matches the index-based fallback `getItemRowId`/`getSourceIdSet`
+          // --- already use over `safeData`.
+          const sourceIndex =
+            typeof originalRow?.order === "number" ? originalRow.order - 1 : index;
+          return String(sourceIndex);
         },
         [idKey],
       ),


### PR DESCRIPTION
Fixes #3887.

## Root cause

The sort math was never broken. `sortedData` really is reordered — the reorder just never reached the DOM.

`getRowId` fell back to `String(index)` for rows carrying no `idKey` value:

```ts
return idVal != null ? String(idVal) : String(index);
```

That `index` is the row's position in the **sorted** array, not in the source data. So for id-less rows the key list is `"0","1","2"…` both before and after every sort — identical. React sees an unchanged key list on the virtualizer's `<tr key={row.id}>` children, moves no instances, and every `VirtualTableRow` keeps its `rowIndex`. `TableMemoizedCells` compares purely positionally, and nothing in `rowRenderVersion` bumps on a sort, so the cells bail out and keep painting their pre-sort content.

The header indicator lives outside the memo, which is why it flips while the rows sit still — the "silent no-op" in the report. With real ids the keys reorder, React moves the instances, `rowIndex` changes, and cells repaint; hence the A/B in the issue.

## The fix

Fall back to the row's **source** index. `dataWithOrder` already stamps `order: index + 1`, which is stable under sorting and paging:

```ts
const sourceIndex = typeof originalRow?.order === "number" ? originalRow.order - 1 : index;
return String(sourceIndex);
```

This is resolution 1 from the issue — sorting now works out of the box on id-less data, using the row-index identity `$rowId` already documents.

It also removes an inconsistency that was already present: `getItemRowId` (row expansion) and `getSourceIdSet` both index over `safeData` in source order, so only `getRowId` disagreed with them. The `$rowId` format is unchanged, so `getSelectedIds()` and `selectId()` behave exactly as before.

## Verification

Two tests added using the issue's exact id-less shape — both **fail before this change, pass after**. Every existing sorting test used data with ids, which is why this went unnoticed.

- `Table.spec.ts`: 290 passed (smoke + nonsmoke)
- `TableCellTextOverflow`, `Locale`, `ModalDialog` specs: 54 passed
- `tsc --noEmit`: clean

## Notes for the reviewer

- **Prettier flags both touched files, but it flags them at `main` too** — pre-existing drift. Left alone rather than burying the fix in a reformat.
- **One adjacent bug found and deliberately scoped out.** When *some* rows carry an id, the index fallback can collide with a real one (`[{id:"0"},{},{id:"1"}]` → row ids `"0","1","1"`), giving React duplicate keys and scrambled rows after a sort. A failing test was written for it and then removed from this PR: fixing it means changing the documented `$rowId` fallback format, which is a public-API decision (it surfaces through `$rowId`, `getSelectedIds()`, and `selectId()`) and deserves its own issue rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
